### PR TITLE
Make the geocoder return more options for address messages to use,

### DIFF
--- a/app/src/filter.js
+++ b/app/src/filter.js
@@ -66,13 +66,13 @@ amqp.connect(config.rabbit.conn, function(err, conn) {
                 query.monsterWhoCares(data, function (whocares) {
                     if(whocares.length !== 0) {
 
-                        gmaps.getAddress({lat:data.latitude, lon:data.longitude}, function(err, address){
+                        gmaps.getAddress({lat:data.latitude, lon:data.longitude}, function(err, geoResult){
+
                             let view = {
                                 time : data.distime,
                                 tthh : data.tth.hours,
                                 tthm : data.tth.minutes,
                                 tths : data.tth.seconds,
-                                addr : address,
                                 name : data.name,
                                 move1 : data.quick_move,
                                 move2 : data.charge_move,
@@ -88,15 +88,26 @@ amqp.connect(config.rabbit.conn, function(err, conn) {
                                 rocketmap : data.rocketmap,
                                 form : data.formname,
                                 imgurl : data.imgurl.toLowerCase(),
-                                color : data.color
+                                color : data.color,
+                                // geocode stuff
+                                addr: geoResult.addr,
+                                streetNumber: geoResult.streetNumber,
+                                streetName: geoResult.streetName,
+                                zipcode: geoResult.zipcode,
+                                country: geoResult.country,
+                                countryCode: geoResult.countryCode,
+                                city: geoResult.city,
+                                state: geoResult.state,
+                                stateCode: geoResult.stateCode
                             };
+
                             let template = JSON.stringify(dts.monster);
                             let message = mustache.render(template,view);
                             message = JSON.parse(message);
                             whocares.forEach(function (cares) {
 
                                 alarm.sendDMAlarm(message, cares.id, e, cares.map_enabled);
-                                log.info(`Alerted ${cares.name} about ${data.name} raid`);
+                                log.info(`Alerted ${cares.name} about ${data.name} monster`);
                             })
 
                         });
@@ -147,14 +158,13 @@ amqp.connect(config.rabbit.conn, function(err, conn) {
                             });
                             query.raidWhoCares(data, function(whocares){
                                 if(whocares.length !== 0) {
-                                    gmaps.getAddress({lat:data.latitude, lon:data.longitude}, function(address){
+                                    gmaps.getAddress({lat:data.latitude, lon:data.longitude}, function(err, geoResult){
 
                                         let view = {
                                             time : data.distime,
                                             tthh : data.tth.hours,
                                             tthm : data.tth.minutes,
                                             tths : data.tth.seconds,
-                                            addr : address,
                                             name : data.name,
                                             cp20 : raidCpData[data.pokemon_id].max_cp_20,
                                             cp25 : raidCpData[data.pokemon_id].max_cp_25,
@@ -170,7 +180,17 @@ amqp.connect(config.rabbit.conn, function(err, conn) {
                                             mapurl : data.mapurl,
                                             rocketmap : data.rocketmap,
                                             imgurl : data.imgurl.toLowerCase(),
-                                            color : data.color
+                                            color : data.color,
+                                            // geocode stuff
+                                            addr: geoResult.addr,
+                                            streetNumber: geoResult.streetNumber,
+                                            streetName: geoResult.streetName,
+                                            zipcode: geoResult.zipcode,
+                                            country: geoResult.country,
+                                            countryCode: geoResult.countryCode,
+                                            city: geoResult.city,
+                                            state: geoResult.state,
+                                            stateCode: geoResult.stateCode
                                         };
 
                                         let template = JSON.stringify(dts.raid);
@@ -222,14 +242,13 @@ amqp.connect(config.rabbit.conn, function(err, conn) {
                             });
                             query.eggWhoCares(data, function(whocares){
                                 if(whocares.length !== 0) {
-                                    gmaps.getAddress({lat:data.latitude, lon:data.longitude}, function(err, address){
+                                    gmaps.getAddress({lat:data.latitude, lon:data.longitude}, function(err, geoResult){
 
                                         let view = {
                                             time : data.hatchtime,
                                             tthh : data.tth.hours,
                                             tthm : data.tth.minutes,
                                             tths : data.tth.seconds,
-                                            addr : address,
                                             gymname : data.gymname,
                                             description : data.description,
                                             level : data.level,
@@ -238,7 +257,17 @@ amqp.connect(config.rabbit.conn, function(err, conn) {
                                             mapurl : data.mapurl,
                                             rocketmap : data.rocketmap,
                                             imgurl : data.imgurl.toLowerCase(),
-                                            color : data.color
+                                            color : data.color,
+                                            // geocode stuff
+                                            addr: geoResult.addr,
+                                            streetNumber: geoResult.streetNumber,
+                                            streetName: geoResult.streetName,
+                                            zipcode: geoResult.zipcode,
+                                            country: geoResult.country,
+                                            countryCode: geoResult.countryCode,
+                                            city: geoResult.city,
+                                            state: geoResult.state,
+                                            stateCode: geoResult.stateCode
                                         };
 
                                         let template = JSON.stringify(dts.egg);

--- a/app/src/geo/google.js
+++ b/app/src/geo/google.js
@@ -3,12 +3,11 @@ let config = require('config');
 let inside = require('point-in-polygon');
 let _ = require('lodash');
 let NodeGeocoder = require('node-geocoder');
+
 let geocoder = NodeGeocoder({
     provider: 'google',
     httpAdapter: 'https',
-    apiKey: config.gmaps.key,
-    formatter: 'string',
-    formatterPattern: config.locale.addressformat
+    apiKey: config.gmaps.key
 });
 let getCoords = NodeGeocoder({
     provider: 'google',
@@ -27,10 +26,43 @@ module.exports = {
     },
 
     getAddress: function(location, callback) {
-        geocoder.reverse(location, function(err, res) {
+        geocoder.reverse(location, function(err, data) {
             if (err) log.error(err);
-            log.debug(`Fetched address ${res[0]}`);
-            callback(res[0]);
+
+			var res = {};
+			if(data && data.length > 0) {
+				//we found it
+				res.addr = config.locale.addressformat
+				.replace(/%n/, data[0].streetNumber)
+				.replace(/%S/, data[0].streetName)
+				.replace(/%z/, data[0].zipcode)
+				.replace(/%P/, data[0].country)
+				.replace(/%p/, data[0].countryCode)
+				.replace(/%c/, data[0].city)
+				.replace(/%T/, data[0].state)
+				.replace(/%t/, data[0].stateCode);
+				res.streetNumber = data[0].streetNumber;
+				res.streetName = data[0].streetName;
+				res.zipcode = data[0].zipcode;
+				res.country = data[0].country;
+				res.countryCode = data[0].countryCode;
+				res.city = data[0].city;
+				res.state = data[0].state;
+				res.stateCode = data[0].stateCode;
+			} else {
+				//didn't find anything, default it
+				res.addr = '';
+				res.streetNumber = '';
+				res.streetName = '';
+				res.zipcode = '';
+				res.country = '';
+				res.countryCode = '';
+				res.city = '';
+				res.state = '';
+				res.stateCode = '';
+			}
+
+            callback(err, res);
         });
     },
 

--- a/app/src/geo/google.js
+++ b/app/src/geo/google.js
@@ -9,16 +9,11 @@ let geocoder = NodeGeocoder({
     httpAdapter: 'https',
     apiKey: config.gmaps.key
 });
-let getCoords = NodeGeocoder({
-    provider: 'google',
-    httpAdapter: 'https',
-    apiKey: config.gmaps.key
-});
 
 module.exports = {
 
     geolocate: function(location, callback) {
-        getCoords.geocode(location, function(err, res) {
+        geocoder.geocode(location, function(err, res) {
             if (err) log.error(err);
             log.info(`Figuring out where ${location} is`);
             callback(err, res[0]);
@@ -26,29 +21,29 @@ module.exports = {
     },
 
     getAddress: function(location, callback) {
-        geocoder.reverse(location, function(err, data) {
+        geocoder.reverse(location, function(err, geocodeResult) {
             if (err) log.error(err);
 
 			var res = {};
-			if(data && data.length > 0) {
+			if(geocodeResult && geocodeResult.length > 0) {
 				//we found it
 				res.addr = config.locale.addressformat
-				.replace(/%n/, data[0].streetNumber)
-				.replace(/%S/, data[0].streetName)
-				.replace(/%z/, data[0].zipcode)
-				.replace(/%P/, data[0].country)
-				.replace(/%p/, data[0].countryCode)
-				.replace(/%c/, data[0].city)
-				.replace(/%T/, data[0].state)
-				.replace(/%t/, data[0].stateCode);
-				res.streetNumber = data[0].streetNumber;
-				res.streetName = data[0].streetName;
-				res.zipcode = data[0].zipcode;
-				res.country = data[0].country;
-				res.countryCode = data[0].countryCode;
-				res.city = data[0].city;
-				res.state = data[0].state;
-				res.stateCode = data[0].stateCode;
+				.replace(/%n/, geocodeResult[0].streetNumber || '')
+				.replace(/%S/, geocodeResult[0].streetName || '')
+				.replace(/%z/, geocodeResult[0].zipcode || '')
+				.replace(/%P/, geocodeResult[0].country || '')
+				.replace(/%p/, geocodeResult[0].countryCode || '')
+				.replace(/%c/, geocodeResult[0].city || '')
+				.replace(/%T/, geocodeResult[0].state || '')
+				.replace(/%t/, geocodeResult[0].stateCode || '');
+				res.streetNumber = geocodeResult[0].streetNumber || '';
+				res.streetName = geocodeResult[0].streetName || '';
+				res.zipcode = geocodeResult[0].zipcode || '';
+				res.country = geocodeResult[0].country || '';
+				res.countryCode = geocodeResult[0].countryCode || '';
+				res.city = geocodeResult[0].city || '';
+				res.state = geocodeResult[0].state || '';
+				res.stateCode = geocodeResult[0].stateCode || '';
 			} else {
 				//didn't find anything, default it
 				res.addr = '';

--- a/docs/dts.md
+++ b/docs/dts.md
@@ -99,6 +99,14 @@ Any of the fields can be cusomtized with the following:
 |{{tthm}}| Full minutes until raid ends|
 |{{tths}}| Full seconds until raid ends|
 |{{addr}}| Address of the alerted location|
+|{{streetNumber}| Street number of the alerted location|
+|{{streetName}| Street name of the alerted location|
+|{{zipcode}| Zip code of the alerted location|
+|{{country}| Country of the alerted location|
+|{{countryCode}| 2 letter country code of the alerted location|
+|{{city}| City name of the alerted location|
+|{{state}| State name of the alerted location|
+|{{stateCode}| 2 letter state code of the alerted location|
 |{{move1}}| Monsers quick move|
 |{{move2}}| Monsters charge move|
 |{{cp20}}| Monsters cp with 100% perfect IV and level 20|
@@ -149,6 +157,14 @@ Any of the fields can be cusomtized with the following:
 |{{tthm}}| Full minutes until raid ends|
 |{{tths}}| Full seconds until raid ends|
 |{{addr}}| Address of the alerted location|
+|{{streetNumber}| Street number of the alerted location|
+|{{streetName}| Street name of the alerted location|
+|{{zipcode}| Zip code of the alerted location|
+|{{country}| Country of the alerted location|
+|{{countryCode}| 2 letter country code of the alerted location|
+|{{city}| City name of the alerted location|
+|{{state}| State name of the alerted location|
+|{{stateCode}| 2 letter state code of the alerted location|
 |{{gymname}}| Name of the gym|
 |{{description}}| Description of the gym|
 |{{level}}| Raid level|

--- a/docs/dts.md
+++ b/docs/dts.md
@@ -43,6 +43,14 @@ Any of the fields can be cusomtized with the following:
 |{{tthm}}| Full minutes until hidden|
 |{{tths}}| Full seconds until hidden|
 |{{addr}}| Address of the alerted location|
+|{{streetNumber}| Street number of the alerted location|
+|{{streetName}| Street name of the alerted location|
+|{{zipcode}| Zip code of the alerted location|
+|{{country}| Country of the alerted location|
+|{{countryCode}| 2 letter country code of the alerted location|
+|{{city}| City name of the alerted location|
+|{{state}| State name of the alerted location|
+|{{stateCode}| 2 letter state code of the alerted location|
 |{{move1}}| Monsers quick move|
 |{{move2}}| Monsters charge move|
 |{{iv}}| Monsters Individual Value Precentage|


### PR DESCRIPTION
When reverse geocoding coordinates, return not only the formated address, but also the individual components to allow for more complex message DTS like `{{city}}`

Fix error in address lookup for raid/monster

Added DTS template keywords:

streetNumber - the street number
streetName - name of the street
zipcode - zip code if applicable
country - country 
countryCode - two letter country code
city - the city
state - the US state name (possibly others, don't know)
stateCode: two letter state code (unknown what this does for non us addresses, probably blank)

tested:
yes?