### PR TITLE
Store geocodes in a time limited cache to avoid repeated lookups

### DIFF
--- a/app/src/geo/google.js
+++ b/app/src/geo/google.js
@@ -37,26 +37,24 @@ module.exports = {
     },
 
     getAddress: function(location, callback) {
-        var cacheKey = location.lat + "-" + location.lon;
+        let cacheKey = `${location.lat}-${location.lon}`;
         addrCache.get(cacheKey, function(err, addr) {
-            if(err) {
-                log.error(err);
-            }
+            if(err) log.error(err);
 
             if(addr) {
                 parseAddr(err, addr, callback);
                 return;
             }
 
-            geocoder.reverse(location, function(gerr, geocodeResult) {
-                if (gerr) log.error(gerr);
+            geocoder.reverse(location, function(err, geocodeResult) {
+                if (err) log.error(err);
 
                 if(geocodeResult && geocodeResult.length > 0) {
-                    addrCache.put(cacheKey, geocodeResult, function(aerr, r) {
-                        if(aerr) log.error(`Error saving addr of ${cacheKey}: ${aerr}`)
+                    addrCache.put(cacheKey, geocodeResult, function(err, r) {
+                        if(err) log.error(`Error saving addr of ${cacheKey}: ${err}`)
                     });
                 }
-                parseAddr(gerr, geocodeResult ,callback);
+                parseAddr(err, geocodeResult ,callback);
             });
         });
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mustache": "^2.3.0",
     "mysql2": "^1.5.1",
     "node-geocoder": "^3.21.1",
+    "persistent-cache": "^1.1.1",
     "pm2": "^2.9.3",
     "point-in-polygon": "^1.0.1",
     "prettyjson": "^1.2.1",


### PR DESCRIPTION
Add the use of a persistent cache to save address lookups for 30 days (max allowed by google) so that we do not have to worry about key expiration because of lookups to the same addresses.

adds a new requirement, so a `npm install` is required after upgrade.

Also not sure on the "global" method in google.js - cause I don't know node.js enough to understand where such utility functions should live.