### PR TITLE
Make cache live for 1 hour and add dissapear time as key

### DIFF
--- a/src/app/handlers/receiver.js
+++ b/src/app/handlers/receiver.js
@@ -17,7 +17,7 @@ discordcache.on('hit', (key, val) => { })
 const queue = []
 
 const cache = new Cache({
-	ttl: 300 * 1000,
+	ttl: 60 * 60 * 1000,
 })
 
 const MonsterController = require('../controllers/monster')
@@ -104,7 +104,7 @@ module.exports = async (req, reply) => {
 						})
 				}
 				else {
-					log.log({ level: 'warn', message: `Raid at gym :${hook.message.gym_id} was sent again too soon`, event: 'cache:duplicate' })
+					log.log({ level: 'warn',message `Raid at gym:${hook.message.gym_id}_${hook.message.pokemon_id} was sent again too soon`, event: 'cache:duplicate' })
 				}
 				break
 			}


### PR DESCRIPTION
Some scanner clients like MAD likes to send a lot of webhooks. This PR makes Poracle not post repeat alerts every 5 minutes.
## Description
Caches received messages for 1 hr and only reposts alerts if they are with a different end time.

## Motivation and Context
MAD sends anything it finds every time it finds it. it gets old very fast when Poracle keeps alerting

## How Has This Been Tested?
tested on windows server with MAD mitm as source system

## Screenshots (if appropriate):
`[pic of your mom here]`
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.