### PR TITLE
Add config option to only send alert about monsters with more than X sec to hidden

### DIFF
--- a/config/default.json.example
+++ b/config/default.json.example
@@ -14,7 +14,8 @@
     "port": "3030",
     "imgurl": "https://raw.githubusercontent.com/KartulUdus/PoracleJS/master/src/app/util/images/",
     "webroot": "/",
-    "max_pokemon": 500
+    "max_pokemon": 500,
+    "monsterMinimumTimeTillHidden": 0
   },
 
   "locale": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poraclejs",
-  "version": "2.7.13",
+  "version": "2.8.14",
   "description": "Webhook processing and personalised alarms",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poraclejs",
-  "version": "2.8.14",
+  "version": "2.8.13",
   "description": "Webhook processing and personalised alarms",
   "main": "index.js",
   "repository": {

--- a/src/app/controllers/monster.js
+++ b/src/app/controllers/monster.js
@@ -20,6 +20,7 @@ const moment = require('moment-timezone')
 require('moment-precise-range-plugin')
 
 moment.locale(config.locale.timeformat)
+const minTth = config.general.monsterMinimumTimeTillHidden || 0;
 
 class Monster extends Controller {
 
@@ -133,9 +134,9 @@ class Monster extends Controller {
 			data.emoji = e
 			data.emojiString = e.join('')
 
-			// Stop handling if it already disappeared
-			if (data.tth.firstDateWasLater) {
-				log.warn(`Weird, the ${data.name} already disappeared`)
+			// Stop handling if it already disappeared or is about to go away
+			if (data.tth.firstDateWasLater || ( (data.tth.hours * 3600) + (data.tth.minutes*60) + data.tth.seconds) < minTth) {
+				log.warn(`${data.name} already disappeared or is about to go away in: ${data.tth.hours}:${data.tth.minutes}:${data.tth.seconds}`)
 				resolve([])
 				return null
 			}


### PR DESCRIPTION

## Description
To prevent alerts with say 1 minute remaining before a monster goes away, make it configurable to ignore anything with less than X seconds until hidden

## Motivation and Context
Solves the annoying problem of a good mon showing up with 1 min left

## How Has This Been Tested?
I showed it to a band of traveling merchants and they aproved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.