### PR TITLE
Replace sponsor_id with ex_raid_eligible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poraclejs",
-  "version": "2.8.13",
+  "version": "2.8.14",
   "description": "Webhook processing and personalised alarms",
   "main": "index.js",
   "repository": {

--- a/src/app/controllers/raid.js
+++ b/src/app/controllers/raid.js
@@ -138,8 +138,8 @@ class Raid extends Controller {
 						data.gymname = gymInfo ? gymInfo.gym_name : data.gym_name
 						data.description = gymInfo ? gymInfo.description : ''
 						data.url = gymInfo ? gymInfo.url : ''
-						data.park = gymInfo ? gymInfo.park : data.sponsor_id
-						data.park = data.sponsor_id ? data.sponsor_id : data.park
+						data.park = gymInfo ? gymInfo.park : data.ex_raid_eligible
+						data.park = data.ex_raid_eligible ? data.ex_raid_eligible : data.park
 						data.ex = data.park ? 'EX' : ''
 						if (data.tth.firstDateWasLater) {
 							log.warn(`Raid against ${data.name} was sent but already ended`)

--- a/src/app/handlers/receiver.js
+++ b/src/app/handlers/receiver.js
@@ -112,11 +112,11 @@ module.exports = async (req, reply) => {
 				const g = hook.message
 				g.park = false
 				if (!g.description) g.description = ''
-				if (!g.sponsor_id) g.sponsor_id = false
+				if (!g.ex_raid_eligible) g.ex_raid_eligible = false
 				if (!g.team) g.team = 0
 				if (!g.name) g.name = ''
 				if (!g.url) g.url = ''
-				g.park = g.sponsor_id
+				g.park = g.ex_raid_eligible
 				g.name = g.name.replace(/"/g, '')
 				g.description = g.description.replace(/"/g, '')
 				g.name = g.name.replace(/'/g, '')

--- a/src/app/helpers/commands.js
+++ b/src/app/helpers/commands.js
@@ -493,7 +493,7 @@ client.on('message', (msg) => {
 					}
 				})
 				args.forEach((element) => {
-					if (element.match(/park/gi)) park = 1
+					if (element.match(/ex/gi)) park = 1
 					else if (element.match(/level\d/gi)) levels.push(element.replace(/level/gi, ''))
 					else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
 					else if (element.match(/instinct/gi)) team = 3
@@ -616,7 +616,7 @@ client.on('message', (msg) => {
 			let template = 3
 
 			args.forEach((element) => {
-				if (element.match(/park/gi)) park = 1
+				if (element.match(/ex/gi)) park = 1
 				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
 				else if (element.match(/level\d/gi)) level = element.replace(/level/gi, '')
 				else if (element.match(/instinct/gi)) team = 3
@@ -1243,7 +1243,7 @@ client.on('message', (msg) => {
 				}
 			})
 			args.forEach((element) => {
-				if (element.match(/park/gi)) park = 1
+				if (element.match(/ex/gi)) park = 1
 				else if (element.match(/instinct/gi)) team = 3
 				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
 				else if (element.match(/valor/gi)) team = 2
@@ -1349,7 +1349,7 @@ client.on('message', (msg) => {
 			let team = 4
 			let template = 3
 			args.forEach((element) => {
-				if (element.match(/park/gi)) park = 1
+				if (element.match(/ex/gi)) park = 1
 				else if (element.match(/level\d/gi)) level = element.replace(/level/gi, '')
 				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
 				else if (element.match(/instinct/gi)) team = 3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
RDM beta switched 1/31 to use ex_raid_eligible instead of sponsor_id, this updates the necessary files. This is only for RDM beta, if you are on RDM master it still uses sponsor_id
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Discovered my !track park notifications were broken
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In production on my server. Seeing park "1" in poracle gym-info db now and receiving poracle alerts for !raid park now.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.