### PR TITLE
Develop webhook subscribers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,7 @@
     // this rule collides with vuex store strict mode, so it will be disabled
     "import/prefer-default-export": 0,
     // something used by nuxt and needed to run statistics page
-    "no-restricted-syntax": 0
+    "no-restricted-syntax": 0,
+    "linebreak-style": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poraclejs",
-  "version": "2.9.19",
+  "version": "2.10.20",
   "description": "Webhook processing and personalised alarms",
   "main": "index.js",
   "repository": {

--- a/src/app/controllers/controller.js
+++ b/src/app/controllers/controller.js
@@ -350,8 +350,6 @@ class Controller {
 			this.db.query(query)
 				.then((result, cols) => {
 					log.log({ level: 'debug', message: `select human ${name}:${kind}=${result[0][0].id}`, event: 'sql:getHumanByName' })
-					console.log(result)
-					console.log(cols)
 					resolve(result[0][0].id)
 				})
 				.catch((err) => {

--- a/src/app/controllers/controller.js
+++ b/src/app/controllers/controller.js
@@ -264,7 +264,7 @@ class Controller {
 					resolve(result)
 				})
 				.catch((err) => {
-					log.error(`insertOrUpdateQuery errored with: ${err}`)
+					log.error(`insertOrUpdateQuery ${query} errored with: ${err}`)
 				})
 		})
 	}
@@ -340,6 +340,35 @@ class Controller {
 				.then(log.log({ level: 'debug', message: `addOneQuery ${table}`, event: 'sql:addOneQuery' }))
 				.catch((err) => {
 					log.error(`addOneQuery errored with: ${err}`)
+				})
+		})
+	}
+
+	async getHumanByName(name, kind = 'discord') {
+		return new Promise((resolve) => {
+			const query = `SELECT id FROM humans WHERE name='${name}' AND humanKind='${kind}'`
+			this.db.query(query)
+				.then((result, cols) => {
+					log.log({ level: 'debug', message: `select human ${name}:${kind}=${result[0][0].id}`, event: 'sql:getHumanByName' })
+					console.log(result)
+					console.log(cols)
+					resolve(result[0][0].id)
+				})
+				.catch((err) => {
+					log.error(`getHumanByName errored with: ${err}`)
+				})
+		})
+	}
+
+	async getHuman(id, kind = 'discord') {
+		return new Promise((resolve) => {
+			this.db.query('SELECT name FROM humans WHERE id = ? AND humanKind=?', [id, kind])
+				.then((result) => {
+					log.log({ level: 'debug', message: `select human ${id}-${kind}->${result}`, event: 'sql:getHuman' })
+					resolve(result[0][0])
+				})
+				.catch((err) => {
+					log.error(`getHuman errored with: ${err}`)
 				})
 		})
 	}

--- a/src/app/controllers/monster.js
+++ b/src/app/controllers/monster.js
@@ -32,7 +32,7 @@ class Monster extends Controller {
 				areastring = areastring.concat(`or humans.area like '%${area}%' `)
 			})
 			const query = `
-			select humans.id, humans.name, monsters.template from monsters 
+			select humans.id, humans.name, humans.humanKind, monsters.template from monsters 
             join humans on humans.id = monsters.id
             where humans.enabled = 1 and
             pokemon_id=${data.pokemon_id} and 
@@ -237,6 +237,7 @@ class Monster extends Controller {
 								message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : message,
 								target: cares.id,
 								name: cares.name,
+								kind: cares.humanKind,
 								emoji: caresCache === config.discord.limitamount + 1 ? [] : data.emoji,
 								meta: { correlationId: data.correlationId, messageId: data.messageId, alarmId: alarmId }
 

--- a/src/app/controllers/quest.js
+++ b/src/app/controllers/quest.js
@@ -22,7 +22,7 @@ class Quest extends Controller {
 				areastring = areastring.concat(`or humans.area like '%${area}%' `)
 			})
 			const query = `
-			select humans.id, humans.name, quest.template from quest
+			select humans.id, humans.name, humans.humanKind, quest.template from quest
             join humans on humans.id = quest.id
             where humans.enabled = 1 and
             ((reward_type=7 and reward in (${data.rewardData.monsters}) and shiny = 1 and ${data.isShiny}=1 or reward_type=7 and reward in (${data.rewardData.monsters}) and shiny = 0) 
@@ -169,6 +169,7 @@ class Quest extends Controller {
 							const work = {
 								message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : JSON.parse(message),
 								target: cares.id,
+								kind: cares.humanKind,
 								name: cares.name,
 								emoji: [],
 								meta: { correlationId: data.correlationId, messageId: data.messageId, alarmId: alarmId }

--- a/src/app/controllers/raid.js
+++ b/src/app/controllers/raid.js
@@ -33,7 +33,7 @@ class Raid extends Controller {
 				areastring = areastring.concat(`or humans.area like '%${area}%' `)
 			})
 			const query = `
-			select humans.id, humans.name, raid.template from raid 
+			select humans.id, humans.name, humans.humanKind, raid.template from raid 
             join humans on humans.id = raid.id
             where humans.enabled = 1 and
             (pokemon_id=${data.pokemon_id} or (pokemon_id=721 and raid.level=${data.level})) and 
@@ -66,7 +66,7 @@ class Raid extends Controller {
 				areastring = areastring.concat(`or humans.area like '%${area}%' `)
 			})
 			const query = `
-			select humans.id, humans.name, egg.template from egg 
+			select humans.id, humans.name, humans.humanKind, egg.template from egg 
             join humans on humans.id = egg.id
             where humans.enabled = 1 and 
             (egg.park = ${!!data.park} or egg.park = 0) and
@@ -231,6 +231,7 @@ class Raid extends Controller {
 												message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : message,
 												target: cares.id,
 												name: cares.name,
+												kind: cares.humanKind,
 												emoji: caresCache === config.discord.limitamount + 1 ? [] : data.emoji,
 												meta: { correlationId: data.correlationId, messageId: data.messageId, alarmId: alarmId }
 											}
@@ -348,6 +349,7 @@ class Raid extends Controller {
 												message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : message,
 												target: cares.id,
 												name: cares.name,
+												kind: cares.humanKind,
 												emoji: [],
 												meta: { correlationId: data.correlationId, messageId: data.messageId, alarmId: alarmId }
 											}

--- a/src/app/helpers/commands.js
+++ b/src/app/helpers/commands.js
@@ -43,8 +43,10 @@ client.on('ready', () => {
 
 	query.selectAllQuery('humans', 'enabled', 1).then((humans) => {
 		humans.forEach((human) => {
-			if (!client.channels.keyArray().includes(human.id) && !client.users.keyArray().includes(human.id)) {
-				log.log({ level: 'debug', message: `unregistered ${human.name} due to 404`, event: 'discord:registerCheck' })
+			const channels = client.channels.keyArray()
+			const users = client.users.keyArray()
+			if ((human.humanKind || 'discord') === 'discord' && !channels.includes(human.id) && !users.includes(human.id)) {
+				log.log({ level: 'debug', message: `unregistered ${human.name}:${human.humanKind} due to 404`, event: 'discord:registerCheck' })
 
 				query.deleteQuery('egg', 'id', human.id)
 				query.deleteQuery('monsters', 'id', human.id)
@@ -104,23 +106,788 @@ if (config.discord.userRole) {
 
 
 client.on('message', (msg) => {
+	log.log({ level: 'debug', message: `got a message: ${msg.content}` })
+	function registerHuman(id, name, registeredWhat, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((exists) => {
+				if (exists) {
+					msg.react('👌')
+					return null
+				}
+				query.insertOrUpdateQuery('humans', ['id', 'name', 'area', 'humanKind'], [[`${id}`, `${emojiStrip(name)}`, '[]', `${humanKind}`]])
+				msg.react('✅')
+				msg.reply(`${name} has been registered`)
+				log.log({
+					level: 'debug',
+					message: `${msg.author.username} registered ${name}`,
+					event: registeredWhat,
+				})
 
-/*
- _   _ _   _       _____ _   _     ___   _____             _____ _   _ ___   ___
-( ) ( ( ) ( /'\_/`(  _  ( ) ( )   (  _`\(  _  /'\_/`/'\_/`(  _  ( ) ( (  _`\(  _`\
-| |_| | | | |     | (_) | `\| |   | ( (_| ( ) |     |     | (_) | `\| | | ) | (_(_)
-|  _  | | | | (_) |  _  | , ` |   | |  _| | | | (_) | (_) |  _  | , ` | | | `\__ \
-| | | | (_) | | | | | | | |`\ |   | (_( | (_) | | | | | | | | | | |`\ | |_) ( )_) |
-(_) (_(_____(_) (_(_) (_(_) (_)   (____/(_____(_) (_(_) (_(_) (_(_) (_(____/`\____)
+			})
+			.catch((err) => {
+				log.error(`uh oh ${err}`)
+			})
+	}
 
-*/
+	function unregisterHuman(id, name, eventName, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (isregistered) {
+					msg.react('👌')
+					return null
+				}
+				query.deleteQuery('egg', 'id', id)
+				query.deleteQuery('monsters', 'id', id)
+				query.deleteQuery('raid', 'id', id)
+				query.deleteQuery('humans', 'id', id)
+				msg.react('✅')
+				log.log({
+					level: 'debug',
+					message: `${msg.author.username} unregistered ${name}`,
+					event: eventName,
+				})
+			})
+	}
+
+	function registerLocation(id, name, registerHelpText, search, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				query.geolocate(search)
+					.then((location) => {
+						query.updateLocation('humans', location[0].latitude, location[0].longitude, 'id', id)
+						const maplink = `https://www.google.com/maps/search/?api=1&query=${location[0].latitude},${location[0].longitude}`
+						msg.reply(`:wave:, I set ${name}'s location to : \n${maplink}`)
+						msg.react('✅')
+					})
+			})
+	}
+
+	function startHuman(name, registerHelpText, id, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				query.updateQuery('humans', 'enabled', true, 'id', id)
+				msg.react('✅')
+				log.log({
+					level: 'debug',
+					message: `${msg.author.username} enabled alarms for ${name}`,
+					event: eventText,
+				})
+			})
+	}
+
+	function stopHuman(id, name, registerHelpText, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				query.updateQuery('humans', 'enabled', false, 'id', id)
+				msg.react('✅')
+				log.log({
+					level: 'debug',
+					message: `${msg.author.username} enabled alarms in ${name}`,
+					event: eventText,
+				})
+			})
+	}
+
+	function areaAdd(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} - ${id} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|')
+					.toLowerCase()
+					.split('|')
+				const confAreas = geofence.map(area => area.name.toLowerCase())
+				query.selectOneQuery('humans', 'id', id)
+					.then((row) => {
+						const oldArea = JSON.parse(row.area.split())
+						const validAreas = confAreas.filter(x => args.includes(x))
+						const addAreas = validAreas.filter(x => !oldArea.includes(x))
+						let newAreas = oldArea.concat(addAreas)
+						newAreas = newAreas.filter(n => n)
+						if (addAreas.length !== 0) {
+							query.updateQuery('humans', 'area', JSON.stringify(newAreas), 'id', id)
+						}
+						if (validAreas.length) {
+							if (addAreas.length) {
+								msg.reply(`Added areas: ${addAreas}`)
+								log.log({
+									level: 'debug',
+									message: `${msg.author.username} added areas ${addAreas} to ${name}`,
+									event: eventText,
+								})
+							}
+							else {
+								msg.react('👌')
+							}
+						}
+						else {
+							msg.reply(`no valid areas there, please use one of ${confAreas}`)
+						}
+					})
+			})
+	}
+
+	function areaRemove(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|')
+					.toLowerCase()
+					.split('|')
+				const confAreas = geofence.map(area => area.name.toLowerCase())
+				query.selectOneQuery('humans', 'id', id)
+					.then((row) => {
+						const oldArea = JSON.parse(row.area.split())
+						const validAreas = oldArea.filter(x => args.includes(x))
+						const removeAreas = validAreas.filter(x => oldArea.includes(x))
+						const newAreas = oldArea.filter(x => !removeAreas.includes(x))
+						if (removeAreas.length !== 0) {
+							query.updateQuery('humans', 'area', JSON.stringify(newAreas), 'id', id)
+						}
+						if (validAreas.length !== 0) {
+							if (removeAreas.length !== 0) {
+								msg.reply(`Removed areas: ${removeAreas}`)
+								log.log({
+									level: 'debug',
+									message: `${msg.author.username} removed areas ${removeAreas} from ${name}`,
+									event: eventText,
+								})
+							}
+							else {
+								msg.react('👌')
+							}
+						}
+						else {
+							msg.reply(`404 NO VALID AND TRACKED AREAS FOUND \n VALID: ${confAreas} \n TRACKED: ${oldArea}`)
+						}
+					})
+			})
+	}
+
+	function monsterTrack(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|').toLowerCase().split('|')
+				let monsters = []
+				let distance = '0'
+				let cp = 0
+				let maxcp = 9000
+				let iv = -1
+				let maxiv = 100
+				let level = 0
+				let maxlevel = 40
+				let atk = 0
+				let def = 0
+				let sta = 0
+				let weight = 0
+				let template = 3
+				let maxweight = 9000000
+				const forms = []
+
+				args.forEach((element) => {
+					const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
+					if (pid !== undefined) monsters.push(pid)
+				})
+				args.forEach((element) => {
+
+					if (element.match(/maxlevel\d/gi)) 	maxlevel = element.replace(/maxlevel/gi, '')
+					else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
+					else if (element.match(/maxcp\d/gi)) maxcp = element.replace(/maxcp/gi, '')
+					else if (element.match(/maxiv\d/gi)) maxiv = element.replace(/maxiv/gi, '')
+					else if (element.match(/maxweight\d/gi)) maxweight = element.replace(/maxweight/gi, '')
+					else if (element.match(/cp\d/gi)) cp = element.replace(/cp/gi, '')
+					else if (element.match(/level\d/gi)) level = element.replace(/level/gi, '')
+					else if (element.match(/iv\d/gi)) iv = element.replace(/iv/gi, '')
+					else if (element.match(/atk\d/gi)) atk = element.replace(/atk/gi, '')
+					else if (element.match(/def\d/gi)) def = element.replace(/def/gi, '')
+					else if (element.match(/sta\d/gi)) sta = element.replace(/sta/gi, '')
+					else if (element.match(/weight\d/gi)) 	weight = element.replace(/weight/gi, '')
+					else if (element.match(/form\w/gi)) forms.push(element.replace(/form/gi, ''))
+					else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
+						const Type = element.replace(/\b\w/g, l => l.toUpperCase())
+						_.filter(monsterData, (o, k) => {
+							if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
+								if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
+							} return k
+						})
+					}
+					else if (element.match(/everything/gi)) monsters = [...Array(config.general.max_pokemon).keys()].map(x => x += 1)
+					else if (element.match(/d\d/gi)) {
+						distance = element.replace(/d/gi, '')
+						if (distance.length >= 10) distance = distance.substr(0, 9)
+					}
+
+				})
+				if (monsters.length && !forms.length) {
+					const form = 0
+					const insertData = monsters.map(monster => [id, monster, template, distance, iv, maxiv, cp, maxcp, level, maxlevel, atk, def, sta, weight, maxweight, form])
+					query.insertOrUpdateQuery(
+						'monsters',
+						['id', 'pokemon_id', 'template', 'distance', 'min_iv', 'max_iv', 'min_cp', 'max_cp', 'min_level', 'max_level', 'atk', 'def', 'sta', 'min_weight', 'max_weight', 'form'],
+						insertData
+					)
+					msg.react('✅')
+					log.log({ level: 'debug', message: `${msg.author.username} started tracking ${monsters} in ${name}`, event: eventText })
+
+				}
+				else if (monsters.length > 1 && forms.length !== 0) msg.reply('Form filters can be added to 1 monster at a time')
+				else if (monsters.length === 0) msg.reply('404 NO MONSTERS FOUND')
+				else if (monsters.length === 1 && forms.length) {
+					if (_.has(formData, monsters[0])) {
+						const fids = []
+						forms.forEach((form) => {
+							const fid = _.findKey(formData[monsters[0]], monforms => monforms.toLowerCase() === form)
+							if (fid !== undefined) fids.push(fid)
+						})
+						const insertData = fids.map(form => [id, monsters[0], template, distance, iv, maxiv, cp, maxcp, level, maxlevel, atk, def, sta, weight, maxweight, form])
+						query.insertOrUpdateQuery(
+							'monsters',
+							['id', 'pokemon_id', 'template', 'distance', 'min_iv', 'max_iv', 'min_cp', 'max_cp', 'min_level', 'max_level', 'atk', 'def', 'sta', 'min_weight', 'max_weight', 'form'],
+							insertData
+						)
+						if (fids.length > 0) {
+							msg.react('✅')
+							log.log({ level: 'debug', message: `${msg.author.username} started tracking ${monsters[0]}, forms ${fids} in ${name}`, event: eventText })
+						}
+						else {
+							msg.reply(`Sorry, I didn't find those forms for ID ${monsters[0]}`)
+						}
+					}
+					else {
+						msg.reply(`Sorry, ${monsters[0]} doesn't have forms`)
+					}
+				}
+			})
+	}
+
+	function monsterUntrack(id, name, registerHelpText, rawArgs, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|')
+					.toLowerCase()
+					.split('|')
+				let monsters = []
+				args.forEach((element) => {
+					const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
+					if (pid !== undefined) {
+						monsters.push(pid)
+					}
+					else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
+						const Type = element.replace(/\b\w/g, l => l.toUpperCase())
+						_.filter(monsterData, (o, k) => {
+							if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
+								if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
+							}
+							return k
+						})
+					}
+					else if (element.match(/everything/gi)) {
+						monsters = [...Array(config.general.max_pokemon)
+							.keys()].map(x => x += 1)
+					}
+				})
+				if (monsters.length) {
+					monsters.forEach((monster) => {
+						query.deleteByIdQuery('monsters', 'pokemon_id', `${monster}`, id)
+					})
+					msg.react('✅')
+				}
+				else {
+					msg.reply('404 NO MONSTERS FOUND')
+				}
+			})
+	}
+
+	function raidTrack(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|').toLowerCase().split('|')
+				const monsters = []
+				let park = 0
+				let distance = 0
+				let team = 4
+				let template = 3
+				const levels = []
+
+				args.forEach((element) => {
+					const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
+					if (pid !== undefined) monsters.push(pid)
+					else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
+						const Type = element.replace(/\b\w/g, l => l.toUpperCase())
+						_.filter(monsterData, (o, k) => {
+							if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
+								if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
+							} return k
+						})
+					}
+				})
+				args.forEach((element) => {
+					if (element.match(/ex/gi)) park = 1
+					else if (element.match(/instinct/gi)) team = 3
+					else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
+					else if (element.match(/valor/gi)) team = 2
+					else if (element.match(/mystic/gi)) team = 1
+					else if (element.match(/harmony/gi)) team = 0
+					else if (element.match(/level\d/gi)) levels.push(element.replace(/level/gi, ''))
+					else if (element.match(/d\d/gi)) {
+						distance = element.replace(/d/gi, '')
+						if (distance.length >= 10) distance = distance.substr(0, 9)
+					}
+
+				})
+
+				if (monsters.length !== 0 && levels.length === 0) {
+					const level = 0
+					const insertData = monsters.map(monster => [id, monster, template, distance, park, team, level])
+					query.insertOrUpdateQuery(
+						'raid',
+						['id', 'pokemon_id', 'template', 'distance', 'park', 'team', 'level'],
+						insertData
+					)
+					msg.react('✅')
+					log.log({ level: 'debug', message: `${msg.author.username} started tracking ${monsters} in ${name}`, event: eventText })
+
+				}
+				else if (monsters.length === 0 && levels.length === 0) msg.reply('404 NO MONSTERS FOUND')
+				else if (monsters.length !== 0 && levels.length !== 0) msg.reply('400 Can\'t track raids by name and level at the same time')
+				else if (monsters.length === 0 && levels.length !== 0) {
+					const insertData = levels.map(level => [id, 721, template, distance, park, team, level])
+					query.insertOrUpdateQuery(
+						'raid',
+						['id', 'pokemon_id', 'template', 'distance', 'park', 'team', 'level'],
+						insertData
+					)
+					msg.react('✅')
+					log.log({ level: 'debug', message: `${msg.author.username} started tracking raid levels:${levels} raids in ${name} `, event: eventText })
+				}
+			})
+	}
+
+	function raidUntrack(id, registerHelpText, rawArgs, name, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|')
+					.toLowerCase()
+					.split('|')
+				const monsters = []
+				const levels = []
+				args.forEach((element) => {
+					const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
+					if (pid !== undefined) {
+						monsters.push(pid)
+					}
+					else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
+						const Type = element.replace(/\b\w/g, l => l.toUpperCase())
+						_.filter(monsterData, (o, k) => {
+							if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
+								if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
+							}
+							return k
+						})
+					}
+					if (element.match(/level\d/gi)) {
+						levels.push(element.replace(/level/gi, ''))
+					}
+				})
+				if (monsters.length) {
+					monsters.forEach((monster) => {
+						query.deleteByIdQuery('raid', 'pokemon_id', `${monster}`, id)
+					})
+					log.log({
+						level: 'debug',
+						message: `${msg.author.username} removed tracking raid monsters:${monsters} raids in ${name} `,
+						event: eventText,
+					})
+					msg.react('✅')
+				}
+				if (levels.length) {
+					levels.forEach((level) => {
+						query.deleteByIdQuery('raid', 'level', `${level}`, id)
+					})
+					log.log({
+						level: 'debug',
+						message: `${msg.author.username} removed tracking raid level:${levels} raids in ${name} `,
+						event: eventText,
+					})
+					msg.react('✅')
+				}
+				if (!monsters.length && !levels.length) msg.reply('404 No raid bosses or levels found')
+			})
+	}
+
+	function eggTrack(id, registerHelpText, rawArgs, name, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|').toLowerCase().split('|')
+				let park = 0
+				const levels = []
+				let distance = 0
+				let team = 4
+				let template = 3
+				args.forEach((element) => {
+					if (element.match(/ex/gi)) park = 1
+					else if (element.match(/level\d/gi)) levels.push(element.replace(/level/gi, ''))
+					else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
+					else if (element.match(/instinct/gi)) team = 3
+					else if (element.match(/valor/gi)) team = 2
+					else if (element.match(/mystic/gi)) team = 1
+					else if (element.match(/harmony/gi)) team = 0
+					else if (element.match(/d\d/gi)) {
+						distance = element.replace(/d/gi, '')
+						if (distance.length >= 10) distance = distance.substr(0, 9)
+					}
+				})
+				if (levels.length) {
+					const insertData = levels.map(level => [id, level, template, distance, park, team])
+					query.insertOrUpdateQuery(
+						'egg',
+						['id', 'raid_level', 'template', 'distance', 'park', 'team'],
+						insertData
+					)
+					msg.react('✅')
+					log.log({ level: 'debug', message: `${msg.author.username} started tracking level (${levels.join(',')}) eggs`, event: eventText })
+				}
+				else msg.reply('404 NO EGGS FOUND')
+			})
+	}
+
+	function eggUntrack(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				const args = rawArgs.join('|')
+					.toLowerCase()
+					.split('|')
+				let level = false
+				args.forEach((element) => {
+					if (element.match(/level\d/gi)) level = element.replace(/level/gi, '')
+				})
+				if (level) {
+					query.deleteByIdQuery('egg', 'raid_level', `${level}`, id)
+					msg.react('✅')
+					log.log({
+						level: 'debug',
+						message: `${msg.author.username} started untracked level ${level} eggs in ${name}`,
+						event: eventText,
+					})
+
+				}
+				else {
+					msg.reply('404 Raid level not found')
+				}
+			})
+	}
+
+	function showTracked(id, name, registerHelpText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				Promise.all([
+					query.selectAllQuery('monsters', 'id', id),
+					query.selectAllQuery('raid', 'id', id),
+					query.selectAllQuery('egg', 'id', id),
+					query.selectOneQuery('humans', 'id', id),
+					query.selectAllQuery('quest', 'id', id),
+				])
+					.then((data) => {
+						const monsters = data[0]
+						const raids = data[1]
+						const eggs = data[2]
+						const human = data[3]
+						const quests = data[4]
+						const maplink = `https://www.google.com/maps/search/?api=1&query=${human.latitude},${human.longitude}`
+						msg.reply(`👋\nYour location is currently set to ${maplink} \nand you currently are set to receive alarms in ${human.area}`)
+						let message = ''
+						if (monsters.length) {
+							message = message.concat('\n\nYou\'re  tracking the following monsters:\n')
+						}
+						else {
+							message = message.concat('\n\nYou\'re not tracking any monsters')
+						}
+
+						monsters.forEach((monster) => {
+							const monsterName = monsterData[monster.pokemon_id].name
+							let miniv = monster.min_iv
+							if (miniv === -1) miniv = 0
+							message = message.concat(`\n**${monsterName}** distance: ${monster.distance}m iv: ${miniv}%-${monster.max_iv}% cp: ${monster.min_cp}-${monster.max_cp} level: ${monster.min_level}-${monster.max_level} minimum stats: ATK:${monster.atk} DEF:${monster.def} STA:${monster.sta}`)
+						})
+						if (raids.length || eggs.length) {
+							message = message.concat('\n\nYou\'re tracking the following raids:\n')
+						}
+						else {
+							message = message.concat('\n\nYou\'re not tracking any raids')
+						}
+						raids.forEach((raid) => {
+							const monsterName = monsterData[raid.pokemon_id].name
+							const raidTeam = teamData[raid.team].name
+							if (parseInt(raid.pokemon_id, 10) === 721) {
+								message = message.concat(`\n**level:${raid.level} raids** distance: ${raid.distance}m controlled by ${raidTeam} , must be in park: ${raid.park}`)
+							}
+							else {
+								message = message.concat(`\n**${monsterName}** distance: ${raid.distance}m controlled by ${raidTeam} , must be in park: ${raid.park}`)
+							}
+						})
+						eggs.forEach((egg) => {
+							const raidTeam = teamData[egg.team].name
+							message = message.concat(`\n**Level ${egg.raid_level} eggs** distance: ${egg.distance}m controlled by ${raidTeam} , must be in park: ${egg.park}`)
+
+						})
+						if (quests.length) {
+							message = message.concat('\n\nYou\'re tracking the following quests:\n')
+						}
+						quests.forEach((quest) => {
+							let rewardThing = ''
+							if (quest.reward_type === 7) rewardThing = monsterData[quest.reward].name
+							if (quest.reward_type === 3) rewardThing = `${quest.reward} or more stardust`
+							if (quest.reward_type === 2) rewardThing = questDts.rewardItems[quest.reward]
+							message = message.concat(`\nReward: ${rewardThing} distance: ${quest.distance}m `)
+						})
+						log.log({
+							level: 'debug',
+							message: `${msg.author.username} checked trackings`,
+							event: 'discord:trackedChannel',
+						})
+
+						if (message.length < 6000) {
+							msg.reply(message, { split: true })
+						}
+						else {
+							const hastebinMessage = hastebin(message)
+							hastebinMessage.then((hastelink) => {
+								msg.reply(`${name} tracking list is quite long. Have a look at ${hastelink}`)
+							})
+								.catch((err) => {
+									log.error(`Hastebin unhappy: ${err.message}`)
+									msg.reply(`${name} tracking list is long, but Hastebin is also down. ☹️ \nPlease try again later.`)
+								})
+						}
+					})
+			})
+	}
+
+	function questAdd(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				let monsters = []
+				const items = []
+				let distance = 0
+				const questTracks = []
+				let template = 3
+				let mustShiny = 0
+				let minDust = 10000000
+				const args = rawArgs.toLowerCase()
+					.split(' ')
+				args.forEach((element) => {
+					const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
+					if (pid !== undefined) {
+						monsters.push(pid)
+					}
+					else if (element.match(/stardust\d/gi)) {
+						minDust = element.replace(/stardust/gi, '')
+					}
+					else if (element === 'stardust') {
+						minDust = 1
+					}
+					else if (element === 'shiny') {
+						mustShiny = 1
+					}
+					else if (element.match(/d\d/gi)) {
+						distance = element.replace(/d/gi, '')
+						if (distance.length >= 10) distance = distance.substr(0, 9)
+					}
+					else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
+						const Type = element.replace(/\b\w/g, l => l.toUpperCase())
+						_.filter(monsterData, (o, k) => {
+							if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
+								if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
+							}
+							return k
+						})
+					}
+					else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
+				})
+				_.forEach(questDts.rewardItems, (item, key) => {
+					const re = new RegExp(` ${item}`, 'gi')
+					if (rawArgs.match(re)) items.push(key)
+				})
+
+				if (rawArgs.match(/all pokemon/gi)) {
+					monsters = [...Array(config.general.max_pokemon)
+						.keys()].map(x => x += 1)
+				}
+				if (rawArgs.match(/all items/gi)) {
+					_.forEach(questDts.rewardItems, (item, key) => {
+						items.push(key)
+					})
+				}
+				if (rawArgs.match(/stardust/gi)) {
+					questTracks.push({
+						id: id,
+						reward: minDust,
+						mustShiny: 0,
+						template: template,
+						reward_type: 3,
+						distance: distance,
+					})
+				}
+				monsters.forEach((pid) => {
+					questTracks.push({
+						id: id,
+						reward: pid,
+						mustShiny: mustShiny,
+						template: template,
+						reward_type: 7,
+						distance: distance
+					})
+				})
+				items.forEach((i) => {
+					questTracks.push({
+						id: id,
+						reward: i,
+						mustShiny: 0,
+						template: template,
+						reward_type: 2,
+						distance: distance
+					})
+				})
+				const insertData = questTracks.map(t => [t.id, t.reward, t.template, t.reward_type, t.distance, t.mustShiny])
+				query.insertOrUpdateQuery(
+					'quest',
+					['id', 'reward', 'template', 'reward_type', 'distance', 'shiny'],
+					insertData
+				)
+				log.log({ level: 'debug', message: `${msg.author.username} updated quest trackings in ${name}`, event: eventText })
+
+				msg.react('✅')
+			})
+	}
+
+	function questRemove(id, name, registerHelpText, rawArgs, eventText, humanKind = 'discord') {
+		query.getHuman(id, humanKind)
+			.then((isregistered) => {
+				if (!isregistered) {
+					msg.reply(`${name} does not seem to be registered. add it with ${registerHelpText}`)
+					return null
+				}
+				let monsters = [0]
+				const items = [0]
+				let stardustTracking = 99999999
+				const args = rawArgs.toLowerCase()
+					.split(' ')
+				args.forEach((element) => {
+					const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
+					if (pid !== undefined) {
+						monsters.push(pid)
+					}
+					else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
+						const Type = element.replace(/\b\w/g, l => l.toUpperCase())
+						_.filter(monsterData, (o, k) => {
+							if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
+								if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
+							}
+							return k
+						})
+					}
+				})
+				_.forEach(questDts.rewardItems, (item, key) => {
+					const re = new RegExp(item, 'gi')
+					if (rawArgs.match(re)) items.push(key)
+				})
+				if (rawArgs.match(/stardust/gi)) {
+					stardustTracking = 0
+				}
+				if (rawArgs.match(/all pokemon/gi)) {
+					monsters = [...Array(config.general.max_pokemon)
+						.keys()].map(x => x += 1)
+				}
+				if (rawArgs.match(/all items/gi)) {
+					_.forEach(questDts.rewardItems, (item, key) => {
+						items.push(key)
+					})
+				}
+
+				const remQuery = `
+			delete from quest WHERE id=${id} and 
+			((reward_type = 2 and reward in(${items})) or (reward_type = 7 and reward in(${monsters})) or (reward_type = 3 and reward >= ${stardustTracking}))		
+			`
+				query.mysteryQuery(remQuery)
+					.then((t) => {
+						log.log({
+							level: 'debug',
+							message: `${msg.author.username} removed quest trackings in ${name}`,
+							event: eventText,
+						})
+					})
+				msg.react('✅')
+
+			})
+	}
+
+
+	/*
+	 _   _ _   _       _____ _   _     ___   _____             _____ _   _ ___   ___
+	( ) ( ( ) ( /'\_/`(  _  ( ) ( )   (  _`\(  _  /'\_/`/'\_/`(  _  ( ) ( (  _`\(  _`\
+	| |_| | | | |     | (_) | `\| |   | ( (_| ( ) |     |     | (_) | `\| | | ) | (_(_)
+	|  _  | | | | (_) |  _  | , ` |   | |  _| | | | (_) | (_) |  _  | , ` | | | `\__ \
+	| | | | (_) | | | | | | | |`\ |   | (_( | (_) | | | | | | | | | | |`\ | |_) ( )_) |
+	(_) (_(_____(_) (_(_) (_(_) (_)   (____/(_____(_) (_(_) (_(_) (_(_) (_(____/`\____)
+	Human commands
+	*/
+
 
 	if (msg.content === `${config.discord.prefix}poracle` && msg.channel.name === config.discord.channel) {
 		query.countQuery('id', 'humans', 'id', msg.author.id)
 			.then((isregistered) => {
 				if (isregistered) msg.react('👌')
 				if (!isregistered) {
-					query.insertOrUpdateQuery('humans', ['id', 'name', 'area'], [[msg.author.id, emojiStrip(msg.author.username), '[]']])
+					query.insertOrUpdateQuery('humans', ['id', 'name', 'area'], [[msg.author.id, emojiStrip(msg.author.username), []]])
 					msg.react('✅')
 					msg.author.send(dts.greeting)
 					log.log({ level: 'debug', message: `${msg.author.tag} registered`, event: 'discord:registered' })
@@ -137,11 +904,10 @@ client.on('message', (msg) => {
 			.then((isregistered) => {
 				if (!isregistered) msg.react('👌')
 				if (isregistered) {
-					query.deleteQuery('egg', 'id', msg.author.id)
-					query.deleteQuery('monsters', 'id', msg.author.id)
-					query.deleteQuery('raid', 'id', msg.author.id)
-					query.deleteQuery('quest', 'id', msg.author.id)
-					query.deleteQuery('humans', 'id', msg.author.id)
+				msg.react('👌')
+				return null
+			}
+			query.insertOrUpdateQuery('humans', ['id', 'name', 'area'], [[msg.channel.id, emojiStrip(msg.channel.name), '[]']])
 					msg.react('✅')
 					log.log({ level: 'debug', message: `${msg.author.tag} unregistered`, event: 'discord:unregistered' })
 
@@ -912,715 +1678,443 @@ client.on('message', (msg) => {
 	| |  _|  _  |  _  | , ` | , ` |  _)_| |  _    | |  _| | | | (_) | (_) |  _  | , ` | | | `\__ \
 	| (_( | | | | | | | |`\ | |`\ | (_( | |_( )   | (_( | (_) | | | | | | | | | | |`\ | |_) ( )_) |
 	(____/(_) (_(_) (_(_) (_(_) (_(____/(____/'   (____/(_____(_) (_(_) (_(_) (_(_) (_(____/`\____)
-
+	Channel Commands
 	*/
 
 	else if (msg.content === `${config.discord.prefix}channel add`) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (isregistered) {
-				msg.react('👌')
-				return null
-			}
-			query.insertOrUpdateQuery('humans', ['id', 'name', 'area'], [[msg.channel.id, emojiStrip(msg.channel.name), '[]']])
-			msg.react('✅')
-			msg.reply(`${msg.channel.name} has been registered`)
-			log.log({ level: 'debug', message: `${msg.author.username} registered ${msg.channel.name}`, event: 'discord:registeredChannel' })
-
-		})
+		const { id, name } = msg.channel
+		const registeredWhat = 'discord:registeredChannel'
+		registerHuman(id, name, registeredWhat)
 	}
 
 	else if (msg.content === `${config.discord.prefix}channel remove`) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.react('👌')
-				return null
-			}
-			query.deleteQuery('egg', 'id', msg.channel.id)
-			query.deleteQuery('monsters', 'id', msg.channel.id)
-			query.deleteQuery('raid', 'id', msg.channel.id)
-			query.deleteQuery('humans', 'id', msg.channel.id)
-			msg.react('✅')
-			log.log({ level: 'debug', message: `${msg.author.username} unregistered ${msg.channel.name}`, event: 'discord:unregisteredChannel' })
-		})
+
+		const eventName = 'discord:unregisteredChannel'
+		const { id, name } = msg.channel
+		unregisterHuman(id, name, eventName)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel location `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const search = msg.content.split(`${config.discord.prefix}channel location `).pop()
-			query.geolocate(search).then((location) => {
-				query.updateLocation('humans', location[0].latitude, location[0].longitude, 'id', msg.channel.id)
-				const maplink = `https://www.google.com/maps/search/?api=1&query=${location[0].latitude},${location[0].longitude}`
-				msg.reply(`:wave:, I set ${msg.channel.name}'s location to : \n${maplink}`)
-				msg.react('✅')
-			})
-
-		})
+		const { id, name } = msg.channel
+		const search = msg.content.split(`${config.discord.prefix}channel location `).pop()
+		const registerHelpText = `${config.discord.prefix}channel add`
+		registerLocation(id, name, registerHelpText, search)
 	}
 
 	else if (msg.content === `${config.discord.prefix}channel start`) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			query.updateQuery('humans', 'enabled', true, 'id', msg.channel.id)
-			msg.react('✅')
-			log.log({ level: 'debug', message: `${msg.author.username} enabled alarms in ${msg.channel.name}`, event: 'discord:startChannel' })
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const eventText = 'discord:startChannel'
+		startHuman(name, registerHelpText, id, eventText)
 	}
 
 	else if (msg.content === `${config.discord.prefix}channel stop`) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			query.updateQuery('humans', 'enabled', false, 'id', msg.channel.id)
-			msg.react('✅')
-			log.log({ level: 'debug', message: `${msg.author.username} enabled alarms in ${msg.channel.name}`, event: 'discord:stopChannel' })
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const eventText = 'discord:stopChannel'
+		stopHuman(id, name, registerHelpText, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel area add `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel area add`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			const confAreas = geofence.map(area => area.name.toLowerCase())
-			query.selectOneQuery('humans', 'id', msg.channel.id).then((channel) => {
-				const oldArea = JSON.parse(channel.area.split())
-				const validAreas = confAreas.filter(x => args.includes(x))
-				const addAreas = validAreas.filter(x => !oldArea.includes(x))
-				let newAreas = oldArea.concat(addAreas)
-				newAreas = newAreas.filter(n => n)
-				if (addAreas.length !== 0) {
-					query.updateQuery('humans', 'area', JSON.stringify(newAreas), 'id', msg.channel.id)
-				}
-				if (validAreas.length) {
-					if (addAreas.length) {
-						msg.reply(`Added areas: ${addAreas}`)
-						log.log({ level: 'debug', message: `${msg.author.username} added areas ${addAreas} to ${msg.channel.name}`, event: 'discord:areaAddChannel' })
-					}
-					else msg.react('👌')
-				}
-				else msg.reply(`no valid areas there, please use one of ${confAreas}`)
-			})
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const eventText = 'discord:areaAddChannel'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel area add`.length).split(' ')
+		areaAdd(id, name, registerHelpText, rawArgs, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel area remove `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel area remove`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			const confAreas = geofence.map(area => area.name.toLowerCase())
-			query.selectOneQuery('humans', 'id', msg.channel.id).then((channel) => {
-				const oldArea = JSON.parse(channel.area.split())
-				const validAreas = oldArea.filter(x => args.includes(x))
-				const removeAreas = validAreas.filter(x => oldArea.includes(x))
-				const newAreas = oldArea.filter(x => !removeAreas.includes(x))
-				if (removeAreas.length !== 0) {
-					query.updateQuery('humans', 'area', JSON.stringify(newAreas), 'id', msg.channel.id)
-				}
-				if (validAreas.length !== 0) {
-					if (removeAreas.length !== 0) {
-						msg.reply(`Removed areas: ${removeAreas}`)
-						log.log({ level: 'debug', message: `${msg.author.username} removed areas ${removeAreas} from ${msg.channel.name}`, event: 'discord:areaRemoveChannel' })
-					}
-					else msg.react('👌')
-				}
-				else msg.reply(`404 NO VALID AND TRACKED AREAS FOUND \n VALID: ${confAreas} \n TRACKED: ${oldArea}`)
-			})
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const eventText = 'discord:areaRemoveChannel'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel area remove`.length).split(' ')
+		areaRemove(id, name, registerHelpText, rawArgs, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel track `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel track`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			let monsters = []
-			let distance = 0
-			let cp = 0
-			let maxcp = 9000
-			let iv = -1
-			let maxiv = 100
-			let level = 0
-			let maxlevel = 40
-			let atk = 0
-			let def = 0
-			let sta = 0
-			let weight = 0
-			let template = 3
-			let maxweight = 9000000
-			const forms = []
-
-			args.forEach((element) => {
-				const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
-				if (pid !== undefined) monsters.push(pid)
-			})
-			args.forEach((element) => {
-
-				if (element.match(/maxlevel\d/gi)) 	maxlevel = element.replace(/maxlevel/gi, '')
-				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
-				else if (element.match(/maxcp\d/gi)) maxcp = element.replace(/maxcp/gi, '')
-				else if (element.match(/maxiv\d/gi)) maxiv = element.replace(/maxiv/gi, '')
-				else if (element.match(/maxweight\d/gi)) maxweight = element.replace(/maxweight/gi, '')
-				else if (element.match(/cp\d/gi)) cp = element.replace(/cp/gi, '')
-				else if (element.match(/level\d/gi)) level = element.replace(/level/gi, '')
-				else if (element.match(/iv\d/gi)) iv = element.replace(/iv/gi, '')
-				else if (element.match(/atk\d/gi)) atk = element.replace(/atk/gi, '')
-				else if (element.match(/def\d/gi)) def = element.replace(/def/gi, '')
-				else if (element.match(/sta\d/gi)) sta = element.replace(/sta/gi, '')
-				else if (element.match(/weight\d/gi)) 	weight = element.replace(/weight/gi, '')
-				else if (element.match(/form\w/gi)) forms.push(element.replace(/form/gi, ''))
-				else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
-					const Type = element.replace(/\b\w/g, l => l.toUpperCase())
-					_.filter(monsterData, (o, k) => {
-						if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
-							if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
-						} return k
-					})
-				}
-				else if (element.match(/everything/gi)) monsters = [...Array(config.general.max_pokemon).keys()].map(x => x += 1)
-				else if (element.match(/d\d/gi)) {
-					distance = element.replace(/d/gi, '')
-					if (distance.length >= 10) distance = distance.substr(0, 9)
-				}
-
-			})
-			if (monsters.length && !forms.length) {
-				const form = 0
-				const insertData = monsters.map(monster => [msg.channel.id, monster, template, distance, iv, maxiv, cp, maxcp, level, maxlevel, atk, def, sta, weight, maxweight, form])
-				query.insertOrUpdateQuery(
-					'monsters',
-					['id', 'pokemon_id', 'template', 'distance', 'min_iv', 'max_iv', 'min_cp', 'max_cp', 'min_level', 'max_level', 'atk', 'def', 'sta', 'min_weight', 'max_weight', 'form'],
-					insertData
-				)
-				msg.react('✅')
-				log.log({ level: 'debug', message: `${msg.author.username} started tracking ${monsters} in ${msg.channel.name}`, event: 'discord:trackChannel' })
-
-			}
-			else if (monsters.length > 1 && forms.length !== 0) msg.reply('Form filters can be added to 1 monster at a time')
-			else if (monsters.length === 0) msg.reply('404 NO MONSTERS FOUND')
-			else if (monsters.length === 1 && forms.length) {
-				if (_.has(formData, monsters[0])) {
-					const fids = []
-					forms.forEach((form) => {
-						const fid = _.findKey(formData[monsters[0]], monforms => monforms.toLowerCase() === form)
-						if (fid !== undefined) fids.push(fid)
-					})
-					const insertData = fids.map(form => [msg.channel.id, monsters[0], template, distance, iv, maxiv, cp, maxcp, level, maxlevel, atk, def, sta, weight, maxweight, form])
-					query.insertOrUpdateQuery(
-						'monsters',
-						['id', 'pokemon_id', 'template', 'distance', 'min_iv', 'max_iv', 'min_cp', 'max_cp', 'min_level', 'max_level', 'atk', 'def', 'sta', 'min_weight', 'max_weight', 'form'],
-						insertData
-					)
-					if (fids.length > 0) {
-						msg.react('✅')
-						log.log({ level: 'debug', message: `${msg.author.username} started tracking ${monsters[0]}, forms ${fids} in ${msg.channel.name}`, event: 'discord:trackChannel' })
-					}
-					else {
-						msg.reply(`Sorry, I didn't find those forms for ID ${monsters[0]}`)
-					}
-				}
-				else {
-					msg.reply(`Sorry, ${monsters[0]} doesn't have forms`)
-				}
-			}
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const eventText = 'discord:trackChannel'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel track`.length).split(' ')
+		monsterTrack(id, name, registerHelpText, rawArgs, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel untrack `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel untrack`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			let monsters = []
-			args.forEach((element) => {
-				const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
-				if (pid !== undefined) monsters.push(pid)
-				else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
-					const Type = element.replace(/\b\w/g, l => l.toUpperCase())
-					_.filter(monsterData, (o, k) => {
-						if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
-							if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
-						} return k
-					})
-				}
-				else if (element.match(/everything/gi)) {
-					monsters = [...Array(config.general.max_pokemon).keys()].map(x => x += 1)
-				}
-			})
-			if (monsters.length) {
-				monsters.forEach((monster) => {
-					query.deleteByIdQuery('monsters', 'pokemon_id', `${monster}`, msg.channel.id)
-				})
-				msg.react('✅')
-			}
-			else msg.reply('404 NO MONSTERS FOUND')
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel untrack`.length).split(' ')
+		monsterUntrack(id, name, registerHelpText, rawArgs)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel raid `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel raid`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			const monsters = []
-			let park = 0
-			let distance = 0
-			let team = 4
-			let template = 3
-			const levels = []
-
-			args.forEach((element) => {
-				const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
-				if (pid !== undefined) monsters.push(pid)
-				else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
-					const Type = element.replace(/\b\w/g, l => l.toUpperCase())
-					_.filter(monsterData, (o, k) => {
-						if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
-							if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
-						} return k
-					})
-				}
-			})
-			args.forEach((element) => {
-				if (element.match(/ex/gi)) park = 1
-				else if (element.match(/instinct/gi)) team = 3
-				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
-				else if (element.match(/valor/gi)) team = 2
-				else if (element.match(/mystic/gi)) team = 1
-				else if (element.match(/harmony/gi)) team = 0
-				else if (element.match(/level\d/gi)) levels.push(element.replace(/level/gi, ''))
-				else if (element.match(/d\d/gi)) {
-					distance = element.replace(/d/gi, '')
-					if (distance.length >= 10) distance = distance.substr(0, 9)
-				}
-
-			})
-
-			if (monsters.length !== 0 && levels.length === 0) {
-				const level = 0
-				const insertData = monsters.map(monster => [msg.channel.id, monster, template, distance, park, team, level])
-				query.insertOrUpdateQuery(
-					'raid',
-					['id', 'pokemon_id', 'template', 'distance', 'park', 'team', 'level'],
-					insertData
-				)
-				msg.react('✅')
-				log.log({ level: 'debug', message: `${msg.author.username} started tracking ${monsters} in ${msg.channel.name}`, event: 'discord:raidChannel' })
-
-			}
-			else if (monsters.length === 0 && levels.length === 0) msg.reply('404 NO MONSTERS FOUND')
-			else if (monsters.length !== 0 && levels.length !== 0) msg.reply('400 Can\'t track raids by name and level at the same time')
-			else if (monsters.length === 0 && levels.length !== 0) {
-				const insertData = levels.map(level => [msg.channel.id, 721, template, distance, park, team, level])
-				query.insertOrUpdateQuery(
-					'raid',
-					['id', 'pokemon_id', 'template', 'distance', 'park', 'team', 'level'],
-					insertData
-				)
-				msg.react('✅')
-				log.log({ level: 'debug', message: `${msg.author.username} started tracking raid levels:${levels} raids in ${msg.channel.name} `, event: 'discord:raidChannel' })
-			}
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel raid`.length).split(' ')
+		const eventText = 'discord:raidChannel'
+		raidTrack(id, name, registerHelpText, rawArgs, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel unraid`)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel unraid`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			const monsters = []
-			const levels = []
-			args.forEach((element) => {
-				const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
-				if (pid !== undefined) monsters.push(pid)
-				else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
-					const Type = element.replace(/\b\w/g, l => l.toUpperCase())
-					_.filter(monsterData, (o, k) => {
-						if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
-							if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
-						} return k
-					})
-				}
-				if (element.match(/level\d/gi)) {
-					levels.push(element.replace(/level/gi, ''))
-				}
-			})
-			if (monsters.length) {
-				monsters.forEach((monster) => {
-					query.deleteByIdQuery('raid', 'pokemon_id', `${monster}`, msg.channel.id)
-				})
-				log.log({ level: 'debug', message: `${msg.author.username} removed tracking raid monsters:${monsters} raids in ${msg.channel.name} `, event: 'discord:unraidChannel' })
-				msg.react('✅')
-			}
-			if (levels.length) {
-				levels.forEach((level) => {
-					query.deleteByIdQuery('raid', 'level', `${level}`, msg.channel.id)
-				})
-				log.log({ level: 'debug', message: `${msg.author.username} removed tracking raid level:${levels} raids in ${msg.channel.name} `, event: 'discord:unraidChannel' })
-				msg.react('✅')
-			}
-			if (!monsters.length && !levels.length) msg.reply('404 No raid bosses or levels found')
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel unraid`.length).split(' ')
+		const eventText = 'discord:unraidChannel'
+		raidUntrack(id, registerHelpText, rawArgs, name, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel egg `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel egg`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-			let park = 0
-			const levels = []
-			let distance = 0
-			let team = 4
-			let template = 3
-			args.forEach((element) => {
-				if (element.match(/ex/gi)) park = 1
-				else if (element.match(/level\d/gi)) levels.push(element.replace(/level/gi, ''))
-				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
-				else if (element.match(/instinct/gi)) team = 3
-				else if (element.match(/valor/gi)) team = 2
-				else if (element.match(/mystic/gi)) team = 1
-				else if (element.match(/harmony/gi)) team = 0
-				else if (element.match(/d\d/gi)) {
-					distance = element.replace(/d/gi, '')
-					if (distance.length >= 10) distance = distance.substr(0, 9)
-				}
-			})
-			if (levels.length) {
-				const insertData = levels.map(level => [msg.channel.id, level, template, distance, park, team])
-				query.insertOrUpdateQuery(
-					'egg',
-					['id', 'raid_level', 'template', 'distance', 'park', 'team'],
-					insertData
-				)
-				msg.react('✅')
-				log.log({ level: 'debug', message: `${msg.author.username} started tracking level (${levels.join(',')}) eggs`, event: 'discord:eggChannel' })
-			}
-			else msg.reply('404 NO MONSTERS FOUND')
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel egg`.length).split(' ')
+		const eventText = 'discord:eggChannel'
+		eggTrack(id, registerHelpText, rawArgs, name, eventText)
 	}
 
 	else if (msg.content.startsWith(`${config.discord.prefix}channel unegg`)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel unegg`.length).split(' ')
-			const args = rawArgs.join('|').toLowerCase().split('|')
-
-			let level = false
-			args.forEach((element) => {
-				if (element.match(/level\d/gi)) level = element.replace(/level/gi, '')
-			})
-			if (level) {
-				query.deleteByIdQuery('egg', 'raid_level', `${level}`, msg.channel.id)
-				msg.react('✅')
-				log.log({ level: 'debug', message: `${msg.author.username} started untracked level ${level} eggs`, event: 'discord:uneggChannel' })
-
-			}
-			else {
-				msg.reply('404 Raid level not found')
-			}
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel unegg`.length).split(' ')
+		const eventText = 'discord:uneggChannel'
+		eggUntrack(id, name, registerHelpText, rawArgs, eventText)
 	}
 
 	else if (msg.content === `${config.discord.prefix}channel tracked`) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			Promise.all([
-				query.selectAllQuery('monsters', 'id', msg.channel.id),
-				query.selectAllQuery('raid', 'id', msg.channel.id),
-				query.selectAllQuery('egg', 'id', msg.channel.id),
-				query.selectOneQuery('humans', 'id', msg.channel.id),
-				query.selectAllQuery('quest', 'id', msg.channel.id),
-			]).then((data) => {
-				const monsters = data[0]
-				const raids = data[1]
-				const eggs = data[2]
-				const human = data[3]
-				const quests = data[4]
-				const maplink = `https://www.google.com/maps/search/?api=1&query=${human.latitude},${human.longitude}`
-				msg.reply(`👋\nYour location is currently set to ${maplink} \nand you currently are set to receive alarms in ${human.area}`)
-				let message = ''
-				if (monsters.length) {
-					message = message.concat('\n\nYou\'re  tracking the following monsters:\n')
-				}
-				else message = message.concat('\n\nYou\'re not tracking any monsters')
-
-				monsters.forEach((monster) => {
-					const monsterName = monsterData[monster.pokemon_id].name
-					let miniv = monster.min_iv
-					if (miniv === -1) miniv = 0
-					message = message.concat(`\n**${monsterName}** distance: ${monster.distance}m iv: ${miniv}%-${monster.max_iv}% cp: ${monster.min_cp}-${monster.max_cp} level: ${monster.min_level}-${monster.max_level} minimum stats: ATK:${monster.atk} DEF:${monster.def} STA:${monster.sta}`)
-				})
-				if (raids.length || eggs.length) {
-					message = message.concat('\n\nYou\'re tracking the following raids:\n')
-				}
-				else message = message.concat('\n\nYou\'re not tracking any raids')
-				raids.forEach((raid) => {
-					const monsterName = monsterData[raid.pokemon_id].name
-					const raidTeam = teamData[raid.team].name
-					if (parseInt(raid.pokemon_id, 10) === 721) {
-						message = message.concat(`\n**level:${raid.level} raids** distance: ${raid.distance}m controlled by ${raidTeam} , must be in park: ${raid.park}`)
-					}
-					else {
-						message = message.concat(`\n**${monsterName}** distance: ${raid.distance}m controlled by ${raidTeam} , must be in park: ${raid.park}`)
-					}
-				})
-				eggs.forEach((egg) => {
-					const raidTeam = teamData[egg.team].name
-					message = message.concat(`\n**Level ${egg.raid_level} eggs** distance: ${egg.distance}m controlled by ${raidTeam} , must be in park: ${egg.park}`)
-
-				})
-				if (quests.length) {
-					message = message.concat('\n\nYou\'re tracking the following quests:\n')
-				}
-				quests.forEach((quest) => {
-					let rewardThing = ''
-					if (quest.reward_type === 7) rewardThing = monsterData[quest.reward].name
-					if (quest.reward_type === 3) rewardThing = `${quest.reward} or more stardust`
-					if (quest.reward_type === 2) rewardThing = questDts.rewardItems[quest.reward]
-					message = message.concat(`\nReward: ${rewardThing} distance: ${quest.distance}m `)
-				})
-				log.log({ level: 'debug', message: `${msg.author.username} checked trackings`, event: 'discord:trackedChannel' })
-
-				if (message.length < 6000) {
-					msg.reply(message, { split: true })
-				}
-				else {
-					const hastebinMessage = hastebin(message)
-					hastebinMessage.then((hastelink) => {
-						msg.reply(`${msg.channel.name} tracking list is quite long. Have a look at ${hastelink}`)
-					})
-						.catch((err) => {
-							log.error(`Hastebin unhappy: ${err.message}`)
-							msg.reply(`${msg.channel.name} tracking list is long, but Hastebin is also down. ☹️ \nPlease try again later.`)
-						})
-				}
-			})
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		showTracked(id, name, registerHelpText)
 	}
 	else if (msg.content.startsWith(`${config.discord.prefix}channel quest `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			let monsters = []
-			const items = []
-			let distance = 0
-			const questTracks = []
-			let template = 3
-			let mustShiny = 0
-			let minDust = 10000000
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel quest`.length)
-			const args = rawArgs.toLowerCase().split(' ')
-			args.forEach((element) => {
-				const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
-				if (pid !== undefined) monsters.push(pid)
-				else if (element.match(/stardust\d/gi)) minDust = element.replace(/stardust/gi, '')
-				else if (element === 'stardust') minDust = 1
-				else if (element === 'shiny') mustShiny = 1
-				else if (element.match(/d\d/gi)) {
-					distance = element.replace(/d/gi, '')
-					if (distance.length >= 10) distance = distance.substr(0, 9)
-				}
-				else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
-					const Type = element.replace(/\b\w/g, l => l.toUpperCase())
-					_.filter(monsterData, (o, k) => {
-						if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
-							if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
-						} return k
-					})
-				}
-				else if (element.match(/template[1-5]/gi)) template = element.replace(/template/gi, '')
-			})
-			_.forEach(questDts.rewardItems, (item, key) => {
-				const re = new RegExp(` ${item}`, 'gi')
-				if (rawArgs.match(re)) items.push(key)
-			})
-
-			if (rawArgs.match(/all pokemon/gi)) monsters = [...Array(config.general.max_pokemon).keys()].map(x => x += 1)
-			if (rawArgs.match(/all items/gi)) {
-				_.forEach(questDts.rewardItems, (item, key) => {
-					items.push(key)
-				})
-			}
-			if (rawArgs.match(/stardust/gi)) {
-				questTracks.push({
-					id: msg.channel.id,
-					reward: minDust,
-					mustShiny: 0,
-					template: template,
-					reward_type: 3,
-					distance: distance
-				})
-			}
-			monsters.forEach((pid) => {
-				questTracks.push({
-					id: msg.channel.id,
-					reward: pid,
-					mustShiny: mustShiny,
-					template: template,
-					reward_type: 7,
-					distance: distance
-				})
-			})
-			items.forEach((i) => {
-				questTracks.push({
-					id: msg.channel.id,
-					reward: i,
-					mustShiny: 0,
-					template: template,
-					reward_type: 2,
-					distance: distance
-				})
-			})
-			const insertData = questTracks.map(t => [t.id, t.reward, t.template, t.reward_type, t.distance, t.mustShiny])
-			query.insertOrUpdateQuery(
-				'quest',
-				['id', 'reward', 'template', 'reward_type', 'distance', 'shiny'],
-				insertData
-			)
-			log.log({ level: 'debug', message: `${msg.author.username} updated quest trackings in ${msg.channel.name}`, event: 'discord:questChannel' })
-
-			msg.react('✅')
-
-		})
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel quest`.length)
+		const eventText = 'discord:questChannel'
+		questAdd(id, name, registerHelpText, rawArgs, eventText)
 	}
-
 	else if (msg.content.startsWith(`${config.discord.prefix}channel remove quest `)) {
 		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
 			return null
 		}
-		query.countQuery('id', 'humans', 'id', msg.channel.id).then((isregistered) => {
-			if (!isregistered) {
-				msg.reply(`${msg.channel.name} does not seem to be registered. add it with ${config.discord.prefix}channel add`)
-				return null
-			}
-			let monsters = [0]
-			const items = [0]
-			let stardustTracking = 99999999
-			const rawArgs = msg.content.slice(`${config.discord.prefix}channel remove quest `.length)
-			const args = rawArgs.toLowerCase().split(' ')
-			args.forEach((element) => {
-				const pid = _.findKey(monsterData, mon => mon.name.toLowerCase() === element)
-				if (pid !== undefined) monsters.push(pid)
-				else if (_.has(typeData, element.replace(/\b\w/g, l => l.toUpperCase()))) {
-					const Type = element.replace(/\b\w/g, l => l.toUpperCase())
-					_.filter(monsterData, (o, k) => {
-						if (_.includes(o.types, Type) && k < config.general.max_pokemon) {
-							if (!_.includes(monsters, parseInt(k, 10))) monsters.push(parseInt(k, 10))
-						} return k
-					})
-				}
-			})
-			_.forEach(questDts.rewardItems, (item, key) => {
-				const re = new RegExp(item, 'gi')
-				if (rawArgs.match(re)) items.push(key)
-			})
-			if (rawArgs.match(/stardust/gi)) {
-				stardustTracking = 0
-			}
-			if (rawArgs.match(/all pokemon/gi)) monsters = [...Array(config.general.max_pokemon).keys()].map(x => x += 1)
-			if (rawArgs.match(/all items/gi)) {
-				_.forEach(questDts.rewardItems, (item, key) => {
-					items.push(key)
-				})
-			}
+		const { id, name } = msg.channel
+		const registerHelpText = `${config.discord.prefix}channel add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}channel remove quest `.length)
+		const eventText = 'discord:questRemoveChannel'
+		questRemove(id, name, registerHelpText, rawArgs, eventText)
+	}
 
-			const remQuery = `
-			delete from quest WHERE id=${msg.channel.id} and 
-			((reward_type = 2 and reward in(${items})) or (reward_type = 7 and reward in(${monsters})) or (reward_type = 3 and reward >= ${stardustTracking}))		
-			`
-			query.mysteryQuery(remQuery).then((t) => {
-				log.log({ level: 'debug', message: `${msg.author.username} removed quest trackings in ${msg.channel.name}`, event: 'discord:questRemoveChannel' })
-			})
-			msg.react('✅')
+	/*
+  __          ________ ____  _    _  ____   ____  _  __   _____ ____  __  __ __  __          _   _ _____   _____
+ \ \        / /  ____|  _ \| |  | |/ __ \ / __ \| |/ /  / ____/ __ \|  \/  |  \/  |   /\   | \ | |  __ \ / ____|
+  \ \  /\  / /| |__  | |_) | |__| | |  | | |  | | ' /  | |   | |  | | \  / | \  / |  /  \  |  \| | |  | | (
+   \ \/  \/ / |  __| |  _ <|  __  | |  | | |  | |  <   | |   | |  | | |\/| | |\/| | / /\ \ | . ` | |  | |\___ \
+    \  /\  /  | |____| |_) | |  | | |__| | |__| | . \  | |___| |__| | |  | | |  | |/ ____ \| |\  | |__| |____) |
+     \/  \/   |______|____/|_|  |_|\____/ \____/|_|\_\  \_____\____/|_|  |_|_|  |_/_/    \_\_| \_|_____/|_____/
+		Webhook commands
+	 */
 
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook add`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook add `.length).split(' ')
+		if (rawArgs.length >= 2) {
+			const [name, id] = rawArgs
+			const registeredWhat = 'discord:registeredWebhook'
+			registerHuman(id, name, registeredWhat, 'webhook')
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook remove`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+
+		const eventName = 'discord:unregisteredWebhook'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook remove `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook').then((id) => {
+				unregisterHuman(id, name, eventName, 'webhook')
+			})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook location `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook location `.length).toLowerCase().split(' ')
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		if (rawArgs.length > 2) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook').then((id) => {
+				const search = msg.content.split(`${config.discord.prefix}webhook location ${name} `).pop()
+				registerLocation(id, name, registerHelpText, search, 'webhook')
+			})
+		}
+
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook start`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook location `.length).toLowerCase().split(' ')
+		const [name] = rawArgs
+		query.getHumanByName(name, 'webhook').then((id) => {
+			const registerHelpText = `${config.discord.prefix}webhook add`
+			const eventText = 'discord:startWebhook'
+			startHuman(name, registerHelpText, id, eventText, 'webhook')
 		})
 	}
 
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook stop`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const eventText = 'discord:stopWebhook'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook stop `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook').then((id) => {
+				stopHuman(id, name, registerHelpText, eventText, 'webhook')
+			})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook area add `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const eventText = 'discord:areaAddWebhook'
+		let rawArgs = msg.content.slice(`${config.discord.prefix}webhook area add `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook').then((id) => {
+				rawArgs = msg.content.slice(`${config.discord.prefix}webhook area add ${name}`.length)
+					.split(' ')
+				areaAdd(id, name, registerHelpText, rawArgs, eventText, 'webhook')
+			})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}channel area remove `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const eventText = 'discord:areaRemoveWebhook'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook area remove `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook').then((id) => {
+				const rawTrueArgs = msg.content.slice(`${config.discord.prefix}channel area remove ${name} `.length)
+					.split(' ')
+				areaRemove(id, name, registerHelpText, rawTrueArgs, eventText, 'webhook')
+			})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook track `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const eventText = 'discord:trackChannel'
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook track `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook track ${name}`.length)
+						.split(' ')
+					monsterTrack(id, name, registerHelpText, rawArgs2, eventText, 'webhook')
+				})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook untrack `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook untrack `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook untrack ${name}`.length)
+						.split(' ')
+					monsterUntrack(id, name, registerHelpText, rawArgs2, 'webhook')
+				})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook raid `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook raid `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const eventText = 'discord:raidWebhook'
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook raid ${name}`.length)
+						.split(' ')
+					raidTrack(id, name, registerHelpText, rawArgs2, eventText, 'webhook')
+				})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook unraid`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook unraid `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook unraid ${name}`.length)
+						.split(' ')
+					const eventText = 'discord:unraidWebhook'
+					raidUntrack(id, registerHelpText, rawArgs2, name, eventText, 'webhook')
+				})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook egg `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook egg `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook egg ${name}`.length)
+						.split(' ')
+					const eventText = 'discord:eggWebhook'
+					eggTrack(id, registerHelpText, rawArgs2, name, eventText, 'webhook')
+				})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook unegg`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook unegg `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const registerHelpText = `${config.discord.prefix}webhook add`
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook unegg ${name}`.length)
+						.split(' ')
+					const eventText = 'discord:uneggChannel'
+					eggUntrack(id, name, registerHelpText, rawArgs2, eventText, 'webook')
+				})
+		}
+	}
+
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook tracked`)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const registerHelpText = `${config.discord.prefix}webhook add`
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook tracked `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					showTracked(id, name, registerHelpText, 'webhook')
+				})
+		}
+	}
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook quest `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook quest `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const registerHelpText = `${config.discord.prefix}webhook add`
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook quest ${name}`.length)
+					const eventText = 'discord:questWebhook'
+					questAdd(id, name, registerHelpText, rawArgs2, eventText, 'webhook')
+				})
+		}
+	}
+	else if (msg.content.startsWith(`${config.discord.prefix}webhook remove quest `)) {
+		if (!_.includes(config.discord.admins, msg.author.id) || msg.channel.type !== 'text') {
+			return null
+		}
+		const rawArgs = msg.content.slice(`${config.discord.prefix}webhook track `.length).toLowerCase().split(' ')
+		if (rawArgs.length > 0) {
+			const [name] = rawArgs
+			query.getHumanByName(name, 'webhook')
+				.then((id) => {
+					const registerHelpText = `${config.discord.prefix}webhook add`
+					const rawArgs2 = msg.content.slice(`${config.discord.prefix}webhook remove quest ${name}`.length)
+					const eventText = 'discord:questRemoveWebhook'
+					questRemove(id, name, registerHelpText, rawArgs2, eventText, 'webhook')
+				})
+		}
+	}
 })
 
 process.on('exit', (err) => {

--- a/src/app/helpers/commands.js
+++ b/src/app/helpers/commands.js
@@ -904,14 +904,17 @@ client.on('message', (msg) => {
 			.then((isregistered) => {
 				if (!isregistered) msg.react('👌')
 				if (isregistered) {
-				msg.react('👌')
-				return null
-			}
-			query.insertOrUpdateQuery('humans', ['id', 'name', 'area'], [[msg.channel.id, emojiStrip(msg.channel.name), '[]']])
-					msg.react('✅')
-					log.log({ level: 'debug', message: `${msg.author.tag} unregistered`, event: 'discord:unregistered' })
-
+					msg.react('👌')
+					return null
 				}
+
+				query.insertOrUpdateQuery('humans', ['id', 'name', 'area'], [[msg.channel.id, emojiStrip(msg.channel.name), '[]']])
+				msg.react('✅')
+				log.log({
+					level: 'debug',
+					message: `${msg.author.tag} unregistered`,
+					event: 'discord:unregistered'
+				})
 			})
 	}
 

--- a/src/app/helpers/migrator.js
+++ b/src/app/helpers/migrator.js
@@ -180,6 +180,16 @@ const migration3 = {
 	`
 }
 
+const migration4 = {
+	humans: `
+		ALTER TABLE \`humans\` 
+		ADD \`humanKind\` varchar(10) NOT NULL DEFAULT 'discord';
+	`,
+	eggs: 'ALTER TABLE `egg` CHANGE id id varchar(191)  COLLATE utf8_unicode_ci NOT NULL;',
+	raids: 'ALTER TABLE `raid` CHANGE id id varchar(191)  COLLATE utf8_unicode_ci NOT NULL;',
+	monsters: 'ALTER TABLE `monsters` CHANGE id id varchar(191)  COLLATE utf8_unicode_ci NOT NULL;',
+	quest: 'ALTER TABLE `quest` CHANGE id id varchar(191)  COLLATE utf8_unicode_ci NOT NULL;',
+}
 
 module.exports = async () => {
 	queries.countQuery('TABLE_NAME', 'information_schema.tables', 'table_schema', config.db.database).then((tables) => {
@@ -222,6 +232,11 @@ module.exports = async () => {
 						queries.mysteryQuery(migration3.quest)
 						queries.addOneQuery('schema_version', 'val', 'key', 'db_version')
 						log.info('applied Db migration 3')
+					}
+					else if (version.val === 3) {
+						queries.mysteryQuery(migration4.humans)
+						queries.addOneQuery('schema_version', 'val', 'key', 'db_version')
+						log.info('applied Db migration 4')
 					}
 				})
 			})

--- a/test/travis.sql
+++ b/test/travis.sql
@@ -142,6 +142,7 @@ CREATE TABLE `humans` (
   `area` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `latitude` double DEFAULT 0,
   `longitude` double DEFAULT 0,
+  `humanKind` varchar(10) NOT NULL DEFAULT 'discord',
   PRIMARY KEY (`id`),
   KEY `humans_name` (`name`),
   KEY `humans_alerts_sent` (`alerts_sent`),


### PR DESCRIPTION
Allow poracle to register discord webhook urls as if they are humans (webhooks are humans too)


## Description
By reusing human table and adding a (human)kind I have mad it possible for Poracle to send alerts out to channels that are not on the Discord server the bot lives in.

you can now register a webhook by typing
`!webhook add MyFancyWebhookName https://discordWebhookUrl`

All commands from this points is like the channel commands, but between the command and the first parameter we always need the name used in the add command

like:

`!webhook area add MyFancyWebhookName geofenceArea123`

Rebased all "channel" commands to reuse the most amount of stuff

## Motivation and Context
Solves the issue of nosy Poracle wanting to send messages to channels in Discords that it doesn't have bot access. 

## How Has This Been Tested?
Sent the webhooks into the sky and found out they indeed worked

## Screenshots (if appropriate):
NA
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Gotta update readthedocs with all the new commands, should it be accepted