### PR TITLE
Build docker image from current local contents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get -y update 
 RUN apt-get -y update && apt-get install -y git
 
 # PoracleJS
-RUN git clone https://github.com/KartulUdus/PoracleJS.git --branch develop && cd PoracleJS && npm install
-
+COPY . /PoracleJS
+RUN cd PoracleJS && npm install
 
 WORKDIR PoracleJS
 


### PR DESCRIPTION
The current Dockerfile always pulls develop branch from github. If user wants to build a docker image using a PR or any manual changes to project the git clone in current Dockerfile will overwrite. This PR will use the current contents of project directory instead to build the docker image. User would need to pull branch and/or PRs before building.
