### PR TITLE
Invasion rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poraclejs",
-  "version": "3.9.21",
+  "version": "3.10.22",
   "description": "Webhook processing and personalised alarms",
   "main": "src/app.js",
   "repository": {

--- a/src/util/grunt_types.json
+++ b/src/util/grunt_types.json
@@ -1,207 +1,291 @@
 {
-    "0": {
-       "type": "Random",
-       "grunt": "Random",
-       "gender": 0
-    },
-    "1": {
-      "type": "",
-      "grunt": "Blanche",
-      "gender": 2
-    },
-    "2": {
-      "type": "",
-      "grunt": "Candela",
-      "gender": 2
-    },
-    "3": {
-      "type": "",
-      "grunt": "Spark",
-      "gender": 1
-    },
-    "4": {
-      "type": "Mixed",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "5": {
-      "type": "Mixed",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "6": {
-      "type": "Bug",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "7": {
-      "type": "Bug",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "8": {
-      "type": "Ghost",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "9": {
-      "type": "Ghost",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "10": {
-      "type": "Dark",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "11": {
-      "type": "Dark",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "12": {
-      "type": "Dragon",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "13": {
-      "type": "Dragon",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "14": {
-      "type": "Fairy",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "15": {
-      "type": "Fairy",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "16": {
-      "type": "Fighting",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "17": {
-      "type": "Fighting",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "18": {
-      "type": "Fire",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "19": {
-      "type": "Fire",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "20": {
-      "type": "Flying",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "21": {
-      "type": "Flying",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "22": {
-      "type": "Grass",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "23": {
-      "type": "Grass",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "24": {
-      "type": "Ground",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "25": {
-      "type": "Ground",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "26": {
-      "type": "Ice",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "27": {
-      "type": "Ice",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "28": {
-      "type": "Metal",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "29": {
-      "type": "Metal",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "30": {
-      "type": "Normal",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "31": {
-      "type": "Normal",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "32": {
-      "type": "Poison",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "33": {
-      "type": "Poison",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "34": {
-      "type": "Psychic",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "35": {
-      "type": "Psychic",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "36": {
-      "type": "Rock",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "37": {
-      "type": "Rock",
-      "grunt": "Male Grunt", 
-      "gender": 1
-    },
-    "38": {
-      "type": "Water",
-      "grunt": "Female Grunt",
-      "gender": 2
-    },
-    "39": {
-      "type": "Water",
-      "grunt": "Male Grunt",
-      "gender": 1
-    },
-    "40": {
-      "type": "",
-      "grunt": "Player Team Leader",
-      "gender": 0
+  "1": {
+    "type": "",
+    "grunt": "Blanche",
+    "gender": 2
+  },
+  "2": {
+    "type": "",
+    "grunt": "Candela",
+    "gender": 2
+  },
+  "3": {
+    "type": "",
+    "grunt": "Spark",
+    "gender": 1
+  },
+  "4": {
+    "type": "Mixed",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "true",
+    "encounters":{
+        "first": ["001","004","007"],
+        "second":["002","005","008"],
+        "third":["003","006","009"]
     }
+  },
+  "5": {
+    "type": "Mixed",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["143"],
+        "second":["143","062","282"],
+        "third":["143","149","130"]
+    }
+  },
+  "6": {
+    "type": "Bug",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "7": {
+    "type": "Bug",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["123"],
+        "second":["123","212"],
+        "third":["123","212"]
+    }
+  },
+  "8": {
+    "type": "Ghost",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "9": {
+    "type": "Ghost",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "10": {
+    "type": "Dark",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "11": {
+    "type": "Dark",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "12": {
+    "type": "Dragon",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["147"],
+        "second":["147","148"],
+        "third":["148","149","130"]
+    }
+  },
+  "13": {
+    "type": "Dragon",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "14": {
+    "type": "Fairy",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "15": {
+    "type": "Fairy",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "16": {
+    "type": "Fighting",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["107"],
+        "second":["107"],
+        "third":["107"]
+	}
+  },
+  "17": {
+    "type": "Fighting",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "18": {
+    "type": "Fire",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "true",
+    "encounters":{
+        "first": ["004","058","228"],
+        "second":["005","229"],
+        "third":["006","059","229"]
+    }
+  },
+  "19": {
+    "type": "Fire",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "20": {
+    "type": "Flying",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["041","042"],
+        "second":["042","123","169"],
+        "third":["130","149","169"]
+    }
+  },
+  "21": {
+    "type": "Flying",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "22": {
+    "type": "Grass",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "23": {
+    "type": "Grass",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "true",
+    "encounters":{
+        "first": ["001","043","387"],
+        "second":["001","002","044"],
+        "third":["002","003","388"]
+    }
+  },
+  "24": {
+    "type": "Ground",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "25": {
+    "type": "Ground",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["019","104","246"],
+        "second":["020","104","105"],
+        "third":["020","105"]
+    }
+  },
+  "26": {
+    "type": "Ice",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "27": {
+    "type": "Ice",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "28": {
+    "type": "Steel",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "29": {
+    "type": "Steel",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "30": {
+    "type": "Normal",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "31": {
+    "type": "Normal",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "true",
+    "encounters":{
+        "first": ["019","041"],
+        "second":["019","020"],
+        "third":["020","143"]
+    }
+  },
+  "32": {
+    "type": "Poison",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "true",
+    "encounters":{
+        "first": ["041","048","088"],
+        "second":["042","088","089"],
+        "third":["042","049","089"]
+    }
+  },
+  "33": {
+    "type": "Poison",
+    "grunt": "Male Grunt",
+    "gender": 1
+  },
+  "34": {
+    "type": "Psychic",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "35": {
+    "type": "Psychic",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "true",
+    "encounters":{
+        "first": ["063","096","280"],
+        "second":["096","097","280"],
+        "third":["064","097","281"]
+    }
+  },
+  "36": {
+    "type": "Rock",
+    "grunt": "Female Grunt",
+    "gender": 2
+  },
+  "37": {
+    "type": "Rock",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["246"],
+        "second":["246","247"],
+        "third":["247","248"]
+	}
+  },
+  "38": {
+    "type": "Water",
+    "grunt": "Female Grunt",
+    "gender": 2,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["054","060"],
+        "second":["055","061"],
+        "third":["056","061","186"]
+    }
+  },
+  "39": {
+    "type": "Water",
+    "grunt": "Male Grunt",
+    "gender": 1,
+    "second_reward": "false",
+    "encounters":{
+        "first": ["129"],
+        "second":["129"],
+        "third":["129"]
+    }
+  },
+  "40": {
+    "type": "",
+    "grunt": "Player Team Leader"
   }
+}

--- a/src/util/grunt_types.json
+++ b/src/util/grunt_types.json
@@ -18,7 +18,7 @@
     "type": "Mixed",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "true",
+    "second_reward": true,
     "encounters":{
         "first": ["001","004","007"],
         "second":["002","005","008"],
@@ -29,7 +29,7 @@
     "type": "Mixed",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["143"],
         "second":["143","062","282"],
@@ -45,7 +45,7 @@
     "type": "Bug",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["123"],
         "second":["123","212"],
@@ -76,7 +76,7 @@
     "type": "Dragon",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["147"],
         "second":["147","148"],
@@ -102,7 +102,7 @@
     "type": "Fighting",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["107"],
         "second":["107"],
@@ -118,7 +118,7 @@
     "type": "Fire",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "true",
+    "second_reward": true,
     "encounters":{
         "first": ["004","058","228"],
         "second":["005","229"],
@@ -134,7 +134,7 @@
     "type": "Flying",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["041","042"],
         "second":["042","123","169"],
@@ -155,7 +155,7 @@
     "type": "Grass",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "true",
+    "second_reward": true,
     "encounters":{
         "first": ["001","043","387"],
         "second":["001","002","044"],
@@ -171,7 +171,7 @@
     "type": "Ground",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["019","104","246"],
         "second":["020","104","105"],
@@ -207,7 +207,7 @@
     "type": "Normal",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "true",
+    "second_reward": true,
     "encounters":{
         "first": ["019","041"],
         "second":["019","020"],
@@ -218,7 +218,7 @@
     "type": "Poison",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "true",
+    "second_reward": true,
     "encounters":{
         "first": ["041","048","088"],
         "second":["042","088","089"],
@@ -239,7 +239,7 @@
     "type": "Psychic",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "true",
+    "second_reward": true,
     "encounters":{
         "first": ["063","096","280"],
         "second":["096","097","280"],
@@ -255,7 +255,7 @@
     "type": "Rock",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["246"],
         "second":["246","247"],
@@ -266,7 +266,7 @@
     "type": "Water",
     "grunt": "Female Grunt",
     "gender": 2,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["054","060"],
         "second":["055","061"],
@@ -277,7 +277,7 @@
     "type": "Water",
     "grunt": "Male Grunt",
     "gender": 1,
-    "second_reward": "false",
+    "second_reward": false,
     "encounters":{
         "first": ["129"],
         "second":["129"],


### PR DESCRIPTION
Add DTS for Team Rocket Invasion rewards
## Description
new DTS {{gruntRewards}} with the pokemon names of possible rewards. If there's two rewards there will be two lines and the list of names be prefixed like:
85%: abra, kadabra
15%: alakhazam

## Motivation and Context
People be screaming for it

## How Has This Been Tested?
Released 500 drones from my office building to see how many came back with the right reward

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.