### PR TITLE
fix: This stops {{imgurl}} from being lowercased

### DIFF
--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -208,7 +208,7 @@ class Monster extends Controller {
 								atk: data.individual_attack,
 								def: data.individual_defense,
 								sta: data.individual_stamina,
-								imgurl: data.imgurl.toLowerCase(),
+								imgurl: data.imgurl,
 								pokemoji: emojiData.pokemon[data.pokemon_id],
 								areas: data.matched.map(area => area.replace(/'/gi, '').replace(/ /gi, '-')).join(', '),
 

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -142,7 +142,7 @@ class Quest extends Controller {
 							itemNames: itemnames.join(', '),
 							stardust: data.type === 3 ? 'stardust' : '',
 							rewardemoji: data.rewardemoji,
-							imgurl: data.imgurl.toLowerCase(),
+							imgurl: data.imgurl,
 							name: data.pokestop_name.replace(/\n/g, ' '),
 							url: data.pokestop_url,
 							minCp: data.rewardData.monsters[1] ? this.getCp(data.rewardData.monsters[1], 15, 10, 10, 10) : '',

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -211,7 +211,7 @@ class Raid extends Controller {
 												staticmap: data.staticmap,
 												detailsurl: data.url,
 												mapurl: data.mapurl,
-												imgurl: data.imgurl.toLowerCase(),
+												imgurl: data.imgurl,
 												gif: pokemonGif(Number(data.pokemon_id)),
 												color: data.color,
 												// geocode stuff
@@ -336,7 +336,7 @@ class Raid extends Controller {
 												mapurl: data.mapurl,
 												applemap: data.applemap,
 												rocketmap: data.rocketmap,
-												imgurl: data.imgurl.toLowerCase(),
+												imgurl: data.imgurl,
 												color: data.color,
 												ex: data.ex,
 												// geocode stuff

--- a/test/test.js
+++ b/test/test.js
@@ -105,7 +105,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🌿')
 			chai.assert.equal(affirmative.message.embed.color, 16744448)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_001_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_001_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -131,7 +131,7 @@ describe('Pokemon Filters', () => {
 			const zero = work[2]
 			chai.assert.equal(affirmative.emoji[0], '🌿')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_002_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_002_00.png`)
 			negative.should.have.lengthOf(0)
 			zero.should.have.lengthOf(0)
 			done()
@@ -153,7 +153,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🌿')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_003_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_003_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -174,7 +174,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🔥')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_004_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_004_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -195,7 +195,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🔥')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_005_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_005_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -216,7 +216,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🔥')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_006_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_006_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -237,7 +237,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '💧')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_007_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_007_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -258,7 +258,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '💧')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_008_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_008_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -279,7 +279,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '💧')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_009_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_009_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -300,7 +300,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🐛')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_010_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_010_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -321,7 +321,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🐛')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_011_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_011_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -342,7 +342,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🔮')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_201_6.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_201_6.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -363,7 +363,7 @@ describe('Pokemon Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🐛')
 			chai.assert.equal(affirmative.message.embed.color, 10329501)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_012_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_012_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -388,7 +388,7 @@ describe('Raid Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🐛')
 			chai.assert.equal(affirmative.message.embed.color, 7915600)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_013_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_013_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -409,7 +409,7 @@ describe('Raid Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🐛')
 			chai.assert.equal(affirmative.message.embed.color, 7915600)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_014_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_014_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -431,7 +431,7 @@ describe('Raid Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '🐛')
 			chai.assert.equal(affirmative.message.embed.color, 16306224)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_015_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_015_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -452,7 +452,7 @@ describe('Raid Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '⭕')
 			chai.assert.equal(affirmative.message.embed.color, 16306224)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_016_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_016_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -473,7 +473,7 @@ describe('Raid Filters', () => {
 			const negative = work[1]
 			chai.assert.equal(affirmative.emoji[0], '⭕')
 			chai.assert.equal(affirmative.message.embed.color, 16306224)
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_017_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_017_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -576,7 +576,7 @@ describe('Quest Filters', () => {
 		Promise.all([questController.handle(positiveMessage), questController.handle(negativeMessage)]).then((work) => {
 			const affirmative = work[0][0]
 			const negative = work[1]
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_137_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_137_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -595,7 +595,7 @@ describe('Quest Filters', () => {
 		Promise.all([questController.handle(positiveMessage), questController.handle(negativeMessage)]).then((work) => {
 			const affirmative = work[0][0]
 			const negative = work[1]
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_025_00.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}pokemon_icon_025_00.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -614,7 +614,7 @@ describe('Quest Filters', () => {
 		Promise.all([questController.handle(positiveMessage), questController.handle(negativeMessage)]).then((work) => {
 			const affirmative = work[0][0]
 			const negative = work[1]
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}rewards/reward_2_1.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}rewards/reward_2_1.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -633,7 +633,7 @@ describe('Quest Filters', () => {
 		Promise.all([questController.handle(positiveMessage), questController.handle(negativeMessage)]).then((work) => {
 			const affirmative = work[0][0]
 			const negative = work[1]
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}rewards/reward_stardust.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}rewards/reward_stardust.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {
@@ -652,7 +652,7 @@ describe('Quest Filters', () => {
 		Promise.all([questController.handle(positiveMessage), questController.handle(negativeMessage)]).then((work) => {
 			const affirmative = work[0][0]
 			const negative = work[1]
-			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}rewards/reward_705_1.png`.toLowerCase())
+			chai.assert.equal(affirmative.message.embed.thumbnail.url, `${config.general.imgurl}rewards/reward_705_1.png`)
 			negative.should.have.lengthOf(0)
 			done()
 		}).catch((err) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes the img.url to not be forced to be lowercased.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Webservers don't have to support lowercased urls and as such some even consider it a different url, so we get a 404. The following image repos are a few examples that PoracleJS currently doesn't support without this patch. Looking through git blame this seems to have started with the following commit https://github.com/KartulUdus/PoracleJS/commit/efc58ba73b6ea5b27ed00b2d0923ba3983de34e7. I would assume when you wrote the code originally you had a webserver that did support lowercase versions of the URL. It's recommended by most tech to have lowercase URLs but that is not the world we live in.
 
```
https://rawcdn.githack.com/Aranoh/pkmn_shuffle_icons_pokesquad/master/optimized_for_PMSF_frontend/
https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changed these three files locally, linked them in my docker container, restarted poracle, images now show up in discord.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.