### PR TITLE
Update monstersfr.json

### DIFF
--- a/src/util/locale/monstersfr.json
+++ b/src/util/locale/monstersfr.json
@@ -4409,7 +4409,7 @@
     "spawn_rate": ""
   },
   "522": {
-    "name": "Zébribon",
+    "name": "Zébibron",
     "rarity": "",
     "types": [
       "Electric"


### PR DESCRIPTION
Typo fix for pokémon 522

<!--- Provide a general summary of your changes in the Title above -->

## Description
Wrong name for pokémon 522

