### PR TITLE
Replace mustache prefix placeholder in telegram help message

### DIFF
--- a/src/helpers/telegram/commands/help.js
+++ b/src/helpers/telegram/commands/help.js
@@ -31,7 +31,7 @@ module.exports = (ctx) => {
 				greeting.forEach((field) => {
 					message = message.concat(`\n\n${field.name}\n\n${field.value}`)
 				})
-				message = message.replace(/{{prefix}}/g, controller.config.discord.prefix)
+				message = message.replace(/{{prefix}}/g, '/')
 				ctx.reply(message, { parse_mode: 'Markdown' }).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/help.js
+++ b/src/helpers/telegram/commands/help.js
@@ -31,6 +31,7 @@ module.exports = (ctx) => {
 				greeting.forEach((field) => {
 					message = message.concat(`\n\n${field.name}\n\n${field.value}`)
 				})
+				message = message.replace(/{{prefix}}/g, controller.config.discord.prefix)
 				ctx.reply(message, { parse_mode: 'Markdown' }).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})


### PR DESCRIPTION
This patch replaces the existing {{prefix}} placeholder in telegram help message. This is done in the original discord help handling as well.