### PR TITLE
add telegram supergroup support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poraclejs",
-  "version": "3.12.25",
+  "version": "3.12.26",
   "description": "Webhook processing and personalised alarms",
   "main": "src/app.js",
   "repository": {

--- a/src/helpers/telegram/commands/area.js
+++ b/src/helpers/telegram/commands/area.js
@@ -11,15 +11,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/area.js
+++ b/src/helpers/telegram/commands/area.js
@@ -11,15 +11,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/backup.js
+++ b/src/helpers/telegram/commands/backup.js
@@ -10,15 +10,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/backup.js
+++ b/src/helpers/telegram/commands/backup.js
@@ -10,15 +10,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/channel.js
+++ b/src/helpers/telegram/commands/channel.js
@@ -7,7 +7,7 @@ module.exports = (ctx) => {
 	const user = ctx.update.message.from
 	const args = command.splitArgs
 
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		const target = { id: ctx.update.message.chat.id, name: ctx.update.message.chat.title.toLowerCase() }
 		switch (args[0]) {
 			case 'add': {

--- a/src/helpers/telegram/commands/channel.js
+++ b/src/helpers/telegram/commands/channel.js
@@ -7,7 +7,7 @@ module.exports = (ctx) => {
 	const user = ctx.update.message.from
 	const args = command.splitArgs
 
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		const target = { id: ctx.update.message.chat.id, name: ctx.update.message.chat.title.toLowerCase() }
 		switch (args[0]) {
 			case 'add': {

--- a/src/helpers/telegram/commands/egg.js
+++ b/src/helpers/telegram/commands/egg.js
@@ -8,15 +8,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/egg.js
+++ b/src/helpers/telegram/commands/egg.js
@@ -8,15 +8,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/help.js
+++ b/src/helpers/telegram/commands/help.js
@@ -7,15 +7,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/help.js
+++ b/src/helpers/telegram/commands/help.js
@@ -7,15 +7,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/invasion.js
+++ b/src/helpers/telegram/commands/invasion.js
@@ -8,15 +8,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/invasion.js
+++ b/src/helpers/telegram/commands/invasion.js
@@ -8,15 +8,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/location.js
+++ b/src/helpers/telegram/commands/location.js
@@ -8,15 +8,15 @@ module.exports = (ctx) => {
 	const search = command.args
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/location.js
+++ b/src/helpers/telegram/commands/location.js
@@ -8,15 +8,15 @@ module.exports = (ctx) => {
 	const search = command.args
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/quest.js
+++ b/src/helpers/telegram/commands/quest.js
@@ -18,15 +18,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/quest.js
+++ b/src/helpers/telegram/commands/quest.js
@@ -18,15 +18,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/raid.js
+++ b/src/helpers/telegram/commands/raid.js
@@ -18,15 +18,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/raid.js
+++ b/src/helpers/telegram/commands/raid.js
@@ -18,15 +18,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/restore.js
+++ b/src/helpers/telegram/commands/restore.js
@@ -10,15 +10,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/restore.js
+++ b/src/helpers/telegram/commands/restore.js
@@ -10,15 +10,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/start.js
+++ b/src/helpers/telegram/commands/start.js
@@ -7,15 +7,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/start.js
+++ b/src/helpers/telegram/commands/start.js
@@ -7,15 +7,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/stop.js
+++ b/src/helpers/telegram/commands/stop.js
@@ -7,15 +7,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/stop.js
+++ b/src/helpers/telegram/commands/stop.js
@@ -7,15 +7,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/track.js
+++ b/src/helpers/telegram/commands/track.js
@@ -18,15 +18,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/track.js
+++ b/src/helpers/telegram/commands/track.js
@@ -18,15 +18,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/tracked.js
+++ b/src/helpers/telegram/commands/tracked.js
@@ -21,15 +21,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/tracked.js
+++ b/src/helpers/telegram/commands/tracked.js
@@ -21,15 +21,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/untrack.js
+++ b/src/helpers/telegram/commands/untrack.js
@@ -16,15 +16,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/untrack.js
+++ b/src/helpers/telegram/commands/untrack.js
@@ -16,15 +16,15 @@ module.exports = (ctx) => {
 	const args = command.splitArgs
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/version.js
+++ b/src/helpers/telegram/commands/version.js
@@ -10,15 +10,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})

--- a/src/helpers/telegram/commands/version.js
+++ b/src/helpers/telegram/commands/version.js
@@ -10,15 +10,15 @@ module.exports = (ctx) => {
 	const channelName = ctx.update.message.chat.title ? ctx.update.message.chat.title : ''
 
 	let target = { id: user.id.toString(), name: user.first_name }
-	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+	if (!_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 		return ctx.telegram.sendMessage(user.id, 'Please run commands in Direct Messages').catch((O_o) => {
 			controller.log.error(O_o.message)
 		})
 	}
-	if (_.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
+	if (_.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) target = { id: ctx.update.message.chat.id.toString(), name: ctx.update.message.chat.title }
 	controller.query.countQuery('id', 'humans', 'id', target.id)
 		.then((isregistered) => {
-			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup') {
+			if (!isregistered && _.includes(controller.config.telegram.admins, user.id.toString()) && (ctx.update.message.chat.type === 'group' || ctx.update.message.chat.type === 'supergroup')) {
 				return ctx.reply(`${channelName} does not seem to be registered. add it with /channel add`).catch((O_o) => {
 					controller.log.error(O_o.message)
 				})


### PR DESCRIPTION
As Telegram is removing the difference between normal groups and supergroups, Poracle should do the same.

## Description
Basically, i just extended the group type check

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
@KartulUdus can you pls check the combination of the `&&` and `||` ? Not sure if that's the correct way

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.