### PR TITLE
Use correct api call to send tracked document

### DIFF
--- a/src/helpers/telegram/commands/tracked.js
+++ b/src/helpers/telegram/commands/tracked.js
@@ -150,7 +150,7 @@ module.exports = (ctx) => {
 									controller.log.error(O_o.message)
 								})
 								const attachment = fs.readFileSync(filepath, { encoding: 'utf-8' })
-								ctx.telegram.sendDocument(target.id, attachment)
+								ctx.telegram.sendDocument(target.id, { source: attachment, filename: 'tracked.txt' })
 									.then(() => {
 										fs.unlinkSync(filepath)
 									})


### PR DESCRIPTION
## Description
If the Hastebin service is down a static file with tracked information should be sent to the user. Currently the file is not send at all due to api errors.

## Motivation and Context
In an own project I disabled the Hastebin service completely and always want a file to be sent to the user.

## How Has This Been Tested?
This was tested with `/tracked` command.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.