### PR TITLE
Fix the Telegram restore feature

### DIFF
--- a/config/examples/dts.json.example
+++ b/config/examples/dts.json.example
@@ -373,7 +373,7 @@
   "greeting": {
     "embed": {
       "title": "Welcome",
-      "description": "Thank you for registering \nPlease set a location `{{prefix}}location name of place` or add ares where to receive alarms from",
+      "description": "Thank you for registering \nPlease set a location by typing `{{prefix}}location name of place` (use whatever works properly in Google Maps __without__ autocomplete); you will be setting a radius in metres from that point, for all commands. Alternatively, you can add multiple areas where you want to receive alarms from (if your admin has configured areas)",
       "fields": [
         {
           "name": "General commands",
@@ -393,11 +393,27 @@
         },
         {
           "name": "Quest tracking commands",
-          "value": "`{{prefix}}quest porygon pikachu poke ball d500 `: Any arguments are optional, this command would alert you about Quests obtainable within 500m of your location with porygon, pikachu or pokeballs as rewards \n `{{prefix}}quest remove all items` Removes tracking for all item based quests. Can also use `all pokemon` or `stardust`"
+          "value": "`{{prefix}}quest porygon pikachu poke ball d500 `: Any arguments are optional, this command would alert you about Quests obtainable within 500m of your location with porygon, pikachu or pokeballs as rewards \n `{{prefix}}quest remove all items` Removes tracking for all item based quests. Can also use `all pokemon` or `stardust` or `stardust1000`\n See [a list of quest items](https://github.com/KartulUdus/PoracleJS/blob/fb2daebbfb49b0af5ea8472228f9b726d4c4727e/config/examples/questdts.json.example#L92). \n Replace spaces with _ underscores"
         },
         {
           "name": "Invasion tracking commands",
           "value": "`{{prefix}}invasion template3 d500 dragon mixed`: Any arguments are optional, this command would alert you about Team Rocket Incidents within 500m of your location if the grunt type was mixed or dragon. You can use any pokemon type name.\n `{{prefix}}invasion remove` Removes tracking for all Team Rocket Incidents."
+        },
+        {
+          "name": "List your current configuration",
+          "value": "`{{prefix}}tracked`: Shows you what you are currently configured to be notified about."
+        },
+        {
+          "name": "Further info",
+          "value": "See [all the commands available](https://kartuludus.github.io/PoracleJS/#/commands) (including some not listed here)"
+        },
+        {
+          "name": "Examples",
+          "value": "You probably want to start off with something like these 3 commands: \n `{{prefix}}track gible gabite cranidos deino zweilous litwick lampent d1500` \n `{{prefix}}raid timburr litwick d1500` \n `{{prefix}}quest silver_pinap_berry d500`"
+        },
+        {
+          "name": "How far can I walk in metres/minutes? According to the web...",
+          "value": "```Metres | Fast | Moderate | Easy Walk \n 1000      7       10         13 \n 2000      14      20         25 \n 3000      21      30         38 \n 4000      28      40         50 \n 5000      35      50         63```"
         }
       ]
     }

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -267,7 +267,7 @@ class Monster extends Controller {
 							const work = {
 								lat: data.latitude.toString().substring(0, 8),
 								lon: data.longitude.toString().substring(0, 8),
-								sticker: data.sticker.toLowerCase(),
+								sticker: data.sticker,
 								message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : message,
 								target: cares.id,
 								name: cares.name,

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -199,7 +199,7 @@ class Quest extends Controller {
 							const work = {
 								lat: data.latitude.toString().substring(0, 8),
 								lon: data.longitude.toString().substring(0, 8),
-								sticker: data.sticker.toLowerCase(),
+								sticker: data.sticker,
 								message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : JSON.parse(message),
 								target: cares.id,
 								name: cares.name,

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -259,7 +259,7 @@ class Raid extends Controller {
 											const work = {
 												lat: data.latitude.toString().substring(0, 8),
 												lon: data.longitude.toString().substring(0, 8),
-												sticker: data.sticker.toLowerCase(),
+												sticker: data.sticker,
 												message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : message,
 												target: cares.id,
 												name: cares.name,
@@ -395,7 +395,7 @@ class Raid extends Controller {
 											const work = {
 												lat: data.latitude.toString().substring(0, 8),
 												lon: data.longitude.toString().substring(0, 8),
-												sticker: data.sticker.toLowerCase(),
+												sticker: data.sticker,
 												message: caresCache === config.discord.limitamount + 1 ? { content: `You have reached the limit of ${config.discord.limitamount} messages over ${config.discord.limitsec} seconds` } : message,
 												target: cares.id,
 												name: cares.name,

--- a/src/helpers/telegram/commands/restore.js
+++ b/src/helpers/telegram/commands/restore.js
@@ -57,7 +57,7 @@ module.exports = (ctx) => {
 							controller.query.deleteQuery('quest', 'id', target.id).catch((O_o) => {}),
 							controller.query.deleteQuery('incident', 'id', target.id).catch((O_o) => {}),
 						]).then((x) => {
-							const query = fs.readFileSync(path.join(__dirname, '../../commando/commands', `/filterBackups/${args[0]}.sql`), 'utf8').replace('{{ target }}', target.id)
+							const query = fs.readFileSync(path.join(__dirname, '../../commando/commands', `/filterBackups/${args[0]}.sql`), 'utf8').replace(/'{{ target }}'/g, target.id)
 							controller.query.mysteryQuery(query).catch((O_o) => {})
 							ctx.reply('✅').catch((O_o) => {
 								controller.log.error(O_o.message)

--- a/src/helpers/telegram/commands/restore.js
+++ b/src/helpers/telegram/commands/restore.js
@@ -57,7 +57,7 @@ module.exports = (ctx) => {
 							controller.query.deleteQuery('quest', 'id', target.id).catch((O_o) => {}),
 							controller.query.deleteQuery('incident', 'id', target.id).catch((O_o) => {}),
 						]).then((x) => {
-							const query = fs.readFileSync(path.join(__dirname, '../../commando/commands', `/filterBackups/${args[0]}.sql`), 'utf8').replace(/'{{ target }}'/g, target.id)
+							const query = fs.readFileSync(path.join(__dirname, '../../commando/commands', `/filterBackups/${args[0]}.sql`), 'utf8').replace(/{{ target }}/g, target.id)
 							controller.query.mysteryQuery(query).catch((O_o) => {})
 							ctx.reply('✅').catch((O_o) => {
 								controller.log.error(O_o.message)

--- a/src/util/grunt_types.json
+++ b/src/util/grunt_types.json
@@ -31,7 +31,7 @@
     "gender": 2,
     "second_reward": false,
     "encounters":{
-        "first": ["143"],
+        "first": ["131","143"],
         "second":["143","62","282"],
         "third":["143","149","130"]
     }
@@ -187,7 +187,13 @@
   "26": {
     "type": "Ice",
     "grunt": "Female Grunt",
-    "gender": 2
+    "gender": 2,
+    "second_reward": false,
+    "encounters":{
+        "first": ["225","459"],
+        "second":["225"],
+        "third":["225","460"]
+    }
   },
   "27": {
     "type": "Ice",
@@ -300,9 +306,9 @@
     "gender": 1,
     "second_reward": false,
     "encounters":{
-        "first": ["52"],
-        "second":["28","143","330"],
-        "third":["248","392","389"]
+        "first": ["234"],
+        "second":["95","105","466"],
+        "third":["248","260","389"]
     }
   },
   "42": {
@@ -311,9 +317,9 @@
     "gender": 1,
     "second_reward": false,
     "encounters":{
-        "first": ["123"],
-        "second":["130","169","462"],
-        "third":["06","149","212"]
+        "first": ["371"],
+        "second":["6","9","208"],
+        "third":["149","212","373"]
     }
   },
   "43": {
@@ -322,9 +328,9 @@
     "gender": 2,
     "second_reward": false,
     "encounters":{
-        "first": ["215"],
-        "second":["97","131","302"],
-        "third":["65","229","282"]
+        "first": ["359"],
+        "second":["65","131","332"],
+        "third":["229","275","475"]
     }
   },
   "44": {
@@ -333,7 +339,7 @@
     "gender": 1,
     "second_reward": false,
     "encounters":{
-        "first": ["144"]
+        "first": ["145"]
     }
   },
   "45": {


### PR DESCRIPTION
##  Description
Restoring more then 1 Pokemon with the restore feature in telegram did not work, as only a single instance of {{ target }} would be replaced. Thus all the other entries in the DB still have {{ target }} set as ID. With the new search string, every instance of {{ target }} is replaced with the user id.

## How Has This Been Tested?
Yes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.