### PR TITLE
Added pokemon webhook logging to webhook.json

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -122,7 +122,7 @@ async function handleAlarms() {
 		const hook = fastify.hookQueue.shift()
 		switch (hook.type) {
 			case 'pokemon': {
-				fastify.webhooks.info('pokemon', JSON.stringify(hook))
+				fastify.webhooks.info('pokemon', hook.message)
 				if (fastify.cache.get(`${hook.message.encounter_id}_${hook.message.disappear_time}_${hook.message.weight}`)) {
 					fastify.logger.warn(`Wild encounter ${hook.message.encounter_id} was sent again too soon, ignoring`)
 					break


### PR DESCRIPTION
## Description

Changed the logged info for pokemon webhook to the info contained in the message and not the message.

## Motivation and Context
This makes it so you can more easely debug pokemon webhook info.

## How Has This Been Tested?
Tested it with MAD pokemon webhook results on a vps with ubuntu LTS installed.
This should not affect other areas of the code since it is a log message.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.