### PR TITLE
V4

### DIFF
--- a/src/util/util.json
+++ b/src/util/util.json
@@ -142,7 +142,7 @@
 		"4": "{{amount}} {{type}} Candy",
 		"5": "Avatar clothing",
 		"6": "Quest",
-		"7": "{{#isShiny}} Possible Shiny {{/isShiny}}{{pokemon}} {{emoji}}"
+		"7": "{{pokemon}}"
 	},
 	"questMonsterTypeString": "{{name}} {{{emoji}}} ",
 	"questConditions": {

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -128,7 +128,11 @@
 		"27": "Complete {{amount}} Battles",
 		"28": "Take {{amount}} snapshots",
 		"29": "Defeat {{amount}} Team Rocket Grunt",
-		"30": "Purify {{amount}} Pokemon"
+		"30": "Purify {{amount}} Pokemon",
+		"31": "Find {{amount}} Team Rocket Invasion(s)",
+   		"32": "{{amount}} time(s) First Grunt OTD",
+		"33": "",
+    		"34": "Earn {{amount}} hearts with your buddy"
 	},
 	"questRewardTypes": {
 		"0": "",
@@ -166,8 +170,21 @@
 		"22": "Team leader",
 		"23": "Another player",
 		"24": "Location",
-		"25": "Distance"
+		"25": "Distance",
+		"26": "Pokemon Alignment(s): {{alignments}}",
+    		"27": "Invasion Category(s): {{categories}}"
 	},
+	
+	"alignments": {
+   		"1": "Shadow",
+    		"2": "Purified"
+ 	},
+	
+	"categories": {
+    		"1": "team leader",
+    		"2": "grunt"
+  	},
+	
 	"throwType": {
 		"10": "Nice",
 		"11": "Great",

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -181,8 +181,8 @@
  	},
 	
 	"categories": {
-    		"1": "team leader",
-    		"2": "grunt"
+    		"1": "Team Leader",
+    		"2": "Grunt"
   	},
 	
 	"throwType": {

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -142,7 +142,7 @@
 		"4": "{{amount}} {{type}} Candy",
 		"5": "Avatar clothing",
 		"6": "Quest",
-		"7": "{{#isShiny}}Shiny {{/isShiny}}{{pokemon}} {{emoji}}"
+		"7": "{{#isShiny}} Possible Shiny {{/isShiny}}{{pokemon}} {{emoji}}"
 	},
 	"questMonsterTypeString": "{{name}} {{{emoji}}} ",
 	"questConditions": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Quest rewards return **Shiny** status if the pokemon is *possible* shiny

## Description
<!--- Describe your changes in detail -->
changed `shiny` to `possible shiny` in reward string for quests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users are seeing the word **SHINY** in the reward string and think it is a guaranteed shiny when it is only a potential shiny.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.