### PR TITLE
Bounce the command controller on discordjs error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -68,7 +68,7 @@ fastify.decorate('discordQueue', [])
 fastify.decorate('telegramQueue', [])
 fastify.decorate('hookQueue', [])
 
-const discordCommando = config.discord.enabled ? DiscordCommando(knex, config, log, monsterData, utilData, dts, geofence, translator) : null
+const discordCommando = config.discord.enabled ? new DiscordCommando(knex, config, log, monsterData, utilData, dts, geofence, translator) : null
 log.info(`Discord commando ${discordCommando ? '' : ''}starting`)
 const discordWorkers = []
 let telegram

--- a/src/lib/discord/commando/index.js
+++ b/src/lib/discord/commando/index.js
@@ -27,7 +27,7 @@ class DiscordCommando {
 		try {
 			this.client.on('error', (err) => {
 				this.busy = true
-				log.error(`Discord worker #${this.id} \n bouncing`, err)
+				this.log.error(`Discord worker #${this.id} \n bouncing`, err)
 				this.bounceWorker()
 			})
 			// We also need to make sure we're attaching the config to the CLIENT so it's accessible everywhere!

--- a/src/lib/discord/commando/index.js
+++ b/src/lib/discord/commando/index.js
@@ -1,57 +1,85 @@
-module.exports = (knex, config, log, monsterData, utilData, dts, geofence, translator) => {
-	const Controller = require('../../../controllers/controller')
-	const query = new Controller(knex, config)
+const { Client } = require('discord.js')
+const Enmap = require('enmap')
+const fs = require('fs')
+const { S2 } = require('s2-geometry')
+const mustache = require('handlebars')
+const emojiStrip = require('emoji-strip')
+const hastebin = require('hastebin-gen')
+const Controller = require('../../../controllers/controller')
 
-	const re = require('../../../util/regex')(translator)
+class DiscordCommando {
+	constructor(knex, config, log, monsterData, utilData, dts, geofence, translator) {
+		this.config = config
+		this.query = new Controller(knex, config)
+		this.log = log
+		this.monsterData = monsterData
+		this.utilData = utilData
+		this.dts = dts
+		this.geofence = geofence
+		this.translator = translator
+		this.re = require('../../../util/regex')(translator)
+		this.bounceWorker()
+	}
+	
+	async bounceWorker() {
+		delete this.client
+		this.client = new Client()
+		try {
+			this.client.on('error', (err) => {
+				this.busy = true
+				log.error(`Discord worker #${this.id} \n bouncing`, err)
+				this.bounceWorker()
+			})
+			// We also need to make sure we're attaching the config to the CLIENT so it's accessible everywhere!
+			this.client.config = this.config
+			this.client.S2 = S2
+			this.client.query = this.query
+			this.client.emojiStrip = emojiStrip
+			this.client.log = this.log
+			this.client.dts = this.dts
+			this.client.re = this.re
+			this.client.geofence = this.geofence
+			this.client.monsters = this.monsterData
+			this.client.utilData = this.utilData
+			this.client.mustache = mustache
+			this.client.hastebin = hastebin
+			this.client.translator = this.translator
+			this.client.hookRegex = new RegExp('(?:(?:https?):\\/\\/|www\\.)(?:\\([-A-Z0-9+&@#\\/%=~_|$?!:,.]*\\)|[-A-Z0-9+&@#\\/%=~_|$?!:,.])*(?:\\([-A-Z0-9+&@#\\/%=~_|$?!:,.]*\\)|[A-Z0-9+&@#\\/%=~_|$])', 'igm')
 
-	const { Client } = require('discord.js')
-	const Enmap = require('enmap')
-	const fs = require('fs')
-	const { S2 } = require('s2-geometry')
-	const mustache = require('handlebars')
-	const emojiStrip = require('emoji-strip')
-	const hastebin = require('hastebin-gen')
+			fs.readdir(`${__dirname}/events/`, (err, files) => {
+				if (err) return this.log.error(err)
+				files.forEach((file) => {
+					const event = require(`${__dirname}/events/${file}`) // eslint-disable-line global-require
+					const eventName = file.split('.')[0]
+					this.client.on(eventName, event.bind(null, this.client))
+				})
+			})
 
-	const client = new Client()
-	// We also need to make sure we're attaching the config to the CLIENT so it's accessible everywhere!
-	client.config = config
-	client.S2 = S2
-	client.query = query
-	client.emojiStrip = emojiStrip
-	client.log = log
-	client.dts = dts
-	client.re = re
-	client.geofence = geofence
-	client.monsters = monsterData
-	client.utilData = utilData
-	client.mustache = mustache
-	client.hastebin = hastebin
-	client.translator = translator
-	client.hookRegex = new RegExp('(?:(?:https?):\\/\\/|www\\.)(?:\\([-A-Z0-9+&@#\\/%=~_|$?!:,.]*\\)|[-A-Z0-9+&@#\\/%=~_|$?!:,.])*(?:\\([-A-Z0-9+&@#\\/%=~_|$?!:,.]*\\)|[A-Z0-9+&@#\\/%=~_|$])', 'igm')
-
-	fs.readdir(`${__dirname}/events/`, (err, files) => {
-		if (err) return log.error(err)
-		files.forEach((file) => {
-			const event = require(`${__dirname}/events/${file}`) // eslint-disable-line global-require
-			const eventName = file.split('.')[0]
-			client.on(eventName, event.bind(null, client))
-		})
-	})
-
-	client.commands = new Enmap()
-	const enabledCommands = []
-	fs.readdir(`${__dirname}/commands/`, (err, files) => {
-		if (err) return log.error(err)
-		files.forEach((file) => {
-			if (!file.endsWith('.js')) return
-			const props = require(`${__dirname}/commands/${file}`) // eslint-disable-line global-require
-			const commandName = file.split('.')[0]
-			enabledCommands.push(`${config.discord.prefix}${commandName}`)
-			client.commands.set(commandName, props)
-		})
+			this.client.commands = new Enmap()
+			const enabledCommands = []
+			fs.readdir(`${__dirname}/commands/`, (err, files) => {
+				if (err) return this.log.error(err)
+				files.forEach((file) => {
+					if (!file.endsWith('.js')) return
+					const props = require(`${__dirname}/commands/${file}`) // eslint-disable-line global-require
+					const commandName = file.split('.')[0]
+					enabledCommands.push(`${this.config.discord.prefix}${commandName}`)
+					this.client.commands.set(commandName, props)
+				})
 
 
-		log.log({ level: 'debug', message: `Loading discord commands: (${enabledCommands.join(' ')})`, event: 'discord:commandsAdded' })
-	})
-	client.login(client.config.discord.token[0])
+				this.log.log({ level: 'debug', message: `Loading discord commands: (${enabledCommands.join(' ')})`, event: 'discord:commandsAdded' })
+			})
+			this.client.login(this.config.discord.token[0])
+		} catch (err) {
+			this.log.error(`Discord commando didn't bounce, \n ${err.message} \n trying again`)
+			this.sleep(2000)
+			return this.bounceWorker()
+		}
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	async sleep(n) { return new Promise((resolve) => setTimeout(resolve, n)) }
 }
+
+module.exports = DiscordCommando


### PR DESCRIPTION
## Description
When Discordjs emmits an error, we don't bounce the commando handler like we do for the workers.

## Motivation and Context
Fix unexpected crash if connection to Discord fails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.