### PR TITLE
support for custom nominatim and tileserver url + support for pregenerated staticmaps

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -98,7 +98,9 @@
 
     "geocoding": {
       "provider": "GEOCODING_PROVIDER",
+      "providerURL": "GEOCODING_PROVIDER_URL",
       "staticProvider": "STATIC_PROVIDER",
+      "staticProviderURL": "STATIC_PROVIDER_URL",
       "geocodingKey":{
         "__name": "GEOCODING_KEYS",
         "__format": "json"

--- a/config/default.json
+++ b/config/default.json
@@ -62,7 +62,9 @@
 
       "geocoding": {
         "provider": "poracle",
+        "providerURL": "Your Nominatim Server Address",
         "staticProvider": "poracle",
+        "staticProviderURL": "Your TileServerCache Server Address",
         "geocodingKey":["Your Google Geocoding Key if you Use google as provider"],
         "staticKey":["Your MapQuest or Google Key"],
         "width": 320,

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -10,7 +10,7 @@ const geoCache = pcache.load('.geoCache', path.resolve(`${__dirname}../../../`))
 const emojiFlags = require('emoji-flags')
 
 const { log } = require('../lib/logger')
-
+const TileserverPregen = require('../lib/tileserverPregen')
 
 class Controller {
 	constructor(db, config, dts, geofence, monsterData, discordCache, translator, mustache, weatherController) {
@@ -28,6 +28,7 @@ class Controller {
 		this.earthRadius = 6371 * 1000 // m
 		this.weatherController = weatherController
 		this.controllerData = {}
+		this.tileserverPregen = new TileserverPregen()
 	}
 
 	getGeocoder() {
@@ -36,6 +37,13 @@ class Controller {
 				return NodeGeocoder({
 					provider: 'openstreetmap',
 					osmServer: 'https://geocoding.poracle.world/nominatim/',
+					formatterPattern: this.config.locale.addressformat,
+				})
+			}
+			case 'nominatim': {
+				return NodeGeocoder({
+					provider: 'openstreetmap',
+					osmServer: this.config.geocoding.providerURL,
 					formatterPattern: this.config.locale.addressformat,
 				})
 			}

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -70,6 +70,7 @@ class Monster extends Controller {
 
 
 	async handle(obj) {
+		let pregenerateTile = false
 		const data = obj
 		try {
 			moment.locale(this.config.locale.timeformat)
@@ -78,6 +79,10 @@ class Monster extends Controller {
 			switch (this.config.geocoding.staticProvider.toLowerCase()) {
 				case 'poracle': {
 					data.staticmap = `https://tiles.poracle.world/static/${this.config.geocoding.type}/${+data.latitude.toFixed(5)}/${+data.longitude.toFixed(5)}/${this.config.geocoding.zoom}/${this.config.geocoding.width}/${this.config.geocoding.height}/${this.config.geocoding.scale}/png`
+					break
+				}
+				case 'tileservercache': {
+					pregenerateTile = true
 					break
 				}
 				case 'google': {
@@ -191,8 +196,11 @@ class Monster extends Controller {
 
 			if (discordCacheBad) return []
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
-
 			const jobs = []
+
+			if (pregenerateTile) {
+				data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('monster', data)
+			}
 
 			for (const cares of whoCares) {
 				const caresCache = this.getDiscordCache(cares.id).count
@@ -250,13 +258,13 @@ class Monster extends Controller {
 				const mustache = this.mustache.compile(this.translator.translate(template))
 				const message = JSON.parse(mustache(view))
 
-                                if (cares.ping) {
-                                        if (!message.content) {
-                                                message.content = cares.ping;
-                                        } else {
-                                                message.content += cares.ping;
-                                        }
-                                }
+				if (cares.ping) {
+					if (!message.content) {
+						message.content = cares.ping
+					} else {
+						message.content += cares.ping
+					}
+				}
 
 				const work = {
 					lat: data.latitude.toString().substring(0, 8),

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -53,6 +53,7 @@ class Quest extends Controller {
 	}
 
 	async handle(obj) {
+		let pregenerateTile = false
 		const data = obj
 		const minTth = this.config.general.alertMinimumTime || 0
 
@@ -60,6 +61,10 @@ class Quest extends Controller {
 			switch (this.config.geocoding.staticProvider.toLowerCase()) {
 				case 'poracle': {
 					data.staticmap = `https://tiles.poracle.world/static/${this.config.geocoding.type}/${+data.latitude.toFixed(5)}/${+data.longitude.toFixed(5)}/${this.config.geocoding.zoom}/${this.config.geocoding.width}/${this.config.geocoding.height}/${this.config.geocoding.scale}/png`
+					break
+				}
+				case 'tileservercache': {
+					pregenerateTile = true
 					break
 				}
 				case 'google': {
@@ -144,8 +149,11 @@ class Quest extends Controller {
 			if (discordCacheBad) return []
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
-
 			const jobs = []
+
+			if (pregenerateTile) {
+				data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('quest', data)
+			}
 
 			for (const cares of whoCares) {
 				const caresCache = this.getDiscordCache(cares.id).count
@@ -172,13 +180,13 @@ class Quest extends Controller {
 				const mustache = this.mustache.compile(this.translator.translate(template))
 				const message = JSON.parse(mustache(view))
 
-                                if (cares.ping) {
-                                        if (!message.content) {
-                                                message.content = cares.ping;
-                                        } else {
-                                                message.content += cares.ping;
-                                        }
-                                }
+				if (cares.ping) {
+					if (!message.content) {
+						message.content = cares.ping
+					} else {
+						message.content += cares.ping
+					}
+				}
 
 				const work = {
 					lat: data.latitude.toString().substring(0, 8),

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -305,7 +305,7 @@ class Raid extends Controller {
 			const jobs = []
 
 			if (pregenerateTile) {
-				data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('quest', data)
+				data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('raid', data)
 			}
 
 			for (const cares of whoCares) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -202,7 +202,7 @@ class Raid extends Controller {
 				const jobs = []
 
 				if (pregenerateTile) {
-					data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('monster', data)
+					data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('raid', data)
 				}
 
 				for (const cares of whoCares) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -102,6 +102,7 @@ class Raid extends Controller {
 	}
 
 	async handle(obj) {
+		let pregenerateTile = false
 		const data = obj
 		const minTth = this.config.general.alertMinimumTime || 0
 
@@ -109,6 +110,10 @@ class Raid extends Controller {
 			switch (this.config.geocoding.staticProvider.toLowerCase()) {
 				case 'poracle': {
 					data.staticmap = `https://tiles.poracle.world/static/${this.config.geocoding.type}/${+data.latitude.toFixed(5)}/${+data.longitude.toFixed(5)}/${this.config.geocoding.zoom}/${this.config.geocoding.width}/${this.config.geocoding.height}/${this.config.geocoding.scale}/png`
+					break
+				}
+				case 'tileservercache': {
+					pregenerateTile = true
 					break
 				}
 				case 'google': {
@@ -194,8 +199,11 @@ class Raid extends Controller {
 
 				if (discordCacheBad) return []
 				const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
-
 				const jobs = []
+
+				if (pregenerateTile) {
+					data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('monster', data)
+				}
 
 				for (const cares of whoCares) {
 					const caresCache = this.getDiscordCache(cares.id).count
@@ -224,13 +232,13 @@ class Raid extends Controller {
 					const template = JSON.stringify(raidDts.template)
 					const mustache = this.mustache.compile(template)
 					const message = JSON.parse(mustache(view))
-                                	if (cares.ping) {
-                                        	if (!message.content) {
-                                                	message.content = cares.ping;
-                                        	} else {
-                                               		message.content += cares.ping;
-                                        	}
-                                	}
+					if (cares.ping) {
+						if (!message.content) {
+							message.content = cares.ping
+						} else {
+							message.content += cares.ping
+						}
+					}
 					const work = {
 						lat: data.latitude.toString().substring(0, 8),
 						lon: data.longitude.toString().substring(0, 8),
@@ -294,8 +302,11 @@ class Raid extends Controller {
 
 			if (discordCacheBad) return []
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
-
 			const jobs = []
+
+			if (pregenerateTile) {
+				data.staticmap = await this.tileserverPregen.getPregeneratedTileURL('quest', data)
+			}
 
 			for (const cares of whoCares) {
 				const caresCache = this.getDiscordCache(cares.id).count
@@ -324,13 +335,13 @@ class Raid extends Controller {
 				const mustache = this.mustache.compile(template)
 				const message = JSON.parse(mustache(view))
 
-                                if (cares.ping) {
-                                        if (!message.content) {
-                                                message.content = cares.ping;
-                                        } else {
-                                                message.content += cares.ping;
-                                        }
-                                }
+				if (cares.ping) {
+					if (!message.content) {
+						message.content = cares.ping
+					} else {
+						message.content += cares.ping
+					}
+				}
 
 				const work = {
 					lat: data.latitude.toString().substring(0, 8),

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -1,0 +1,31 @@
+const axios = require('axios')
+const config = require('config')
+const { log } = require('./logger.js')
+
+class TileserverPregen {
+	constructor() {
+		this.axios = axios
+		this.log = log
+		this.config = config
+	}
+
+	async getPregeneratedTileURL(type, data) {
+		const url = `${this.config.geocoding.staticProviderURL}/staticmap/poracle-${type}?pregenerate=true&regeneratable=true`
+		try {
+			const result = await axios.post(url, data)
+			if (result.status !== 200) {
+				this.log.warn(`Failed to Pregenerate StaticMap. Got ${result.status}.`)
+				return null
+			} if (typeof result.data !== 'string') {
+				this.log.warn('Failed to Pregenerate StaticMap. No id returned.')
+				return null
+			}
+			return `${this.config.geocoding.staticProviderURL}/staticmap/pregenerated/${result.data}`
+		} catch (error) {
+			this.log.warn(`Failed to Pregenerate StaticMap. Error: ${error}`)
+			return null
+		}
+	}
+}
+
+module.exports = TileserverPregen

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -14,7 +14,7 @@ class TileserverPregen {
 		try {
 			const result = await axios.post(url, data)
 			if (result.status !== 200) {
-				this.log.warn(`Failed to Pregenerate StaticMap. Got ${result.status}.`)
+				this.log.warn(`Failed to Pregenerate StaticMap. Got ${result.status}. Error: ${result.data ? result.data.reason : '?'}.`)
 				return null
 			} if (typeof result.data !== 'string') {
 				this.log.warn('Failed to Pregenerate StaticMap. No id returned.')

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -22,7 +22,11 @@ class TileserverPregen {
 			}
 			return `${this.config.geocoding.staticProviderURL}/staticmap/pregenerated/${result.data}`
 		} catch (error) {
-			this.log.warn(`Failed to Pregenerate StaticMap. Error: ${error}`)
+			if (error.response) {
+				this.log.warn(`Failed to Pregenerate StaticMap. Got ${error.response.status}. Error: ${error.response.data ? error.response.data.reason : '?'}.`)
+			} else {
+				this.log.warn(`Failed to Pregenerate StaticMap. Error: ${error}.`)
+			}
 			return null
 		}
 	}

--- a/tileservercache_templates/poracle-monster.json
+++ b/tileservercache_templates/poracle-monster.json
@@ -1,0 +1,19 @@
+{
+    "style": "klokantech-basic",
+    "latitude": #(latitude),
+    "longitude": #(longitude),
+    "zoom": 15,
+    "width": 500,
+    "height": 250,
+    "scale": 1,
+    "markers": [
+        {
+            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
+            "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
+            "latitude": #(latitude),
+            "longitude": #(longitude),
+            "width": 50,
+            "height": 50
+        }
+    ]
+}

--- a/tileservercache_templates/poracle-pokestop.json
+++ b/tileservercache_templates/poracle-pokestop.json
@@ -1,0 +1,18 @@
+{
+    "style": "klokantech-basic",
+    "latitude": #(latitude),
+    "longitude": #(longitude),
+    "zoom": 15,
+    "width": 500,
+    "height": 250,
+    "scale": 1,
+    "markers": [
+        {
+            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/misc/pokestop.png",
+            "latitude": #(latitude),
+            "longitude": #(longitude),
+            "width": 50,
+            "height": 50
+        }
+    ]
+}

--- a/tileservercache_templates/poracle-quest.json
+++ b/tileservercache_templates/poracle-quest.json
@@ -1,0 +1,18 @@
+{
+    "style": "klokantech-basic",
+    "latitude": #(latitude),
+    "longitude": #(longitude),
+    "zoom": 15,
+    "width": 500,
+    "height": 250,
+    "scale": 1,
+    "markers": [
+        {
+            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/misc/pokestop.png",
+            "latitude": #(latitude),
+            "longitude": #(longitude),
+            "width": 50,
+            "height": 50
+        }
+    ]
+}

--- a/tileservercache_templates/poracle-raid.json
+++ b/tileservercache_templates/poracle-raid.json
@@ -8,13 +8,13 @@
     "scale": 1,
     "markers": [
         {
-			#if(pokemon_id != nil && pokemon_id != 0):
+            #if(pokemon_id != nil && pokemon_id != 0):
             "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
             "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
             #else:
-		    "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/egg#(level).png",	
-			#endif
-			"latitude": #(latitude),
+            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/egg#(level).png",	
+            #endif
+            "latitude": #(latitude),
             "longitude": #(longitude),
             "width": 50,
             "height": 50

--- a/tileservercache_templates/poracle-raid.json
+++ b/tileservercache_templates/poracle-raid.json
@@ -1,0 +1,23 @@
+{
+    "style": "klokantech-basic",
+    "latitude": #(latitude),
+    "longitude": #(longitude),
+    "zoom": 15,
+    "width": 500,
+    "height": 250,
+    "scale": 1,
+    "markers": [
+        {
+			#if(pokemon_id != nil && pokemon_id != 0):
+            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
+            "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
+            #else:
+		    "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/egg#(level).png",	
+			#endif
+			"latitude": #(latitude),
+            "longitude": #(longitude),
+            "width": 50,
+            "height": 50
+        }
+    ]
+}


### PR DESCRIPTION
## Description
- adds support for custom nominatim and tileserver url
  - `provider` = `nominatim` + `providerURL`
  - `staticProviderURL` = `tileservercache` + `staticProviderURL `
- adds support for pregenerated staticmaps

## How Has This Been Tested?
Only minor testing. Needs more testing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.