### PR TITLE
support for custom nominatim server for v3

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -52,6 +52,7 @@
 
   "geocoding": {
     "provider": "GEO_PROVIDER",
+    "providerURL": "GEO_PROVIDER_URL",
     "staticProvider": "STATIC_PROVIDER",
     "osmServer": "OSM_SERVER",
     "geocodingKey":{

--- a/config/default.json
+++ b/config/default.json
@@ -30,6 +30,7 @@
 
   "geocoding": {
     "provider": "poracle",
+    "providerURL": "Your Nominatim Server Address",
     "staticProvider": "poracle",
     "osmServer":"http://nominatim.openstreetmap.org",
     "geocodingKey":["Your Google Geocoding Key if you Use google as provider"],

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -55,6 +55,13 @@ class Controller {
 
 	getGeocoder() {
 		switch (config.geocoding.provider.toLowerCase()) {
+                        case 'nominatim': {
+                                return NodeGeocoder({
+                                        provider: 'openstreetmap',
+                                        osmServer: config.geocoding.providerURL,
+                                        formatterPattern: config.locale.addressformat,
+                                })
+                        }
 			case 'poracle': {
 				return NodeGeocoder({
 					provider: 'openstreetmap',


### PR DESCRIPTION
## Description

- Adds support for custom nominatim server to v3 branch
   - `provider` = `nominatim` + `providerUrl`

## Instructions for Poracle setups using Poracle in docker:
 
1. In order to use .env to set options be sure to copy updated `custom-environment-variables.json` & `default.json` to config folder (subfolder where yml is stored),

2. Edit .env as follows:
```
GEO_PROVIDER=nominatim
GEO_PROVIDER_URL=<your nominatim server url>
```
## Motivation and Context
Provide method to use custom nominatim with v3 without needing code changes

## How Has This Been Tested?
Minor testing w/Poracle docker deployment (using .env override for settings). Needs more testing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.