### PR TITLE
updated v3 questdts.json.example with new entries from v4

### DIFF
--- a/config/examples/questdts.json.example
+++ b/config/examples/questdts.json.example
@@ -32,6 +32,7 @@
     "30": "Purify {{amount}} Pokemon",
     "31": "Find {{amount}} Team Rocket Invasion(s)",
     "32": "{{amount}} time(s) First Grunt OTD",
+    "33": "",
     "34": "Earn {{amount}} hearts with your buddy"
   },
   "questRewardTypes": {
@@ -88,11 +89,12 @@
   },
 
   "categories": {
-    "1": "team leader",
-    "2": "grunt"
+    "1": "Team Leader",
+    "2": "Grunt"
   },
 
   "rewardItems": {
+    "0": "Unkown",
     "1": "Poke Ball",
     "2": "Great Ball",
     "3": "Ultra Ball",
@@ -109,6 +111,7 @@
     "402": "Incense Spicy",
     "403": "Incense Cool",
     "404": "Incense Floral",
+    "405": "Incense beluga box",
     "501": "Troy Disk",
     "502": "Troy Glacial Disk",
     "503": "Troy Mossy Disk",
@@ -124,6 +127,7 @@
     "706": "Golden Razz Berry",
     "707": "Golden Nanab Berry",
     "708": "Silver Pinap Berry",
+    "709": "Poffin",
     "801": "Special Camera",
     "901": "Incubator Basic Unlimited",
     "902": "Incubator Basic",
@@ -144,6 +148,11 @@
     "1402": "Paid Raid Ticket",
     "1403": "Legendary Raid Ticket",
     "1404": "Star Piece",
-    "1405": "Friend Gift Box"
+    "1405": "Friend Gift Box",
+    "1406": "Team change",
+    "1501": "Leader map fragment",
+    "1502": "Leader map",
+    "1503": "Giovanni map",
+    "1600": "Global event ticket"
   }
 }


### PR DESCRIPTION
## Description
update questdts.json.example in v3 branch.  copy this file to your questdts.json in your config folder if running v3 to eliminate following error when quest protos are sent to Poracle: 

`error: pointsInArea errored with: Invalid template! Template should be a "string" but "undefined" was given as the first argument for mustache#render(template, view, partials) {"event":"fail:questpointsInArea"} `

In v4 can be found here: https://github.com/KartulUdus/PoracleJS/blob/v4/src/util/util.json#L101-#L175

## Motivation and Context
enable v3 to process new quest types.

## How Has This Been Tested?
Tested on my vps. Errors reported before have gone away. Needs more testing, but simple edit.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.