### PR TITLE
Fix adding Raid/Egg Level 6 with value everything V4

### DIFF
--- a/src/lib/discord/commando/commands/egg.js
+++ b/src/lib/discord/commando/commands/egg.js
@@ -51,7 +51,7 @@ exports.run = async (client, msg, command) => {
 				else if (element === 'valor') team = 2
 				else if (element === 'mystic') team = 1
 				else if (element === 'harmony') team = 0
-				else if (element === 'everything') levels = [1, 2, 3, 4, 5]
+				else if (element === 'everything') levels = [1, 2, 3, 4, 5, 6]
 				else if (element === 'clean') clean = true
 			})
 

--- a/src/lib/discord/commando/commands/raid.js
+++ b/src/lib/discord/commando/commands/raid.js
@@ -71,7 +71,7 @@ exports.run = async (client, msg, command) => {
 				else if (element === 'valor') team = 2
 				else if (element === 'mystic') team = 1
 				else if (element === 'harmony') team = 0
-				else if (element === 'everything') levels = [1, 2, 3, 4, 5]
+				else if (element === 'everything') levels = [1, 2, 3, 4, 5, 6]
 				else if (element === 'clean') clean = true
 			})
 			if (!levels.length && !monsters.length) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With this little change you could tracking raid/egg level6 with commands !raid/egg everything

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.