### PR TITLE
Change !poracle to always message user

### DIFF
--- a/src/lib/discord/commando/commands/poracle.js
+++ b/src/lib/discord/commando/commands/poracle.js
@@ -12,8 +12,8 @@ exports.run = async (client, msg) => {
 			await client.query.insertQuery('humans', {
 				id: msg.author.id, type: 'discord:user', name: client.emojiStrip(msg.author.username), area: '[]',
 			})
+			await msg.react('✅')
 		}
-		await msg.react('✅')
 		const greetingDts = client.dts.find((template) => template.type === 'greeting')
 		const view = { prefix: client.config.discord.prefix }
 		const greeting = client.mustache.compile(JSON.stringify(greetingDts.template))

--- a/src/lib/discord/commando/commands/poracle.js
+++ b/src/lib/discord/commando/commands/poracle.js
@@ -5,11 +5,14 @@ exports.run = async (client, msg) => {
 	}
 	try {
 		const isRegistered = await client.query.countQuery('humans', { id: msg.author.id })
-		if (isRegistered) return await msg.react('👌')
+		if (isRegistered) {
 
-		await client.query.insertQuery('humans', {
-			id: msg.author.id, type: 'discord:user', name: client.emojiStrip(msg.author.username), area: '[]',
-		})
+			await msg.react('👌')
+		} else {
+			await client.query.insertQuery('humans', {
+				id: msg.author.id, type: 'discord:user', name: client.emojiStrip(msg.author.username), area: '[]',
+			})
+		}
 		await msg.react('✅')
 		const greetingDts = client.dts.find((template) => template.type === 'greeting')
 		const view = { prefix: client.config.discord.prefix }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a user is already registered, !poracle in the wakeup channel just cases a shrug response. This confuses users who may have closed the Poracle DM.  This change simply re-sends them the initial welcome message.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.