### PR TITLE
Special case tracking pokemon 'everything' instead of having individual entries for each mon

### DIFF
--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -16,7 +16,7 @@ class Monster extends Controller {
 		select humans.id, humans.name, humans.type, humans.latitude, humans.longitude, monsters.template, monsters.distance, monsters.clean, monsters.ping from monsters
 		join humans on humans.id = monsters.id
 		where humans.enabled = true and
-		pokemon_id=${data.pokemon_id} and
+		(pokemon_id=${data.pokemon_id} or pokemon_id=0) and
 		min_iv<=${data.iv} and
 		max_iv>=${data.iv} and
 		min_cp<=${data.cp} and

--- a/src/lib/discord/commando/commands/track.js
+++ b/src/lib/discord/commando/commands/track.js
@@ -59,12 +59,20 @@ exports.run = async (client, msg, command) => {
 			const formNames = formArgs ? formArgs.map((arg) => client.translator.reverse(arg.replace(client.translator.translate('form'), ''))) : []
 			const argTypes = args.filter((arg) => typeArray.includes(arg))
 			const genCommand = args.filter((arg) => arg.match(client.re.genRe))
-			const gen = genCommand.length ? client.utilData.genData[+genCommand[0].replace(client.translator.translate('gen'), '')] : 0
+			const gen = genCommand.length ? client.utilData.genData[+(genCommand[0].replace(client.translator.translate('gen'), ''))] : 0
 
 			if (formNames.length) {
 				monsters = Object.values(client.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString())) && formNames.includes(mon.form.name.toLowerCase())
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) && formNames.includes(mon.form.name.toLowerCase())
 				|| args.includes(client.translator.translate('everything'))) && formNames.includes(mon.form.name.toLowerCase()))
+
+				if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
+			} else if (gen) {
+				monsters = Object.values(client.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString())) && !mon.form.id
+				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) && !mon.form.id
+				|| args.includes(client.translator.translate('everything'))) && !mon.form.id)
+
+				monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 			} else {
 				monsters = Object.values(client.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString())) && !mon.form.id
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) && !mon.form.id
@@ -78,7 +86,6 @@ exports.run = async (client, msg, command) => {
 					});
 				}
 			}
-			if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 			// Parse command elements to stuff
 			args.forEach((element) => {
 				if (element.match(client.re.maxlevelRe)) maxlevel = element.match(client.re.maxlevelRe)[0].replace(client.translator.translate('maxlevel'), '')

--- a/src/lib/discord/commando/commands/track.js
+++ b/src/lib/discord/commando/commands/track.js
@@ -68,7 +68,15 @@ exports.run = async (client, msg, command) => {
 			} else {
 				monsters = Object.values(client.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString())) && !mon.form.id
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) && !mon.form.id
-				|| args.includes(client.translator.translate('everything'))) && !mon.form.id)
+				) && !mon.form.id)
+				if (args.includes(client.translator.translate('everything'))) {
+					monsters.push({
+						"id": 0,
+						"form": {
+							"id": 0
+						}
+					});
+				}
 			}
 			if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 			// Parse command elements to stuff

--- a/src/lib/discord/commando/commands/tracked.js
+++ b/src/lib/discord/commando/commands/tracked.js
@@ -51,11 +51,19 @@ exports.run = async (client, msg, [args]) => {
 		} else message = message.concat(client.translator.translate('\n\nYou\'re not tracking any monsters'))
 
 		monsters.forEach((monster) => {
-			const mon = Object.values(client.monsters).find((m) => m.id === monster.pokemon_id && m.form.id === monster.form)
-			const monsterName = mon.name
+			let monsterName
+			let formName
+
+			if (monster.pokemon_id == 0) {
+				monsterName='everything'
+				formName = 'none'
+			} else {
+				const mon = Object.values(client.monsters).find((m) => m.id === monster.pokemon_id && m.form.id === monster.form)
+				monsterName = mon.name
+				formName = mon.form.name
+				if (formName === undefined) formName = 'none'
+			}
 			let miniv = monster.min_iv
-			let formName = mon.form.name
-			if (formName === undefined) formName = 'none'
 			if (miniv === -1) miniv = 0
 			message = message.concat(`\n**${monsterName}** form: ${formName} ${monster.distance ? `, distance: ${monster.distance}m` : ''} iv: ${miniv}%-${monster.max_iv}% cp: ${monster.min_cp}-${monster.max_cp} level: ${monster.min_level}-${monster.max_level} stats: ${monster.atk}/${monster.def}/${monster.sta} - ${monster.max_atk}/${monster.max_def}/${monster.max_sta}, gender:${client.utilData.genders[monster.gender].emoji}`)
 		})

--- a/src/lib/discord/commando/commands/untrack.js
+++ b/src/lib/discord/commando/commands/untrack.js
@@ -39,7 +39,10 @@ exports.run = async (client, msg, command) => {
 		|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) || args.includes(client.translator.translate('everything')))
 		&& !mon.form.id)
 
-		const monsterIds = monsters.map((mon) => mon.id)
+		let monsterIds = monsters.map((mon) => mon.id)
+		if (args.includes(client.translator.translate('everything'))) {
+			monsterIds.push(0)
+		}
 		const result = await client.query.deleteWhereInQuery('monsters', target.id, monsterIds, 'pokemon_id')
 		client.log.info(`${target.name} removed tracking for monsters: ${monsters.map((m) => m.name).join(', ')}`)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The existing implementation for !track everything adds a database entry for every single pokemon. This is inefficient and results in a massive !tracked report. This change allows a '0' to be entered under the pokemon id representing all pokemon.
It does not require a database change as the old format still works. If a user does !untrack everything it will still remove the old entries so the database will gradually move to the new format

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, would appreciate feedback

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.