### PR TITLE
Add track individually to new everything functionality

### DIFF
--- a/src/lib/discord/commando/commands/track.js
+++ b/src/lib/discord/commando/commands/track.js
@@ -67,12 +67,12 @@ exports.run = async (client, msg, command) => {
 				|| args.includes(client.translator.translate('everything'))) && formNames.includes(mon.form.name.toLowerCase()))
 
 				if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
-			} else if (gen) {
+			} else if (gen || args.includes(client.translator.translate('individually'))) {
 				monsters = Object.values(client.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString())) && !mon.form.id
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) && !mon.form.id
 				|| args.includes(client.translator.translate('everything'))) && !mon.form.id)
 
-				monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
+				if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 			} else {
 				monsters = Object.values(client.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString())) && !mon.form.id
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) && !mon.form.id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The track everything functionality helps for the general use case, but some users have a workflow that looks like this:

!track everything d200
!untrack spearow

This doesn't result in the previous behaviour.  In cases like this where you want the individual pokemon tracking entries to be created this change allows

!track everthing d200 individually
!untrack spearow

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.