### PR TITLE
fix track error gesturing_no

### DIFF
--- a/src/lib/discord/commando/commands/track.js
+++ b/src/lib/discord/commando/commands/track.js
@@ -142,11 +142,11 @@ exports.run = async (client, msg, command) => {
 			if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance) distance = client.config.tracking.maxDistance
 
 			if (distance > 0 && !userHasLocation && !target.webhook) {
-				await msg.react(client.translator.translate(':person_gesturing_no:'))
+				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, a distance was set in command but no location is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
 			if (distance === 0 && !userHasArea && !target.webhook) {
-				await msg.react(client.translator.translate(':person_gesturing_no:'))
+				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, no distance was set in command and no area is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
 			const insert = monsters.map((mon) => ({


### PR DESCRIPTION
Fix error 
```
Track command unhappy: Unknown Emoji {"name":"DiscordAPIError","method":"put","path":"/channels/****/messages/*****/reactions/person_gesturing_no/@me","code":10014,"httpStatus":400,"stack":"DiscordAPIError: Unknown Emoji\n    at RequestHandler.execute (/home/mad/Poracle/node_modules/discord.js/src/rest/RequestHandler.js:154:13)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)\n    at async RequestHandler.push (/home/mad/Poracle/node_modules/discord.js/src/rest/RequestHandler.js:39:14)\n    at async Object.exports.run (/home/mad/Poracle/src/lib/discord/commando/commands/track.js:149:5)"}
```