### PR TITLE
Add option to force use of location or area in tracking

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -55,6 +55,7 @@
     "tracking": {
         "disableEverythingTracking": false,
         "forceEverythingSeparately": false,
+        "forceLocationOrArea": false,
         "defaultDistance": 0,
         "maxDistance": 0
     },

--- a/src/lib/discord/commando/commands/egg.js
+++ b/src/lib/discord/commando/commands/egg.js
@@ -66,7 +66,7 @@ exports.run = async (client, msg, command) => {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, a distance was set in command but no location is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
-			if (distance === 0 && !userHasArea && !target.webhook) {
+			if (distance === 0 && !userHasArea && !target.webhook && client.config.tracking.forceLocationOrArea) {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, no distance was set in command and no area is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}

--- a/src/lib/discord/commando/commands/invasion.js
+++ b/src/lib/discord/commando/commands/invasion.js
@@ -61,7 +61,7 @@ exports.run = async (client, msg, command) => {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, a distance was set in command but no location is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
-			if (distance === 0 && !userHasArea && !target.webhook) {
+			if (distance === 0 && !userHasArea && !target.webhook && client.config.tracking.forceLocationOrArea) {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, no distance was set in command and no area is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}

--- a/src/lib/discord/commando/commands/quest.js
+++ b/src/lib/discord/commando/commands/quest.js
@@ -93,7 +93,7 @@ exports.run = async (client, msg, command) => {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, a distance was set in command but no location is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
-			if (distance === 0 && !userHasArea && !target.webhook) {
+			if (distance === 0 && !userHasArea && !target.webhook && client.config.tracking.forceLocationOrArea) {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, no distance was set in command and no area is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}

--- a/src/lib/discord/commando/commands/raid.js
+++ b/src/lib/discord/commando/commands/raid.js
@@ -86,7 +86,7 @@ exports.run = async (client, msg, command) => {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, a distance was set in command but no location is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
-			if (distance === 0 && !userHasArea && !target.webhook) {
+			if (distance === 0 && !userHasArea && !target.webhook && client.config.tracking.forceLocationOrArea) {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, no distance was set in command and no area is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}

--- a/src/lib/discord/commando/commands/track.js
+++ b/src/lib/discord/commando/commands/track.js
@@ -140,12 +140,11 @@ exports.run = async (client, msg, command) => {
 			if (ultraLeagueCP >= pvpFilterUltraMinCP && ultraLeague === 4096) ultraLeague = pvpFilterMaxRank
 			if (client.config.tracking.defaultDistance !== 0 && distance === 0) distance = client.config.tracking.defaultDistance
 			if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance) distance = client.config.tracking.maxDistance
-
 			if (distance > 0 && !userHasLocation && !target.webhook) {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, a distance was set in command but no location is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}
-			if (distance === 0 && !userHasArea && !target.webhook) {
+			if (distance === 0 && !userHasArea && !target.webhook && client.config.tracking.forceLocationOrArea) {
 				await msg.react(client.translator.translate('🙅'))
 				return await msg.reply(`${client.translator.translate('Oops, no distance was set in command and no area is defined for your tracking - check the')} \`${client.config.discord.prefix}${client.translator.translate('help')}\``)
 			}


### PR DESCRIPTION
Add `config > tracking > forceLocationOrArea` to force users having to set a location or area(s) for their tracking commands (default `false`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)