### PR TITLE
fix handlebar for form name

### DIFF
--- a/config/locale/fr.json
+++ b/config/locale/fr.json
@@ -165,7 +165,7 @@
 	"Steel":"Acier",
 	"Water":"Eau",
 	"Autumn":"Automne",
-	"Blue Striped":"Motif bleu",
+	"Blue striped":"Motif bleu",
 	"East Sea":"Mer Orient",
 	"Fall 2019":"Automne 2019",
 	"Galarian":"Galar",

--- a/src/lib/handlebars.js
+++ b/src/lib/handlebars.js
@@ -53,14 +53,14 @@ module.exports = () => {
 
 	handlebars.registerHelper('pokemonForm', (value) => {
 		if (!+value) return ''
-		const monster = Object.values(monsters).find((m) => m.id === +value)
+		const monster = Object.values(monsters).find((m) => m.form.id === +value)
 		if (!monster) return ''
 		return translator.translate(monster.form.name)
 	})
 
 	handlebars.registerHelper('pokemonFormAlt', (value) => {
 		if (!+value) return ''
-		const monster = Object.values(monsters).find((m) => m.id === +value)
+		const monster = Object.values(monsters).find((m) => m.form.id === +value)
 		if (!monster) return ''
 		return translatorAlt.translate(monster.form.name)
 	})


### PR DESCRIPTION
Fix missing `.form` in Handlebar definition for getting form name from `form id`