### PR TITLE
Add mega raids to !raid everything

### DIFF
--- a/src/lib/discord/commando/commands/raid.js
+++ b/src/lib/discord/commando/commands/raid.js
@@ -77,7 +77,7 @@ exports.run = async (client, msg, command) => {
 				else if (element === 'valor') team = 2
 				else if (element === 'mystic') team = 1
 				else if (element === 'harmony') team = 0
-				else if (element === 'everything') levels = [1, 2, 3, 4, 5]
+				else if (element === 'everything') levels = [1, 2, 3, 4, 5, 6]
 				else if (element === 'clean') clean = true
 			})
 			if (client.config.tracking.defaultDistance !== 0 && distance === 0) distance = client.config.tracking.defaultDistance


### PR DESCRIPTION
Add level 6 to track mega raids in the everything group

## Description
Added all levels of raids in the combinatory everything group. Now mega raids will be tracked as well for users enabling !raid everything.


## How Has This Been Tested?
For testing I run this patch on my local version of Poracle. The everything group now includes level 6 raids to include megas.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.