### PR TITLE
Remove/fix some form names.

### DIFF
--- a/src/util/monsters.json
+++ b/src/util/monsters.json
@@ -65370,7 +65370,7 @@
 		]
 	},
 	"658_0": {
-		"name": "Greninja ash-greninja",
+		"name": "Greninja",
 		"id": 658,
 		"form": {
 			"id": 0,
@@ -65844,7 +65844,7 @@
 		]
 	},
 	"678_0": {
-		"name": "Meowstic female",
+		"name": "Meowstic",
 		"id": 678,
 		"form": {
 			"id": 0,
@@ -65919,7 +65919,7 @@
 		]
 	},
 	"681_0": {
-		"name": "Aegislash shield forme",
+		"name": "Aegislash",
 		"id": 681,
 		"form": {
 			"id": 0,
@@ -66642,7 +66642,7 @@
 		]
 	},
 	"710_0": {
-		"name": "Pumpkaboo super size",
+		"name": "Pumpkaboo",
 		"id": 710,
 		"form": {
 			"id": 0,
@@ -66669,7 +66669,7 @@
 		]
 	},
 	"711_0": {
-		"name": "Gourgeist super size",
+		"name": "Gourgeist",
 		"id": 711,
 		"form": {
 			"id": 0,
@@ -66840,7 +66840,7 @@
 		]
 	},
 	"718_0": {
-		"name": "Zygarde complete forme",
+		"name": "Zygarde",
 		"id": 718,
 		"form": {
 			"id": 0,
@@ -66894,7 +66894,7 @@
 		]
 	},
 	"720_0": {
-		"name": "Hoopa hoopa unbound",
+		"name": "Hoopa hoopa",
 		"id": 720,
 		"form": {
 			"id": 0,
@@ -67413,7 +67413,7 @@
 		]
 	},
 	"741_0": {
-		"name": "Oricorio sensu style",
+		"name": "Oricorio",
 		"id": 741,
 		"form": {
 			"id": 0,
@@ -67494,7 +67494,7 @@
 		]
 	},
 	"744_0": {
-		"name": "Rockruff own tempo rockruff",
+		"name": "Rockruff",
 		"id": 744,
 		"form": {
 			"id": 0,
@@ -67515,7 +67515,7 @@
 		]
 	},
 	"745_0": {
-		"name": "Lycanroc dusk form",
+		"name": "Lycanroc",
 		"id": 745,
 		"form": {
 			"id": 0,
@@ -67536,7 +67536,7 @@
 		]
 	},
 	"746_0": {
-		"name": "Wishiwashi school form",
+		"name": "Wishiwashi",
 		"id": 746,
 		"form": {
 			"id": 0,
@@ -68214,7 +68214,7 @@
 		]
 	},
 	"774_0": {
-		"name": "Minior core form",
+		"name": "Minior",
 		"id": 774,
 		"form": {
 			"id": 0,
@@ -68886,7 +68886,7 @@
 		]
 	},
 	"800_0": {
-		"name": "Necrozma ultra necrozma",
+		"name": "Necrozma",
 		"id": 800,
 		"form": {
 			"id": 0,


### PR DESCRIPTION
Tracking pokemon with form id 0 defaults to all of them. 
We don't need to define a random form name within the inital name column.
This makes it so users cant track easily track released pokemon, as well as unreleased pokemon.

Greninja ash-greninja ->Greninja
Meowstic female ->Meowstic
Aegislash shield forme ->Aegislash
Pumpkaboo super size ->Pumpkaboo
Gourgeist super size ->Gourgeist
Zygarde complete forme ->Zygarde
Hoopa hoopa unbound ->Hoopa hoopa
Oricorio sensu style ->Oricorio
Rockruff own tempo rockruff ->Rockruff
Lycanroc dusk form ->Lycanroc 
Wishiwashi school form ->Wishiwashi 
Minior core form ->Minior
Necrozma ultra necrozma ->Necrozma