### PR TITLE
log all DMs to logchannel

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -76,7 +76,9 @@
             "#0070DD",
             "#A335EE",
             "#FF8000"
-        ]
+        ],
+        "dmLogChannelID": "",
+        "dmLogChannelDeletionTime": 0
       },
       "telegram": {
         "enabled": false,

--- a/src/lib/discord/commando/events/message.js
+++ b/src/lib/discord/commando/events/message.js
@@ -12,11 +12,11 @@ module.exports = async (client, msg) => {
 		const message = '<@'+msg.author+'> > ' + msg.cleanContent
 		try {
 			const channel = await client.channels.fetch(client.config.discord.dmLogChannelID)
-			const msgDeletionMs = (client.config.discord.dmLogChannelDeletionTime * 60) * 1000 || 0
+			const msgDeletionMs = (client.config.discord.dmLogChannelDeletionTime ) * 1000 || 0
 			if (!channel) return log.warn(`channel dmLogChannel not found`)
-			const msg = await channel.send(message)
+			const logmsg = await channel.send(message)
 			if (msgDeletionMs > 0) {
-				msg.delete({ timeout: msgDeletionMs, reason: 'Removing old stuff.' })
+				logmsg.delete({ timeout: msgDeletionMs, reason: 'Removing old stuff.' })
 			}
 		} catch (err) {
 			log.error(`Failed to send Discord alert to dmLogChannel`, err)

--- a/src/lib/discord/commando/events/message.js
+++ b/src/lib/discord/commando/events/message.js
@@ -1,6 +1,4 @@
-const moment = require('moment-timezone')
 const { log } = require('../../../logger')
-require('moment-precise-range-plugin')
 
 module.exports = async (client, msg) => {
 	// Ignore all bots
@@ -8,11 +6,10 @@ module.exports = async (client, msg) => {
 
 	// Log all DM messages to dmLogChannelID
 	if (msg.channel.type === "dm" && client.config.discord.dmLogChannelID !== "") {
-		moment.locale(client.config.locale.timeformat)
 		const message = '<@'+msg.author+'> > ' + msg.cleanContent
 		try {
 			const channel = await client.channels.fetch(client.config.discord.dmLogChannelID)
-			const msgDeletionMs = (client.config.discord.dmLogChannelDeletionTime ) * 1000 || 0
+			const msgDeletionMs = (client.config.discord.dmLogChannelDeletionTime * 60) * 1000 || 0
 			if (!channel) return log.warn(`channel dmLogChannel not found`)
 			const logmsg = await channel.send(message)
 			if (msgDeletionMs > 0) {


### PR DESCRIPTION
Based on pr240 from JabLuszko and with addition of auto deletion after some time.

Fill in `config` > `discord` > `dmLogChannelID` with the desired log channel's ID
Optional : `config` > `discord` > `dmLogChannelDeletionTime` : time in minutes after which the logged messages are deleted