### PR TITLE
Add option to watch for config file changes

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -7,6 +7,7 @@
     },
     "general": {
         "environment": "production",
+        "listenFileChanges": false,
         "alertMinimumTime" : 120,
         "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/",
         "locale": "en",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/KartulUdus/reference#readme",
   "dependencies": {
     "axios": "^0.19.0",
+    "chokidar": "^3.4.3",
     "commander": "^4.1.0",
     "config": "^3.2.4",
     "discord-markdown": "^2.3.1",


### PR DESCRIPTION
⚠️ Totally experimental ⚠️

Seems to be working as intended : modification of `dts.json`, `local.json`, `geofence.json` would be taken without restarting Poracle (any file in `config` dir).
Although there might be other consequences that my limited knowledge of js does not see yet..

Needs a npm package to work: `npm install chokidar` in PoracleJS dir.
Then set new `config` > `general` > `listenFileChanges` to `true`