### PR TITLE
Add option to check periodically for member role

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,7 @@
         "unknownResponse": false,
         "invite": "",
         "token": [],
-        "guild": "",
+        "guilds": ["358180805031493634"],
         "channels": ["533927791096233984"],
         "userRole": ["roleId1", "358207117951369217"],
         "admins": ["222742859059560458"],

--- a/config/default.json
+++ b/config/default.json
@@ -60,9 +60,12 @@
     },
     "discord": {
         "enabled": true,
+        "checkRole": false,
+        "checkRoleInterval": 6,
         "unknownResponse": false,
         "invite": "",
         "token": [],
+        "guild": "",
         "channels": ["533927791096233984"],
         "userRole": ["roleId1", "358207117951369217"],
         "admins": ["222742859059560458"],

--- a/src/app.js
+++ b/src/app.js
@@ -120,10 +120,12 @@ async function run() {
 		let roleWorker = new DiscordWorker(config.discord.token[0], 0, config)
 		setInterval(async () => {
 			try {
-				log.info(`Verification of Poracle user's roles starting`)
-				const allUsers = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
+				let usersToCheck = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
 				let invalidUsers = []
-				invalidUsers = await roleWorker.checkRole(config.discord.guild, allUsers, config.discord.userRole)
+				for (const guild of config.discord.guilds) {
+					invalidUsers = await roleWorker.checkRole(guild, usersToCheck, config.discord.userRole)
+					usersToCheck = invalidUsers
+				}
 				if(invalidUsers[0]) {
 					log.info(`Invalid users found, removing from dB...`)
 					invalidUsers.forEach(async function(user) {

--- a/src/app.js
+++ b/src/app.js
@@ -116,17 +116,13 @@ async function run() {
 		}, 10)
 	}
 
-	if (config.discord.checkRole && config.discord.guild != "") {
+	if (config.discord.enabled && config.discord.checkRole && config.discord.guild != "") {
+		let roleWorker = new DiscordWorker(config.discord.token[0], 0, config)
 		setInterval(async () => {
 			log.info(`Verification of Poracle user's roles starting`)
 			const allUsers = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
 			let invalidUsers = []
-			let worker = discordWorkers.find((workerr) => !workerr.busy)
-			if (!worker.busy) {
-				worker.busy = true
-				invalidUsers = await worker.checkRole(allUsers, config.discord.userRole)
-				worker.busy = false
-			}
+			invalidUsers = await roleWorker.checkRole(allUsers, config.discord.userRole)
 			if(invalidUsers[0]) {
 				log.info(`Invalid users found, removing from dB...`)
 				invalidUsers.forEach(async function(user) {

--- a/src/app.js
+++ b/src/app.js
@@ -116,10 +116,11 @@ async function run() {
 		}, 10)
 	}
 
-	if (config.discord.enabled && config.discord.checkRole && config.discord.guild != "") {
-		let roleWorker = new DiscordWorker(config.discord.token[0], 0, config)
-		setInterval(async () => {
+	if (config.discord.enabled && config.discord.checkRole && config.discord.checkRoleInterval && config.discord.guild != "") {
+		let roleWorker = new DiscordWorker(config.discord.token[0], 999, config)
+		async function syncRole() {
 			try {
+				log.info(`Verification of Poracle user's roles starting...`)
 				let usersToCheck = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
 				let invalidUsers = []
 				for (const guild of config.discord.guilds) {
@@ -142,7 +143,9 @@ async function run() {
 			} catch (err) {
 				log.error(`Verification of Poracle user's roles failed with, ${err.message}`)
 			}
-		}, config.discord.checkRoleInterval * 3600000)
+			setTimeout(syncRole, config.discord.checkRoleInterval * 3600000)
+		}
+		setTimeout(syncRole, 10000)
 	}
 
 	// if (config.telegram.enabled) {

--- a/src/app.js
+++ b/src/app.js
@@ -121,9 +121,11 @@ async function run() {
 			log.info(`Verification of Poracle user's roles starting`)
 			const allUsers = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
 			let invalidUsers = []
-			let worker = discordWorkers[0]
+			let worker = discordWorkers.find((workerr) => !workerr.busy)
 			if (!worker.busy) {
+				worker.busy = true
 				invalidUsers = await worker.checkRole(allUsers, config.discord.userRole)
+				worker.busy = false
 			}
 			if(invalidUsers[0]) {
 				log.info(`Invalid users found, removing from dB...`)

--- a/src/app.js
+++ b/src/app.js
@@ -116,6 +116,31 @@ async function run() {
 		}, 10)
 	}
 
+	if (config.discord.checkRole && config.discord.guild != "") {
+		setInterval(async () => {
+			log.info(`Verification of Poracle user's roles starting`)
+			const allUsers = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
+			let invalidUsers = []
+			let worker = discordWorkers[0]
+			if (!worker.busy) {
+				invalidUsers = await worker.checkRole(allUsers, config.discord.userRole)
+			}
+			if(invalidUsers[0]) {
+				log.info(`Invalid users found, removing from dB...`)
+				invalidUsers.forEach(async function(user) {
+					log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
+					await fastify.monsterController.deleteQuery('egg', { id: user.id })
+					await fastify.monsterController.deleteQuery('monsters', { id: user.id })
+					await fastify.monsterController.deleteQuery('raid', { id: user.id })
+					await fastify.monsterController.deleteQuery('quest', { id: user.id })
+					await fastify.monsterController.deleteQuery('humans', { id: user.id })
+				})
+			}else{
+				log.info(`No invalid users found, all good!`)
+			}
+		}, config.discord.checkRoleInterval * 3600000)
+	}
+
 	// if (config.telegram.enabled) {
 	// 	setInterval(() => {
 	// 		if (!fastify.telegramQueue.length) {

--- a/src/app.js
+++ b/src/app.js
@@ -119,24 +119,28 @@ async function run() {
 	if (config.discord.enabled && config.discord.checkRole && config.discord.guild != "") {
 		let roleWorker = new DiscordWorker(config.discord.token[0], 0, config)
 		setInterval(async () => {
-			log.info(`Verification of Poracle user's roles starting`)
-			const allUsers = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
-			let invalidUsers = []
-			invalidUsers = await roleWorker.checkRole(allUsers, config.discord.userRole)
-			if(invalidUsers[0]) {
-				log.info(`Invalid users found, removing from dB...`)
-				invalidUsers.forEach(async function(user) {
-					log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-					await fastify.monsterController.deleteQuery('egg', { id: user.id })
-					await fastify.monsterController.deleteQuery('monsters', { id: user.id })
-					await fastify.monsterController.deleteQuery('raid', { id: user.id })
-					await fastify.monsterController.deleteQuery('quest', { id: user.id })
-					await fastify.monsterController.deleteQuery('humans', { id: user.id })
-				})
-			}else{
-				log.info(`No invalid users found, all good!`)
+			try {
+				log.info(`Verification of Poracle user's roles starting`)
+				const allUsers = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
+				let invalidUsers = []
+				invalidUsers = await roleWorker.checkRole(config.discord.guild, allUsers, config.discord.userRole)
+				if(invalidUsers[0]) {
+					log.info(`Invalid users found, removing from dB...`)
+					invalidUsers.forEach(async function(user) {
+						log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
+						await fastify.monsterController.deleteQuery('egg', { id: user.id })
+						await fastify.monsterController.deleteQuery('monsters', { id: user.id })
+						await fastify.monsterController.deleteQuery('raid', { id: user.id })
+						await fastify.monsterController.deleteQuery('quest', { id: user.id })
+						await fastify.monsterController.deleteQuery('humans', { id: user.id })
+					})
+				}else{
+					log.info(`No invalid users found, all good!`)
+				}
+			} catch (err) {
+				log.error(`Verification of Poracle user's roles failed with, ${err.message}`)
 			}
-		}, config.discord.checkRoleInterval * 3600000)
+		}, config.discord.checkRoleInterval * 1000)
 	}
 
 	// if (config.telegram.enabled) {

--- a/src/app.js
+++ b/src/app.js
@@ -70,6 +70,7 @@ fastify.decorate('hookQueue', [])
 const discordCommando = config.discord.enabled ? new DiscordCommando(knex, config, log, monsterData, utilData, dts, geofence, translator) : null
 log.info(`Discord commando ${discordCommando ? '' : ''}starting`)
 const discordWorkers = []
+let roleWorker
 let telegram
 let workingOnHooks = false
 
@@ -87,6 +88,38 @@ if (config.telegram.enabled) {
 
 // todo remove lint passing log
 log.debug(telegram)
+
+if (config.discord.enabled && config.discord.checkRole && config.discord.checkRoleInterval && config.discord.guild != '') {
+	roleWorker = new DiscordWorker(config.discord.token[0], 999, config)
+}
+
+async function syncRole() {
+	try {
+		log.info('Verification of Poracle user\'s roles starting...')
+		let usersToCheck = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
+		let invalidUsers = []
+		for (const guild of config.discord.guilds) {
+			invalidUsers = await roleWorker.checkRole(guild, usersToCheck, config.discord.userRole)
+			usersToCheck = invalidUsers
+		}
+		if (invalidUsers[0]) {
+			log.info('Invalid users found, removing from dB...')
+			invalidUsers.forEach(async (user) => {
+				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
+				await fastify.monsterController.deleteQuery('egg', { id: user.id })
+				await fastify.monsterController.deleteQuery('monsters', { id: user.id })
+				await fastify.monsterController.deleteQuery('raid', { id: user.id })
+				await fastify.monsterController.deleteQuery('quest', { id: user.id })
+				await fastify.monsterController.deleteQuery('humans', { id: user.id })
+			})
+		} else {
+			log.info('No invalid users found, all good!')
+		}
+	} catch (err) {
+		log.error(`Verification of Poracle user's roles failed with, ${err.message}`)
+	}
+	setTimeout(syncRole, config.discord.checkRoleInterval * 3600000)
+}
 
 async function run() {
 	if (config.discord.enabled) {
@@ -116,35 +149,7 @@ async function run() {
 		}, 10)
 	}
 
-	if (config.discord.enabled && config.discord.checkRole && config.discord.checkRoleInterval && config.discord.guild != "") {
-		let roleWorker = new DiscordWorker(config.discord.token[0], 999, config)
-		async function syncRole() {
-			try {
-				log.info(`Verification of Poracle user's roles starting...`)
-				let usersToCheck = await fastify.monsterController.selectAllQuery('humans', { type: 'discord:user' })
-				let invalidUsers = []
-				for (const guild of config.discord.guilds) {
-					invalidUsers = await roleWorker.checkRole(guild, usersToCheck, config.discord.userRole)
-					usersToCheck = invalidUsers
-				}
-				if(invalidUsers[0]) {
-					log.info(`Invalid users found, removing from dB...`)
-					invalidUsers.forEach(async function(user) {
-						log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-						await fastify.monsterController.deleteQuery('egg', { id: user.id })
-						await fastify.monsterController.deleteQuery('monsters', { id: user.id })
-						await fastify.monsterController.deleteQuery('raid', { id: user.id })
-						await fastify.monsterController.deleteQuery('quest', { id: user.id })
-						await fastify.monsterController.deleteQuery('humans', { id: user.id })
-					})
-				}else{
-					log.info(`No invalid users found, all good!`)
-				}
-			} catch (err) {
-				log.error(`Verification of Poracle user's roles failed with, ${err.message}`)
-			}
-			setTimeout(syncRole, config.discord.checkRoleInterval * 3600000)
-		}
+	if (config.discord.enabled && config.discord.checkRole && config.discord.checkRoleInterval && config.discord.guild != '') {
 		setTimeout(syncRole, 10000)
 	}
 

--- a/src/app.js
+++ b/src/app.js
@@ -140,7 +140,7 @@ async function run() {
 			} catch (err) {
 				log.error(`Verification of Poracle user's roles failed with, ${err.message}`)
 			}
-		}, config.discord.checkRoleInterval * 1000)
+		}, config.discord.checkRoleInterval * 3600000)
 	}
 
 	// if (config.telegram.enabled) {

--- a/src/lib/discord/discordWorker.js
+++ b/src/lib/discord/discordWorker.js
@@ -133,6 +133,24 @@ class Worker {
 		}
 		return true
 	}
+
+	async checkRole(users, roles) {
+		const allUsers = users
+		const validRoles = roles
+		const invalidUsers = []
+		const guild = await this.client.guilds.fetch(this.config.discord.guild)
+		allUsers.forEach(async function(user) {
+			log.info(`Checking role for: ${user.name} - ${user.id}`)
+			let discorduser = await guild.members.fetch(user.id)
+			if(discorduser.roles.cache.find(r => validRoles.includes(r.id))) {
+				log.info(`${discorduser.user.username} has a valid role`)
+			}else{
+				log.info(`${discorduser.user.username} doesn't have a valid role`)
+				invalidUsers.push(user)
+			}
+		})
+		return invalidUsers
+	}
 }
 
 module.exports = Worker

--- a/src/lib/discord/discordWorker.js
+++ b/src/lib/discord/discordWorker.js
@@ -139,7 +139,7 @@ class Worker {
 		const validRoles = roles
 		const invalidUsers = []
 		const guild = await this.client.guilds.fetch(guildID)
-		allUsers.forEach(async function(user) {
+		for (const user of allUsers) {
 			log.info(`Checking role for: ${user.name} - ${user.id}`)
 			let discorduser = await guild.members.fetch(user.id)
 			if(discorduser.roles.cache.find(r => validRoles.includes(r.id))) {
@@ -148,7 +148,7 @@ class Worker {
 				log.info(`${discorduser.user.username} doesn't have a valid role`)
 				invalidUsers.push(user)
 			}
-		})
+		}
 		return invalidUsers
 	}
 }

--- a/src/lib/discord/discordWorker.js
+++ b/src/lib/discord/discordWorker.js
@@ -134,11 +134,11 @@ class Worker {
 		return true
 	}
 
-	async checkRole(users, roles) {
+	async checkRole(guildID, users, roles) {
 		const allUsers = users
 		const validRoles = roles
 		const invalidUsers = []
-		const guild = await this.client.guilds.fetch(this.config.discord.guild)
+		const guild = await this.client.guilds.fetch(guildID)
 		allUsers.forEach(async function(user) {
 			log.info(`Checking role for: ${user.name} - ${user.id}`)
 			let discorduser = await guild.members.fetch(user.id)


### PR DESCRIPTION
Add the option to set an interval for member role verification: will compare users in Poracle dB to discord server and remove users without the valid user role.

Set the guild ids in `config` > `discord` > `guilds`
Toggle on the feature `config` > `discord` > `checkRole`
Set the verification interval (in hours) `config` > `discord` > `checkRoleInterval`