### PR TITLE
make default template name configurable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -21,7 +21,8 @@
         "roleCheckDeletionsAllowed": false,
         "availableLanguages": {
           "en": {"poracle": "poracle", "help": "help" }
-        }
+        },
+        "defaultTemplateName": 1
     },
     "logger": {
         "level": "info",

--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -17,7 +17,7 @@ exports.run = async (client, msg, args) => {
 		let exclusive = 0
 		let distance = 0
 		let team = 4
-		let template = 1
+		let template = client.config.general.defaultTemplateName
 		let clean = false
 		let levels = []
 		const pings = msg.getPings()

--- a/src/lib/poracleMessage/commands/invasion.js
+++ b/src/lib/poracleMessage/commands/invasion.js
@@ -16,7 +16,7 @@ exports.run = async (client, msg, args) => {
 		const remove = !!args.find((arg) => arg === 'remove')
 		const commandEverything = !!args.find((arg) => arg === 'everything')
 		let distance = 0
-		let template = 1
+		let template = client.config.general.defaultTemplateName
 		let gender = 0
 		let clean = false
 		const types = args.filter((arg) => typeArray.includes(arg))

--- a/src/lib/poracleMessage/commands/quest.js
+++ b/src/lib/poracleMessage/commands/quest.js
@@ -19,7 +19,7 @@ exports.run = async (client, msg, args) => {
 		let items = []
 		let distance = 0
 		const questTracks = []
-		let template = 1
+		let template = client.config.general.defaultTemplateName
 		let mustShiny = 0
 		let remove = false
 		let minDust = 10000000

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -21,7 +21,7 @@ exports.run = async (client, msg, args) => {
 		let exclusive = 0
 		let distance = 0
 		let team = 4
-		let template = 1
+		let template = client.config.general.defaultTemplateName
 		let clean = false
 		let levels = []
 		const pings = msg.getPings()

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -37,7 +37,7 @@ exports.run = async (client, msg, args) => {
 		const { pvpFilterMaxRank } = Math.min(client.config.pvp, 4096)
 		const { pvpFilterGreatMinCP } = client.config.pvp
 		const { pvpFilterUltraMinCP } = client.config.pvp
-		let template = 1
+		let template = client.config.general.defaultTemplateName
 		let clean = false
 		const pings = msg.getPings()
 


### PR DESCRIPTION
When no template name is specified in a user’s command, a default of “1” was
used so far.
This makes the default name configurable, thereby working around the issues
described in: https://github.com/KartulUdus/PoracleJS/issues/317