### PR TITLE
Improve everything permissions

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -79,8 +79,7 @@
         "pvpFilterUltraMinCP": 2450
     },
     "tracking": {
-        "disableEverythingTracking": false,
-        "forceEverythingSeparately": false,
+        "everythingFlagPermissions": "allow-any",
         "defaultDistance": 0,
         "maxDistance": 0
     },

--- a/src/lib/configChecker.js
+++ b/src/lib/configChecker.js
@@ -45,6 +45,11 @@ function checkConfig(config) {
 	if (config.geocoding.staticProvider != 'none' && !config.geocoding.staticProviderURL.startsWith('http')) {
 		logs.log.warn('Config Check: geocoding/staticProviderURL does not start with http')
 	}
+
+	// check whether tracking.everythingFlagPermissions has a valid value
+	if (!['allow-any', 'allow-and-always-individually', 'allow-and-ignore-individually', 'deny'].includes(config.tracking.everythingFlagPermissions)) {
+		logs.log.warn('Config Check: everything flag permissions is not one of allow-any,allow-and-always-individually,allow-and-ignore-individually,deny')
+	}
 }
 
 function checkGeofence(geofence) {

--- a/src/lib/configChecker.js
+++ b/src/lib/configChecker.js
@@ -50,6 +50,9 @@ function checkConfig(config) {
 	if (!['allow-any', 'allow-and-always-individually', 'allow-and-ignore-individually', 'deny'].includes(config.tracking.everythingFlagPermissions)) {
 		logs.log.warn('Config Check: everything flag permissions is not one of allow-any,allow-and-always-individually,allow-and-ignore-individually,deny')
 	}
+	// check for legacy options
+	if (typeof config.tracking.disableEverythingTracking != 'undefined') logs.log.warn('Config Check: legacy option “tracking.disableEverythingTracking” given and ignored, replace with “tracking.everythingFlagPermissions”')
+	if (typeof config.tracking.forceEverythingSeparately != 'undefined') logs.log.warn('Config Check: legacy option “tracking.forceEverythingSeparately” given and ignored, replace with “tracking.everythingFlagPermissions”')
 }
 
 function checkGeofence(geofence) {

--- a/src/lib/poracleMessage/commands/quest.js
+++ b/src/lib/poracleMessage/commands/quest.js
@@ -31,6 +31,20 @@ exports.run = async (client, msg, args) => {
 		let commandEverything = 0
 		let clean = false
 
+		let disableEverythingTracking
+		switch (client.config.tracking.everythingFlagPermissions.toLowerCase()) {
+			case 'allow-any':
+			case 'allow-and-always-individually':
+			case 'allow-and-ignore-individually': {
+				disableEverythingTracking = false
+				break
+			}
+			case 'deny':
+			default: {
+				disableEverythingTracking = true
+			}
+		}
+
 		const argTypes = args.filter((arg) => typeArray.includes(arg))
 		const genCommand = args.filter((arg) => arg.match(client.re.genRe))
 		const gen = genCommand.length ? client.GameData.utilData.genData[+(genCommand[0].match(client.re.genRe)[2])] : 0
@@ -42,7 +56,7 @@ exports.run = async (client, msg, args) => {
 		if (gen) fullMonsters = fullMonsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 		monsters = fullMonsters.map((mon) => mon.id)
 		items = Object.keys(client.GameData.items).filter((key) => args.includes(translator.translate(client.GameData.items[key].name.toLowerCase())) || args.includes('all items'))
-		if (args.includes('everything') && !client.config.tracking.disableEverythingTracking
+		if (args.includes('everything') && !disableEverythingTracking
 			|| args.includes('everything') && msg.isFromAdmin) {
 			monsters = Object.values(client.GameData.monsters).filter((mon) => !mon.form.id).map((m) => m.id)
 			items = Object.keys(client.GameData.items)

--- a/src/lib/poracleMessage/commands/quest.js
+++ b/src/lib/poracleMessage/commands/quest.js
@@ -56,8 +56,7 @@ exports.run = async (client, msg, args) => {
 		if (gen) fullMonsters = fullMonsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 		monsters = fullMonsters.map((mon) => mon.id)
 		items = Object.keys(client.GameData.items).filter((key) => args.includes(translator.translate(client.GameData.items[key].name.toLowerCase())) || args.includes('all items'))
-		if (args.includes('everything') && !disableEverythingTracking
-			|| args.includes('everything') && msg.isFromAdmin) {
+		if (args.includes('everything') && (!disableEverythingTracking || args.includes('remove') || msg.isFromAdmin)) {
 			monsters = Object.values(client.GameData.monsters).filter((mon) => !mon.form.id).map((m) => m.id)
 			items = Object.keys(client.GameData.items)
 			minDust = 0

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -43,6 +43,36 @@ exports.run = async (client, msg, args) => {
 		let clean = false
 		const pings = msg.getPings()
 
+		let disableEverythingTracking
+		let forceEverythingSeparately
+		let individuallyAllowed
+		switch (client.config.tracking.everythingFlagPermissions.toLowerCase()) {
+			case 'allow-any': {
+				disableEverythingTracking = false
+				forceEverythingSeparately = false
+				individuallyAllowed	= true
+				break
+			}
+			case 'allow-and-always-individually': {
+				disableEverythingTracking = false
+				forceEverythingSeparately = true
+				individuallyAllowed	= true
+				break
+			}
+			case 'allow-and-ignore-individually': {
+				disableEverythingTracking = false
+				forceEverythingSeparately = false
+				individuallyAllowed	= false
+				break
+			}
+			case 'deny':
+			default: {
+				disableEverythingTracking = true
+				forceEverythingSeparately = true
+				individuallyAllowed	= false
+			}
+		}
+
 		// Check for monsters or forms
 		const formArgs = args.filter((arg) => arg.match(client.re.formRe))
 		const formNames = formArgs ? formArgs.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase()) : []
@@ -53,15 +83,15 @@ exports.run = async (client, msg, args) => {
 			monsters = Object.values(client.GameData.monsters).filter((mon) => (
 				(args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString()))
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))
-				|| args.includes('everything') && !client.config.tracking.disableEverythingTracking
+				|| args.includes('everything') && !disableEverythingTracking
 				|| args.includes('everything') && msg.isFromAdmin) && formNames.includes(mon.form.name.toLowerCase()))
 
 			if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
-		} else if (gen || args.includes('individually') || client.config.tracking.forceEverythingSeparately) {
+		} else if (gen || (args.includes('individually') && individuallyAllowed) || forceEverythingSeparately) {
 			monsters = Object.values(client.GameData.monsters).filter((mon) => (
 				(args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString()))
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))
-				|| args.includes('everything') && !client.config.tracking.disableEverythingTracking
+				|| args.includes('everything') && !disableEverythingTracking
 				|| args.includes('everything') && msg.isFromAdmin) && !mon.form.id)
 
 			if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
@@ -70,7 +100,7 @@ exports.run = async (client, msg, args) => {
 				(args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString()))
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))) && !mon.form.id)
 
-			if (args.includes('everything') && !client.config.tracking.disableEverythingTracking || args.includes('everything') && msg.isFromAdmin) {
+			if (args.includes('everything') && !disableEverythingTracking || args.includes('everything') && msg.isFromAdmin) {
 				monsters.push({
 					id: 0,
 					form: {

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -87,7 +87,7 @@ exports.run = async (client, msg, args) => {
 				|| args.includes('everything') && msg.isFromAdmin) && formNames.includes(mon.form.name.toLowerCase()))
 
 			if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
-		} else if (gen || (args.includes('individually') && individuallyAllowed) || forceEverythingSeparately) {
+		} else if (gen || (args.includes('individually') && (individuallyAllowed || msg.isFromAdmin)) || forceEverythingSeparately) {
 			monsters = Object.values(client.GameData.monsters).filter((mon) => (
 				(args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString()))
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))


### PR DESCRIPTION
As per discussion in discord.

Perhaps you may want to have different option names, e.g. instead of `allow-everything-only` the name `allow-wildcard-only` or something like this could be a reasonable choice?