### PR TITLE
manually set the proper form name for Armored Mewtwo during generation

### DIFF
--- a/src/util/updateGameData.js
+++ b/src/util/updateGameData.js
@@ -324,6 +324,8 @@ function Add_Missing_Pokemon() {
 	// Remove missing Diancie and Volcanion
 	delete GameMaster.pokemon['719_0']
 	delete GameMaster.pokemon['721_0']
+	// set proper form name for Armored Mewtwo
+	if (GameMaster.pokemon['150_133'].form.name === "A") GameMaster.pokemon['150_133'].form.name = "Armored"
 }
 
 (async function () {


### PR DESCRIPTION
This is not just needed because `Armored` is the form name users will expect, but also because with just `A`, one couldn’t localise it, since Unown A shares the same form name.

Which also kinda points us to a more general problem in the whole architecture:
What if Niantic adds form names which are identical in English, but translate differently in other languages.

@Petap0w would you be so kind to review whether I did it properly? :-)