### PR TITLE
recude logging

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -26,15 +26,15 @@
         "persistDuplicateCache": false
     },
     "logger": {
-        "consoleLogLevel": "verbose",
+        "consoleLogLevel": "warn",
         "logLevel": "verbose",
         "enableLogs": {
-          "webhooks": true,
+          "webhooks": false,
           "discord": true,
           "telegram": true
         },
         "dailyLogLimit": 7,
-        "webhookLogLimit": 12
+        "webhookLogLimit": 2
     },
     "database": {
         "client": "sqlite",


### PR DESCRIPTION
- journald/systemd/console probably doesn’t need to be spammed with verbose
  logging, if everything goes into a file anyway
- webhook logging seems to be purely for debugging, so one can presumably
  disable it per default
- even if enabled, 2 files, each ~1,5 GB, should probably plenty enough