### PR TITLE
Support Telegram location share function

### DIFF
--- a/src/lib/telegram/Telegram.js
+++ b/src/lib/telegram/Telegram.js
@@ -25,10 +25,7 @@ class Telegram {
 			.use(commandParser(this.translatorFactory))
 			.use(controller(query, dts, logs, GameData, geofence, config, re, translatorFactory))
 
-		/* install middleware for telegram location sharing function */
-		const locationHandler = require(`${__dirname}/commands/location`)
-		this.bot.on('location', locationHandler)
-
+		/* set command middleware for each enabled command */
 		this.commandFiles.map((file) => {
 			if (!file.endsWith('.js')) return
 			this.tempProps = require(`${__dirname}/commands/${file}`) // eslint-disable-line global-require
@@ -47,6 +44,11 @@ class Telegram {
 				}
 			}
 		})
+		/* install extra middleware for telegram location sharing function, because .command(...) only catch text type messages */
+		if (!this.config.general.disabledCommands.includes('location')){
+			const locationHandler = require(`${__dirname}/commands/location`)
+			this.bot.on('location', locationHandler)
+		}
 
 		if (this.config.general.availableLanguages && !this.config.general.disabledCommands.includes('poracle')) {
 			for (const [, availableLanguage] of Object.entries(this.config.general.availableLanguages)) {

--- a/src/lib/telegram/Telegram.js
+++ b/src/lib/telegram/Telegram.js
@@ -24,6 +24,11 @@ class Telegram {
 		this.bot
 			.use(commandParser(this.translatorFactory))
 			.use(controller(query, dts, logs, GameData, geofence, config, re, translatorFactory))
+
+		/* install middleware for telegram location sharing function */
+		const locationHandler = require(`${__dirname}/commands/location`)
+		this.bot.on('location', locationHandler)
+
 		this.commandFiles.map((file) => {
 			if (!file.endsWith('.js')) return
 			this.tempProps = require(`${__dirname}/commands/${file}`) // eslint-disable-line global-require

--- a/src/lib/telegram/middleware/commandParser.js
+++ b/src/lib/telegram/middleware/commandParser.js
@@ -4,18 +4,16 @@ module.exports = (translatorFactory) => mount(['text', 'location'], (ctx, next) 
 	const regex = /^\/([^@\s]+)@?(?:(\S+)|)\s?([\s\S]*)$/i
 	if (!ctx.message) return next()
 
-	var tempTextMsg = ""
-	/* if we have a location type message -> convert location data to text string to handle as text command */
-	if (ctx.message.location) {
-		tempTextMsg = `/location ${ctx.message.location.latitude} ${ctx.message.location.longitude}`
-	} else {
-		tempTextMsg = ctx.message.text
-	}
+	let commandText = ctx.message.text || ''
+    /* if we have a location type message -> convert location data to text string to handle as text command */
+    if (ctx.message.location) {
+        commandText = `/location ${ctx.message.location.latitude} ${ctx.message.location.longitude}`
+    }
 
-	const parts = regex.exec(tempTextMsg)
+	const parts = regex.exec(commandText)
 	if (!parts) return next()
 	const command = {
-		text: tempTextMsg,
+		text: commandText,
 		command: parts[1],
 		bot: parts[2],
 		args: parts[3],

--- a/src/lib/telegram/middleware/commandParser.js
+++ b/src/lib/telegram/middleware/commandParser.js
@@ -1,12 +1,21 @@
 const { mount } = require('telegraf')
 /* eslint no-param-reassign: ["error", { "props": false }] */
-module.exports = (translatorFactory) => mount('text', (ctx, next) => {
+module.exports = (translatorFactory) => mount(['text', 'location'], (ctx, next) => {
 	const regex = /^\/([^@\s]+)@?(?:(\S+)|)\s?([\s\S]*)$/i
 	if (!ctx.message) return next()
-	const parts = regex.exec(ctx.message.text)
+
+	var tempTextMsg = ""
+	/* if we have a location type message -> convert location data to text string to handle as text command */
+	if (ctx.message.location) {
+		tempTextMsg = `/location ${ctx.message.location.latitude} ${ctx.message.location.longitude}`
+	} else {
+		tempTextMsg = ctx.message.text
+	}
+
+	const parts = regex.exec(tempTextMsg)
 	if (!parts) return next()
 	const command = {
-		text: ctx.message.text,
+		text: tempTextMsg,
 		command: parts[1],
 		bot: parts[2],
 		args: parts[3],

--- a/src/lib/telegram/middleware/controller.js
+++ b/src/lib/telegram/middleware/controller.js
@@ -1,7 +1,7 @@
 const { mount } = require('telegraf')
 
 /* eslint no-param-reassign: ["error", { "props": false }] */
-module.exports = (query, dts, logs, GameData, geofence, config, re, translatorFactory) => mount('text', (ctx, next) => {
+module.exports = (query, dts, logs, GameData, geofence, config, re, translatorFactory) => mount(['text', 'location'], (ctx, next) => {
 	ctx.state.controller = {
 		query,
 		dts,


### PR DESCRIPTION
With this new feature, PoracleJS user can use built-in location share function of Telegram mobile app to set new user location instead of using handwritten /location command.
See Issue #314 

## Description
Adding 'location' type for Telegram controller and commandParser. Also added extra middleware to catch location message to trigger location command.

## Motivation and Context
Better user experience. Also no need of geoconding to set location.

## How Has This Been Tested?
Local instance with Visual Studio Code.

## Screenshots - How to share location in Telegram mobile app:
![1](https://user-images.githubusercontent.com/78230819/108610502-5fa86880-73d6-11eb-8232-c39188a7e451.jpg)
![2](https://user-images.githubusercontent.com/78230819/108610503-6040ff00-73d6-11eb-898f-c61d7cb19d25.jpg)
![3](https://user-images.githubusercontent.com/78230819/108610504-60d99580-73d6-11eb-8472-2ea01ae0ce8f.jpg)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.