### PR TITLE
gym_name is undefined for MAD raid-hooks

### DIFF
--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -163,6 +163,7 @@ class Raid extends Controller {
 			if (data.name) {
 				data.name = this.escapeJsonString(data.name)
 				data.gymName = data.name
+				data.gym_name = data.name
 			}
 			if (data.gym_name) {
 				data.gym_name = this.escapeJsonString(data.gym_name)


### PR DESCRIPTION
MAD sends gym name as `name`  both for raids and raid eggs. 

This gets mapped into `gymName` in the handling, but not into `gym_name` which is used for internal logging (and perhaps DTS, who knows)

This oneliner mapes `name` into `gym_name` for complete MAD support

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes "raid at undefined appeared blablabla log messages

## Motivation and Context
Who doesn't love one line PRs?

## How Has This Been Tested?
Arcane Divination 🔮 
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5710881/108977579-f8fea580-7688-11eb-8c20-fb60520489ed.png)
Here's how this looks like in Visual Studio Code 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.