### PR TITLE
Re-introduce | capability

### DIFF
--- a/src/lib/configFetcher.js
+++ b/src/lib/configFetcher.js
@@ -72,10 +72,10 @@ module.exports = {
 		translator = translatorFactory.default
 
 		if (performChecks) {
-		knex.migrate.latest({
-			directory: path.join(__dirname, './db/migrations'),
-			tableName: 'migrations',
-		})
+			knex.migrate.latest({
+				directory: path.join(__dirname, './db/migrations'),
+				tableName: 'migrations',
+			})
 			configChecker.checkConfig(config)
 			configChecker.checkDts(dts, config)
 			configChecker.checkGeofence(geofence)

--- a/src/lib/db/migrations/v02_profileslures.js
+++ b/src/lib/db/migrations/v02_profileslures.js
@@ -17,7 +17,7 @@ exports.up = async function migrationUp(knex) {
 		if (config.database.client !== 'sqlite' && config.database.client !== 'sqlite3') table.dropForeign(['id'])
 		table.dropUnique(null, 'monsters_tracking')
 		table.unique([
-			'id', 'profile_no', 'pokemon_id', 'min_iv', 'max_iv', 'min_level', 'max_level', 'atk', 'def', 'sta', 'form', 
+			'id', 'profile_no', 'pokemon_id', 'min_iv', 'max_iv', 'min_level', 'max_level', 'atk', 'def', 'sta', 'form',
 			'great_league_ranking', 'great_league_ranking_min_cp', 'ultra_league_ranking', 'ultra_league_ranking_min_cp', 'min_time',
 		], 'monsters_tracking')
 		if (config.database.client !== 'sqlite' && config.database.client !== 'sqlite3') table.foreign('id').references('humans.id').onDelete('CASCADE')

--- a/src/lib/discord/commando/commands/area.js
+++ b/src/lib/discord/commando/commands/area.js
@@ -7,5 +7,7 @@ exports.run = async (client, msg, command) => {
 	const pdm = new PoracleDiscordMessage(client, msg)
 	const pds = new PoracleDiscordState(client)
 
-	await commandLogic.run(pds, pdm, command[0])
+	for (const c of command) {
+		await commandLogic.run(pds, pdm, c)
+	}
 }

--- a/src/lib/discord/commando/commands/quest.js
+++ b/src/lib/discord/commando/commands/quest.js
@@ -7,5 +7,7 @@ exports.run = async (client, msg, command) => {
 	const pdm = new PoracleDiscordMessage(client, msg)
 	const pds = new PoracleDiscordState(client)
 
-	await commandLogic.run(pds, pdm, command[0])
+	for (const c of command) {
+		await commandLogic.run(pds, pdm, c)
+	}
 }

--- a/src/lib/discord/commando/commands/raid.js
+++ b/src/lib/discord/commando/commands/raid.js
@@ -7,5 +7,7 @@ exports.run = async (client, msg, command) => {
 	const pdm = new PoracleDiscordMessage(client, msg)
 	const pds = new PoracleDiscordState(client)
 
-	await commandLogic.run(pds, pdm, command[0])
+	for (const c of command) {
+		await commandLogic.run(pds, pdm, c)
+	}
 }

--- a/src/lib/discord/commando/commands/track.js
+++ b/src/lib/discord/commando/commands/track.js
@@ -7,5 +7,7 @@ exports.run = async (client, msg, command) => {
 	const pdm = new PoracleDiscordMessage(client, msg)
 	const pds = new PoracleDiscordState(client)
 
-	await commandLogic.run(pds, pdm, command[0])
+	for (const c of command) {
+		await commandLogic.run(pds, pdm, c)
+	}
 }

--- a/src/lib/telegram/commands/area.js
+++ b/src/lib/telegram/commands/area.js
@@ -13,7 +13,9 @@ module.exports = async (ctx) => {
 		const ptm = new PoracleTelegramMessage(ctx)
 		const pts = new PoracleTelegramState(ctx)
 
-		await commandLogic.run(pts, ptm, command.splitArgsArray[0])
+		for (const c of command.splitArgsArray) {
+			await commandLogic.run(pts, ptm, c)
+		}
 	} catch (err) {
 		controller.logs.telegram.error('Area command unhappy:', err)
 	}

--- a/src/lib/telegram/commands/quest.js
+++ b/src/lib/telegram/commands/quest.js
@@ -13,7 +13,9 @@ module.exports = async (ctx) => {
 		const ptm = new PoracleTelegramMessage(ctx)
 		const pts = new PoracleTelegramState(ctx)
 
-		await commandLogic.run(pts, ptm, command.splitArgsArray[0])
+		for (const c of command.splitArgsArray) {
+			await commandLogic.run(pts, ptm, c)
+		}
 	} catch (err) {
 		controller.logs.telegram.error('Quest command unhappy:', err)
 	}

--- a/src/lib/telegram/commands/raid.js
+++ b/src/lib/telegram/commands/raid.js
@@ -13,7 +13,9 @@ module.exports = async (ctx) => {
 		const ptm = new PoracleTelegramMessage(ctx)
 		const pts = new PoracleTelegramState(ctx)
 
-		await commandLogic.run(pts, ptm, command.splitArgsArray[0])
+		for (const c of command.splitArgsArray) {
+			await commandLogic.run(pts, ptm, c)
+		}
 	} catch (err) {
 		controller.logs.telegram.error('Raid command unhappy:', err)
 	}

--- a/src/lib/telegram/commands/track.js
+++ b/src/lib/telegram/commands/track.js
@@ -13,7 +13,9 @@ module.exports = async (ctx) => {
 		const ptm = new PoracleTelegramMessage(ctx)
 		const pts = new PoracleTelegramState(ctx)
 
-		await commandLogic.run(pts, ptm, command.splitArgsArray[0])
+		for (const c of command.splitArgsArray) {
+			await commandLogic.run(pts, ptm, c)
+		}
 	} catch (err) {
 		controller.logs.telegram.error('Track command unhappy:', err)
 	}


### PR DESCRIPTION
The capability to use | between certain commands was originally available in v4 but badly broken.  This was taken out as part of the telegram re-work.  This has now been re-introduced for some commands (most notably track) for users who are scripting lots of commands.

eg use:
`!track bulbasaur iv75 | charmander iv50`
This is treated as if two separate track commands had been entered.  Note the pipe has to appear with spaces before and after it, consistent with the earlier implementation. 