### PR TITLE
Apply command to multiple channels at once

### DIFF
--- a/src/lib/discord/commando/commands/apply.js
+++ b/src/lib/discord/commando/commands/apply.js
@@ -1,0 +1,11 @@
+const PoracleDiscordMessage = require('../../poracleDiscordMessage')
+const PoracleDiscordState = require('../../poracleDiscordState')
+
+const commandLogic = require('../../../poracleMessage/specials/apply')
+
+exports.run = async (client, msg, command) => {
+	const pdm = new PoracleDiscordMessage(client, msg)
+	const pds = new PoracleDiscordState(client)
+
+	await commandLogic.run(pds, pdm, command)
+}

--- a/src/lib/discord/commando/events/message.js
+++ b/src/lib/discord/commando/events/message.js
@@ -31,27 +31,31 @@ module.exports = async (client, msg) => {
 			}
 		}
 
-		// Ignore msgs not starting with the prefix (in config)
-		if (msg.content.indexOf(client.config.discord.prefix) !== 0) return
+		for (const commandText of msg.content.split('\n')) {
+			// Ignore msgs not starting with the prefix (in config)
+			// eslint-disable-next-line no-continue
+			if (commandText.indexOf(client.config.discord.prefix) !== 0) continue
 
-		let args = msg.content.slice(client.config.discord.prefix.length).trim().split(/ +/g)
+			let args = commandText.slice(client.config.discord.prefix.length).trim().split(/ +/g)
 
-		args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase().replace(/_/g, ' '), true).toLowerCase())
-		const command = args.shift()
+			args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase().replace(/_/g, ' '), true).toLowerCase())
+			const command = args.shift()
 
-		if (client.config.general.disabledCommands.includes(command)) return
+			// eslint-disable-next-line no-continue
+			if (client.config.general.disabledCommands.includes(command)) continue
 
-		let initialArgs
-		if (args.includes('|')) {
-			initialArgs = args.join(' ').split('|').map((com) => com.split(' ').filter((a) => a))
-		} else {
-			initialArgs = [args]
+			let initialArgs
+			if (args.includes('|')) {
+				initialArgs = args.join(' ').split('|').map((com) => com.split(' ').filter((a) => a))
+			} else {
+				initialArgs = [args]
+			}
+
+			const cmd = client.commands[command]
+			if (cmd) {
+				cmd.run(client, msg, initialArgs)
+			}
 		}
-
-		const cmd = client.commands[command]
-		if (!cmd) return
-
-		cmd.run(client, msg, initialArgs)
 	} catch (err) {
 		client.logs.discord.error('Error during message event', err)
 	}

--- a/src/lib/discord/poracleDiscordState.js
+++ b/src/lib/discord/poracleDiscordState.js
@@ -21,8 +21,8 @@ class PoracleDiscordState {
 		return new PoracleDiscordMessage(this, msg)
 	}
 
-	createUtil(msg, command) {
-		return new PoracleDiscordUtil(this, msg, command)
+	createUtil(msg, options) {
+		return new PoracleDiscordUtil(this, msg, options)
 	}
 }
 

--- a/src/lib/discord/poracleDiscordUtil.js
+++ b/src/lib/discord/poracleDiscordUtil.js
@@ -1,8 +1,8 @@
 class PoracleDiscordUtil {
-	constructor(client, msg, command) {
+	constructor(client, msg, options) {
 		this.client = client
 		this.msg = msg
-		this.command = command
+		this.options = options
 
 		this.prefix = this.client.config.discord.prefix
 	}
@@ -48,62 +48,72 @@ class PoracleDiscordUtil {
 			id: this.msg.msg.author.id, type: 'discord:user', name: this.msg.msg.author.tag, webhook: false,
 		}
 
-		let webhookName = args.find((arg) => arg.match(this.client.re.nameRe))
-		if (webhookName) [,, webhookName] = webhookName.match(this.client.re.nameRe)
+		let status
 
-		let userIdOverride = args.find((arg) => arg.match(this.client.re.userRe))
-		if (userIdOverride) [,, userIdOverride] = userIdOverride.match(this.client.re.userRe)
+		if (this.options && this.options.targetOveride) {
+			target.id = this.options.targetOveride.id
+			target.name = this.options.targetOveride.name
+			target.type = this.options.targetOveride.type
+			target.webook = (target.type == 'webhook')
+			status = await this.checkRegistrationStatus(target)
+		} else {
+			let webhookName = args.find((arg) => arg.match(this.client.re.nameRe))
+			if (webhookName) [, , webhookName] = webhookName.match(this.client.re.nameRe)
 
-		if (this.msg.isFromAdmin && this.msg.msg.channel.type === 'text') {
-			target = {
-				id: this.msg.msg.channel.id,
-				name: this.msg.msg.channel.name,
-				type: 'discord:channel',
-				webhook: false,
+			let userIdOverride = args.find((arg) => arg.match(this.client.re.userRe))
+			if (userIdOverride) [, , userIdOverride] = userIdOverride.match(this.client.re.userRe)
+
+			if (this.msg.isFromAdmin && this.msg.msg.channel.type === 'text') {
+				target = {
+					id: this.msg.msg.channel.id,
+					name: this.msg.msg.channel.name,
+					type: 'discord:channel',
+					webhook: false,
+				}
 			}
-		}
 
-		if (this.msg.isFromAdmin && userIdOverride) {
-			target.id = userIdOverride
-		}
-
-		if (this.msg.isFromAdmin && webhookName) {
-			target = {
-				name: webhookName,
-				type: 'webhook',
-				webhook: true,
+			if (this.msg.isFromAdmin && userIdOverride) {
+				target.id = userIdOverride
 			}
+
+			if (this.msg.isFromAdmin && webhookName) {
+				target = {
+					name: webhookName,
+					type: 'webhook',
+					webhook: true,
+				}
+			}
+
+			status = await this.checkRegistrationStatus(target)
+
+			if (!status.isRegistered && this.msg.isFromAdmin && target.webhook) {
+				await this.msg.reply(`Webhook ${target.name} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.client.config.discord.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')} ${this.client.translator.translate('name')}webhookname ${this.client.translator.translate('<Your-Webhook-url>')}`)
+				return { canContinue: false }
+			}
+
+			if (!status.isRegistered && this.msg.isFromAdmin && this.msg.msg.channel.type === 'text') {
+				await this.msg.reply(`${this.msg.msg.channel.name} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.client.config.discord.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')}`)
+				return { canContinue: false }
+			}
+
+			if (!status.isRegistered && this.msg.isFromAdmin && userIdOverride) {
+				await this.msg.reply(this.client.translator.translate('User with that identity does not appear to be registered (or is disabled)'))
+				return { canContinue: false }
+			}
+
+			if (!status.isRegistered && this.msg.msg.channel.type === 'dm') {
+				await this.msg.react(this.client.translator.translate('🙅'))
+				return { canContinue: false }
+			}
+
+			if (this.msg.isFromAdmin && userIdOverride) {
+				target.name = status.name
+				target.type = status.type
+				await this.msg.reply(`${this.client.translator.translate('This command is being executed as')} ${target.id} ${target.name}`)
+			}
+
+			if (target.webhook) target.id = status.id
 		}
-
-		const status = await this.checkRegistrationStatus(target)
-
-		if (!status.isRegistered && this.msg.isFromAdmin && target.webhook) {
-			await this.msg.reply(`Webhook ${target.name} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.client.config.discord.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')} ${this.client.translator.translate('name')}webhookname ${this.client.translator.translate('<Your-Webhook-url>')}`)
-			return { canContinue: false }
-		}
-
-		if (!status.isRegistered && this.msg.isFromAdmin && this.msg.msg.channel.type === 'text') {
-			await this.msg.reply(`${this.msg.msg.channel.name} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.client.config.discord.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')}`)
-			return { canContinue: false }
-		}
-
-		if (!status.isRegistered && this.msg.isFromAdmin && userIdOverride) {
-			await this.msg.reply(this.client.translator.translate('User with that identity does not appear to be registered (or is disabled)'))
-			return { canContinue: false }
-		}
-
-		if (!status.isRegistered && this.msg.msg.channel.type === 'dm') {
-			await this.msg.react(this.client.translator.translate('🙅'))
-			return { canContinue: false }
-		}
-
-		if (this.msg.isFromAdmin && userIdOverride) {
-			target.name = status.name
-			target.type = status.type
-			await this.msg.reply(`${this.client.translator.translate('This command is being executed as')} ${target.id} ${target.name}`)
-		}
-
-		if (target.webhook) target.id = status.id
 
 		return {
 			canContinue: true,

--- a/src/lib/poracleMessage/commands/area.js
+++ b/src/lib/poracleMessage/commands/area.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/backup.js
+++ b/src/lib/poracleMessage/commands/backup.js
@@ -1,14 +1,14 @@
 const fs = require('fs')
 const path = require('path')
 
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
 		if (!msg.isFromAdmin) {
 			return client.log.info(`${msg.userId} ran "backup" command`)
 		}
 
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, currentProfileNo,

--- a/src/lib/poracleMessage/commands/disable.js
+++ b/src/lib/poracleMessage/commands/disable.js
@@ -1,11 +1,11 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		if (!msg.isFromAdmin) {
 			return await msg.react('🙅')
 		}
 
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue,

--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -1,6 +1,6 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, userHasLocation, userHasArea, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/enable.js
+++ b/src/lib/poracleMessage/commands/enable.js
@@ -1,11 +1,11 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		if (!msg.isFromAdmin) {
 			return await msg.react('🙅')
 		}
 
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue,

--- a/src/lib/poracleMessage/commands/help.js
+++ b/src/lib/poracleMessage/commands/help.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language,

--- a/src/lib/poracleMessage/commands/invasion.js
+++ b/src/lib/poracleMessage/commands/invasion.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, userHasLocation, userHasArea, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/language.js
+++ b/src/lib/poracleMessage/commands/language.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language,

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/lure.js
+++ b/src/lib/poracleMessage/commands/lure.js
@@ -1,6 +1,6 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, userHasLocation, userHasArea, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/profile.js
+++ b/src/lib/poracleMessage/commands/profile.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/quest.js
+++ b/src/lib/poracleMessage/commands/quest.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, userHasLocation, userHasArea, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, userHasLocation, userHasArea, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/restore.js
+++ b/src/lib/poracleMessage/commands/restore.js
@@ -1,12 +1,12 @@
 const fs = require('fs')
 const path = require('path')
 
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
-			canContinue, target, currentProfileNo
+			canContinue, target, currentProfileNo,
 		} = await util.buildTarget(args)
 
 		if (!canContinue) return

--- a/src/lib/poracleMessage/commands/start.js
+++ b/src/lib/poracleMessage/commands/start.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language,

--- a/src/lib/poracleMessage/commands/stop.js
+++ b/src/lib/poracleMessage/commands/stop.js
@@ -1,7 +1,7 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target,

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -1,6 +1,6 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, userHasLocation, userHasArea, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -1,9 +1,9 @@
 const fs = require('fs')
 const path = require('path')
 
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, language, currentProfileNo,

--- a/src/lib/poracleMessage/commands/unregister.js
+++ b/src/lib/poracleMessage/commands/unregister.js
@@ -1,6 +1,6 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	// Check target
-	const util = client.createUtil(msg, args)
+	const util = client.createUtil(msg, options)
 
 	const {
 		canContinue, target,

--- a/src/lib/poracleMessage/commands/untrack.js
+++ b/src/lib/poracleMessage/commands/untrack.js
@@ -1,6 +1,6 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, target, currentProfileNo,

--- a/src/lib/poracleMessage/commands/userlist.js
+++ b/src/lib/poracleMessage/commands/userlist.js
@@ -1,11 +1,11 @@
-exports.run = async (client, msg, args) => {
+exports.run = async (client, msg, args, options) => {
 	try {
 		if (!msg.isFromAdmin) {
 			return await msg.react('🙅')
 		}
 
 		// Check target
-		const util = client.createUtil(msg, args)
+		const util = client.createUtil(msg, options)
 
 		const {
 			canContinue, language,

--- a/src/lib/poracleMessage/specials/apply.js
+++ b/src/lib/poracleMessage/specials/apply.js
@@ -1,0 +1,46 @@
+exports.run = async (client, msg, commands) => {
+	try {
+		if (!msg.isFromAdmin) {
+			return await msg.react('🙅')
+		}
+
+		const targets = []
+		for (const channel of commands[0]) {
+			const humansById = await client.query.selectOneQuery('humans', { id: channel })
+			if (humansById) targets.push(humansById)
+			const webhookByName = await client.query.selectAllQuery('humans', (builder) => {
+				builder.whereIn('type',
+					['webhook', 'discord:channel', 'telegram:channel', 'telegram:group'])
+					.andWhere('name', 'like', channel)
+			})
+			if (webhookByName) targets.push(...webhookByName)
+		}
+
+		for (const target of targets) {
+			await msg.reply(`>>> Executing as ${target.type} / ${target.name} ${target.type != 'webhook' ? target.id : ''}`)
+			for (let x = 1; x < commands.length; x++) {
+				const command = commands[x]
+				msg.reply(`>> ${command.join(' ')}`)
+				const cmdName = command[0]
+
+				try {
+					const cmd = require(`../commands/${cmdName}`)
+
+					await cmd.run(client, msg, command.slice(1),
+						{
+							targetOverride: {
+								type: target.type,
+								id: target.id,
+								name: target.name,
+							},
+						})
+				} catch (err) {
+					msg.reply('>> Error executing command')
+				}
+			}
+		}
+		await msg.react('✅')
+	} catch (err) {
+		client.log.error(`apply command ${msg.content} unhappy:`, err)
+	}
+}

--- a/src/lib/poracleMessage/specials/apply.js
+++ b/src/lib/poracleMessage/specials/apply.js
@@ -20,7 +20,7 @@ exports.run = async (client, msg, commands) => {
 			await msg.reply(`>>> Executing as ${target.type} / ${target.name} ${target.type != 'webhook' ? target.id : ''}`)
 			for (let x = 1; x < commands.length; x++) {
 				const command = commands[x]
-				msg.reply(`>> ${command.join(' ')}`)
+				await msg.reply(`>> ${command.join(' ')}`)
 				const cmdName = command[0]
 
 				try {
@@ -35,7 +35,7 @@ exports.run = async (client, msg, commands) => {
 							},
 						})
 				} catch (err) {
-					msg.reply('>> Error executing command')
+					await msg.reply('>> Error executing command')
 				}
 			}
 		}

--- a/src/lib/telegram/commands/apply.js
+++ b/src/lib/telegram/commands/apply.js
@@ -1,0 +1,20 @@
+const PoracleTelegramMessage = require('../poracleTelegramMessage')
+const PoracleTelegramState = require('../poracleTelegramState')
+
+const commandLogic = require('../../poracleMessage/specials/apply')
+
+module.exports = async (ctx) => {
+	const { controller, command } = ctx.state
+
+	// channel message authors aren't identifiable, ignore all commands sent in channels
+	if (Object.keys(ctx.update).includes('channel_post')) return
+
+	try {
+		const ptm = new PoracleTelegramMessage(ctx)
+		const pts = new PoracleTelegramState(ctx)
+
+		await commandLogic.run(pts, ptm, command.splitArgsArray)
+	} catch (err) {
+		controller.logs.telegram.error('Apply command unhappy:', err)
+	}
+}

--- a/src/lib/telegram/poracleTelegramState.js
+++ b/src/lib/telegram/poracleTelegramState.js
@@ -23,8 +23,8 @@ class PoracleTelegramState {
 		return new PoracleTelegramMessage(this, msg)
 	}
 
-	createUtil(msg, command) {
-		return new PoracleTelegramUtil(this, msg, command)
+	createUtil(msg, options) {
+		return new PoracleTelegramUtil(this, msg, options)
 	}
 }
 

--- a/src/lib/telegram/poracleTelegramUtil.js
+++ b/src/lib/telegram/poracleTelegramUtil.js
@@ -1,8 +1,8 @@
 class PoracleTelegramUtil {
-	constructor(client, msg, command) {
+	constructor(client, msg, options) {
 		this.client = client
 		this.msg = msg
-		this.command = command
+		this.options = options
 
 		this.prefix = '/'
 	}
@@ -51,56 +51,72 @@ class PoracleTelegramUtil {
 			channel: false,
 		}
 
-		let channelName = args.find((arg) => arg.match(this.client.re.nameRe))
-		if (channelName) [,, channelName] = channelName.match(this.client.re.nameRe)
+		let status
 
-		let userIdOverride = args.find((arg) => arg.match(this.client.re.userRe))
-		if (userIdOverride) [,, userIdOverride] = userIdOverride.match(this.client.re.userRe)
+		if (this.options && this.options.targetOveride) {
+			target.id = this.options.targetOveride.id
+			target.name = this.options.targetOveride.name
+			target.type = this.options.targetOveride.type
+			target.channel = (target.type == 'telegram:channel')
+			status = await this.checkRegistrationStatus(target)
+		} else {
+			let channelName = args.find((arg) => arg.match(this.client.re.nameRe))
+			if (channelName) [, , channelName] = channelName.match(this.client.re.nameRe)
 
-		if (this.msg.isFromAdmin && !this.msg.isDM) {
-			target = {
-				id: this.msg.ctx.update.message.chat.id.toString(),
-				type: 'telegram:group',
-				name: this.msg.ctx.update.message.chat ? this.msg.ctx.update.message.chat.title.toLowerCase() : '',
-				channel: false,
+			let userIdOverride = args.find((arg) => arg.match(this.client.re.userRe))
+			if (userIdOverride) [, , userIdOverride] = userIdOverride.match(this.client.re.userRe)
+
+			if (this.msg.isFromAdmin && !this.msg.isDM) {
+				target = {
+					id: this.msg.ctx.update.message.chat.id.toString(),
+					type: 'telegram:group',
+					name: this.msg.ctx.update.message.chat ? this.msg.ctx.update.message.chat.title.toLowerCase() : '',
+					channel: false,
+				}
 			}
+
+			if (this.msg.isFromAdmin && userIdOverride) {
+				target.id = userIdOverride
+			}
+
+			if (this.msg.isFromAdmin && channelName) {
+				target = {
+					name: channelName,
+					type: 'telegram:channel',
+					channel: true,
+				}
+			}
+
+			status = await this.checkRegistrationStatus(target)
+
+			if (!status.isRegistered && this.msg.isFromAdmin && target.webhook) {
+				await this.msg.reply(`Channel ${target.name} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.msg.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')} ${this.client.translator.translate('name')}name ${this.client.translator.translate('<Your-Channel-id>')}`)
+				return { canContinue: false }
+			}
+
+			if (!status.isRegistered && this.msg.isFromAdmin && !this.msg.isDM) {
+				await this.msg.reply(`${this.msg.ctx.update.message.chat.title} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.msg.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')}`)
+				return { canContinue: false }
+			}
+
+			if (!status.isRegistered && this.msg.isFromAdmin && userIdOverride) {
+				await this.msg.reply(this.client.translator.translate('User with that identity does not appear to be registered (or is disabled)'))
+				return { canContinue: false }
+			}
+
+			if (!status.isRegistered && this.msg.isDM) {
+				await this.msg.react(this.client.translator.translate('🙅'))
+				return { canContinue: false }
+			}
+
+			if (this.msg.isFromAdmin && userIdOverride) {
+				target.name = status.name
+				target.type = status.type
+				await this.msg.reply(`${this.client.translator.translate('This command is being executed as')} ${target.id} ${target.name}`)
+			}
+
+			if (target.channel) target.id = status.id
 		}
-
-		if (this.msg.isFromAdmin && userIdOverride) {
-			target.id = userIdOverride
-		}
-
-		if (this.msg.isFromAdmin && channelName) target = { name: channelName, type: 'telegram:channel', channel: true }
-
-		const status = await this.checkRegistrationStatus(target)
-
-		if (!status.isRegistered && this.msg.isFromAdmin && target.webhook) {
-			await this.msg.reply(`Channel ${target.name} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.msg.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')} ${this.client.translator.translate('name')}name ${this.client.translator.translate('<Your-Channel-id>')}`)
-			return { canContinue: false }
-		}
-
-		if (!status.isRegistered && this.msg.isFromAdmin && !this.msg.isDM) {
-			await this.msg.reply(`${this.msg.ctx.update.message.chat.title} ${this.client.translator.translate('does not seem to be registered. add it with')} ${this.msg.prefix}${this.client.translator.translate('channel')} ${this.client.translator.translate('add')}`)
-			return { canContinue: false }
-		}
-
-		if (!status.isRegistered && this.msg.isFromAdmin && userIdOverride) {
-			await this.msg.reply(this.client.translator.translate('User with that identity does not appear to be registered (or is disabled)'))
-			return { canContinue: false }
-		}
-
-		if (!status.isRegistered && this.msg.isDM) {
-			await this.msg.react(this.client.translator.translate('🙅'))
-			return { canContinue: false }
-		}
-
-		if (this.msg.isFromAdmin && userIdOverride) {
-			target.name = status.name
-			target.type = status.type
-			await this.msg.reply(`${this.client.translator.translate('This command is being executed as')} ${target.id} ${target.name}`)
-		}
-
-		if (target.channel) target.id = status.id
 
 		return {
 			canContinue: true,


### PR DESCRIPTION
Now you've got lots of channels all receiving notifications. How on earth do you manage them?

You can now use the new apply command to issue commands against multiple channels, by ID or by name.  Remember `!userlist` will list your users and channels if you need to remember what's going on.  You can use % wildcards for matching channel names.

Use the | separator to indicate the end of the channel list and start of commands, and between commands. You need the spaces!

`!apply 34455322334 234442223432 | track bulbasaur`
`!apply %events | untrack everything | track fletchling iv95` 

In addition, if you're using discord you can send multiple commands in a single buffer which makes pasting a list of commands much easier.