### PR TITLE
Implement userDisableInstead for Discord

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -35,7 +35,11 @@
       "disablePokestop": false,
       "disableQuest": false,
       "disableWeather": false,
-      "roleCheckDeletionsAllowed": false,       // can poracle delete registered users when they lose their roles (test with false, set to true when confident)
+    // roleCheckDeletionsMode
+    // 0 - don't delete users once required role is removed
+    // 1 - delete user from database along with trackings once required role is removed
+    // 2 - disable user once required role is removed and re-enable once it's restored, trackings will remain
+      "roleCheckDeletionsMode": 0,
     // availableLanguages
     // - This is an array of available languages that users can swap between using the !language command
     // - Each language can have it's own call word which pre-sets that language, and you also define the help text
@@ -168,10 +172,6 @@
     //   actually carry out the deletions rather than just logging them)
       "checkRole": false,
       "checkRoleInterval": 6,
-    // userDisableInstead - In case where user (and all of his settings) would get removed from database
-    // we will use `admin_disable` flag to switch his state. This way user configuration won't be deleted.
-    // Keep in mind that auto-register event will overwrite state of manually issued command `!disable`
-      "userDisableInstead": false,
     // token - array of discord tokens - poracle can support any number of bots for transmitting
     //   messages but the first will be used as the command controller
       "token": ["discord bot token"],

--- a/config/default.json
+++ b/config/default.json
@@ -168,6 +168,10 @@
     //   actually carry out the deletions rather than just logging them)
       "checkRole": false,
       "checkRoleInterval": 6,
+    // userDisableInstead - In case where user (and all of his settings) would get removed from database
+    // we will use `admin_disable` flag to switch his state. This way user configuration won't be deleted.
+    // Keep in mind that auto-register event will overwrite state of manually issued command `!disable`
+      "userDisableInstead": false,
     // token - array of discord tokens - poracle can support any number of bots for transmitting
     //   messages but the first will be used as the command controller
       "token": ["discord bot token"],

--- a/config/default.json
+++ b/config/default.json
@@ -35,11 +35,11 @@
       "disablePokestop": false,
       "disableQuest": false,
       "disableWeather": false,
-    // roleCheckMode
-    // 0 - don't delete users once required role is removed
-    // 1 - delete user from database along with trackings once required role is removed
-    // 2 - disable user once required role is removed and re-enable once it's restored, trackings will remain
-      "roleCheckMode": 0,
+    // roleCheckMode (case sensitive)
+    // "ignore" - log and don't delete/disable users once required role is removed
+    // "delete" - delete user from database along with trackings once required role is removed
+    // "disable" - disable user once required role is removed and re-enable once it's restored, trackings will remain
+      "roleCheckMode": "ignore",
     // availableLanguages
     // - This is an array of available languages that users can swap between using the !language command
     // - Each language can have it's own call word which pre-sets that language, and you also define the help text

--- a/config/default.json
+++ b/config/default.json
@@ -35,11 +35,11 @@
       "disablePokestop": false,
       "disableQuest": false,
       "disableWeather": false,
-    // roleCheckDeletionsMode
+    // roleCheckMode
     // 0 - don't delete users once required role is removed
     // 1 - delete user from database along with trackings once required role is removed
     // 2 - disable user once required role is removed and re-enable once it's restored, trackings will remain
-      "roleCheckDeletionsMode": 0,
+      "roleCheckMode": 0,
     // availableLanguages
     // - This is an array of available languages that users can swap between using the !language command
     // - Each language can have it's own call word which pre-sets that language, and you also define the help text

--- a/src/app.js
+++ b/src/app.js
@@ -106,8 +106,8 @@ if (config.telegram.enabled) {
 }
 
 async function removeInvalidUser(user) {
-    if (client.config.discord.userDisableInstead) {
-        await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
+    if (client.config.general.roleCheckDeletionsMode == 2) {
+        if (!user.admin_disable) await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
     } else {
         await query.deleteQuery('egg', { id: user.id })
         await query.deleteQuery('monsters', { id: user.id })
@@ -135,7 +135,7 @@ async function syncTelegramMembership() {
 			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-				if (config.general.roleCheckDeletionsAllowed) {
+				if (config.general.roleCheckDeletionsMode) {
 					await removeInvalidUser(user)
 				} else {
 					log.info('config.general.roleCheckDeletionAllowed not set, not removing')
@@ -164,7 +164,7 @@ async function syncDiscordRole() {
 			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-				if (config.general.roleCheckDeletionsAllowed) {
+				if (config.general.roleCheckDeletionsMode) {
 					await removeInvalidUser(user)
 				} else {
 					log.info('config.general.roleCheckDeletionAllowed not set, not removing')

--- a/src/app.js
+++ b/src/app.js
@@ -106,13 +106,17 @@ if (config.telegram.enabled) {
 }
 
 async function removeInvalidUser(user) {
-	await query.deleteQuery('egg', { id: user.id })
-	await query.deleteQuery('monsters', { id: user.id })
-	await query.deleteQuery('raid', { id: user.id })
-	await query.deleteQuery('quest', { id: user.id })
-	await query.deleteQuery('lures', { id: user.id })
-	await query.deleteQuery('profiles', { id: user.id })
-	await query.deleteQuery('humans', { id: user.id })
+    if (client.config.discord.userDisableInstead) {
+        await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
+    } else {
+        await query.deleteQuery('egg', { id: user.id })
+        await query.deleteQuery('monsters', { id: user.id })
+        await query.deleteQuery('raid', { id: user.id })
+        await query.deleteQuery('quest', { id: user.id })
+        await query.deleteQuery('lures', { id: user.id })
+        await query.deleteQuery('profiles', { id: user.id })
+        await query.deleteQuery('humans', { id: user.id })
+    }
 }
 
 async function syncTelegramMembership() {
@@ -128,7 +132,7 @@ async function syncTelegramMembership() {
 		}
 
 		if (invalidUsers[0]) {
-			log.info('Invalid users found, removing from dB...')
+			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
 				if (config.general.roleCheckDeletionsAllowed) {
@@ -157,7 +161,7 @@ async function syncDiscordRole() {
 			usersToCheck = invalidUsers
 		}
 		if (invalidUsers[0]) {
-			log.info('Invalid users found, removing from dB...')
+			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
 				if (config.general.roleCheckDeletionsAllowed) {

--- a/src/app.js
+++ b/src/app.js
@@ -106,17 +106,17 @@ if (config.telegram.enabled) {
 }
 
 async function removeInvalidUser(user) {
-    if (client.config.general.roleCheckDeletionsMode == 2) {
-        if (!user.admin_disable) await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
-    } else if (client.config.general.roleCheckDeletionsMode == 1) {  // sanity check
-        await query.deleteQuery('egg', { id: user.id })
-        await query.deleteQuery('monsters', { id: user.id })
-        await query.deleteQuery('raid', { id: user.id })
-        await query.deleteQuery('quest', { id: user.id })
-        await query.deleteQuery('lures', { id: user.id })
-        await query.deleteQuery('profiles', { id: user.id })
-        await query.deleteQuery('humans', { id: user.id })
-    }
+	if (config.general.roleCheckMode == 2) {
+		if (!user.admin_disable) await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
+	} else if (config.general.roleCheckMode == 1) { // sanity check
+		await query.deleteQuery('egg', { id: user.id })
+		await query.deleteQuery('monsters', { id: user.id })
+		await query.deleteQuery('raid', { id: user.id })
+		await query.deleteQuery('quest', { id: user.id })
+		await query.deleteQuery('lures', { id: user.id })
+		await query.deleteQuery('profiles', { id: user.id })
+		await query.deleteQuery('humans', { id: user.id })
+	}
 }
 
 async function syncTelegramMembership() {
@@ -135,7 +135,7 @@ async function syncTelegramMembership() {
 			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-				if (config.general.roleCheckDeletionsMode) {
+				if (config.general.roleCheckMode) {
 					await removeInvalidUser(user)
 				} else {
 					log.info('config.general.roleCheckDeletionAllowed not set, not removing')
@@ -164,7 +164,7 @@ async function syncDiscordRole() {
 			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-				if (config.general.roleCheckDeletionsMode) {
+				if (config.general.roleCheckMode) {
 					await removeInvalidUser(user)
 				} else {
 					log.info('config.general.roleCheckDeletionAllowed not set, not removing')

--- a/src/app.js
+++ b/src/app.js
@@ -106,9 +106,9 @@ if (config.telegram.enabled) {
 }
 
 async function removeInvalidUser(user) {
-	if (config.general.roleCheckMode == 2) {
+	if (config.general.roleCheckMode == "disable") {
 		if (!user.admin_disable) await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
-	} else if (config.general.roleCheckMode == 1) { // sanity check
+	} else if (config.general.roleCheckMode == "delete") { // sanity check
 		await query.deleteQuery('egg', { id: user.id })
 		await query.deleteQuery('monsters', { id: user.id })
 		await query.deleteQuery('raid', { id: user.id })
@@ -135,7 +135,7 @@ async function syncTelegramMembership() {
 			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-				if (config.general.roleCheckMode) {
+				if (config.general.roleCheckMode != "ignore") {
 					await removeInvalidUser(user)
 				} else {
 					log.info('config.general.roleCheckDeletionAllowed not set, not removing')
@@ -164,7 +164,7 @@ async function syncDiscordRole() {
 			log.info('Invalid users found, removing/disabling from dB...')
 			for (const user of invalidUsers) {
 				log.info(`Removing ${user.name} - ${user.id} from Poracle dB`)
-				if (config.general.roleCheckMode) {
+				if (config.general.roleCheckMode != "ignore") {
 					await removeInvalidUser(user)
 				} else {
 					log.info('config.general.roleCheckDeletionAllowed not set, not removing')

--- a/src/app.js
+++ b/src/app.js
@@ -108,7 +108,7 @@ if (config.telegram.enabled) {
 async function removeInvalidUser(user) {
     if (client.config.general.roleCheckDeletionsMode == 2) {
         if (!user.admin_disable) await query.updateQuery('humans', { admin_disable: 1 }, { id: user.id })
-    } else {
+    } else if (client.config.general.roleCheckDeletionsMode == 1) {  // sanity check
         await query.deleteQuery('egg', { id: user.id })
         await query.deleteQuery('monsters', { id: user.id })
         await query.deleteQuery('raid', { id: user.id })

--- a/src/lib/configChecker.js
+++ b/src/lib/configChecker.js
@@ -56,7 +56,7 @@ function checkConfig(config) {
 	}
 
 	if (config.general.roleCheckDeletionsAllowed == true) {
-	    logs.log.warn('Config Check: legacy option “roleCheckDeletionsAllowed“ given and ignored, replace with “roleCheckDeletionsMode“')
+		logs.log.warn('Config Check: legacy option “roleCheckDeletionsAllowed“ given and ignored, replace with “roleCheckMode“')
 	}
 
 	if (typeof config.discord.limitSec != 'undefined') logs.log.warn('Config Check: legacy option “discord.limitSec” given and ignored, replace with “alertLimits.timingPeriod”')

--- a/src/lib/configChecker.js
+++ b/src/lib/configChecker.js
@@ -55,6 +55,10 @@ function checkConfig(config) {
 		logs.log.warn('Config Check: geocoding/staticProviderURL does not start with http')
 	}
 
+	if (config.general.roleCheckDeletionsAllowed == true) {
+	    logs.log.warn('Config Check: legacy option “roleCheckDeletionsAllowed“ given and ignored, replace with “roleCheckDeletionsMode“')
+	}
+
 	if (typeof config.discord.limitSec != 'undefined') logs.log.warn('Config Check: legacy option “discord.limitSec” given and ignored, replace with “alertLimits.timingPeriod”')
 	if (typeof config.discord.limitAmount != 'undefined') logs.log.warn('Config Check: legacy option “discord.limitAmount” given and ignored, replace with “alertLimits.dmLimit/channelLimit”')
 

--- a/src/lib/db/migrations/v02a_admindisable.js
+++ b/src/lib/db/migrations/v02a_admindisable.js
@@ -1,0 +1,15 @@
+const { log } = require('../../logger')
+
+exports.up = async function migrationUp(knex) {
+    await knex.schema.alterTable('humans', (table) => {
+        table.dateTime('disabled_date').nullable().alter()
+    })
+
+    await knex.table('humans').update({ disabled_date: null })
+
+    log.info('Admin disable migration applied')
+}
+
+exports.down = async function migrationDown(knex) {
+    log.info(knex)
+}

--- a/src/lib/db/migrations/v02a_admindisable.js
+++ b/src/lib/db/migrations/v02a_admindisable.js
@@ -1,15 +1,15 @@
 const { log } = require('../../logger')
 
 exports.up = async function migrationUp(knex) {
-    await knex.schema.alterTable('humans', (table) => {
-        table.dateTime('disabled_date').nullable().alter()
-    })
+	await knex.schema.alterTable('humans', (table) => {
+		table.dateTime('disabled_date').nullable().alter()
+	})
 
-    await knex.table('humans').update({ disabled_date: null })
+	await knex.table('humans').update({ disabled_date: null })
 
-    log.info('Admin disable migration applied')
+	log.info('Admin disable migration applied')
 }
 
 exports.down = async function migrationDown(knex) {
-    log.info(knex)
+	log.info(knex)
 }

--- a/src/lib/discord/commando/commands/poracle.js
+++ b/src/lib/discord/commando/commands/poracle.js
@@ -18,6 +18,16 @@ exports.run = async (client, msg) => {
 
 		const isRegistered = await client.query.countQuery('humans', { id: msg.author.id })
 		if (isRegistered) {
+            if (client.config.general.roleCheckDeletionsMode == 2) {
+                const user = await client.query.selectOneQuery('humans', { id: msg.author.id })
+                if (user.admin_disable && !user.disabled_date) {
+                    await client.query.updateQuery('humans', { admin_disable: 0 }, { id: msg.author.id })
+                    client.logs.discord.log({ level: 'debug', message: `user ${member.tag} used poracle command to remove admin_disable flag`, event: 'discord:registerCheck' })
+                } else if (user.admin_disable && user.disabled_date) {
+                    await msg.react('🙅')  // account was disabled by admin, don't let him re-enable
+                }
+            }
+
 			await msg.react('👌')
 			//			await client.query.updateQuery('humans', { language: language }, { id: msg.author.id })
 		} else {

--- a/src/lib/discord/commando/commands/poracle.js
+++ b/src/lib/discord/commando/commands/poracle.js
@@ -18,15 +18,15 @@ exports.run = async (client, msg) => {
 
 		const isRegistered = await client.query.countQuery('humans', { id: msg.author.id })
 		if (isRegistered) {
-            if (client.config.general.roleCheckDeletionsMode == 2) {
-                const user = await client.query.selectOneQuery('humans', { id: msg.author.id })
-                if (user.admin_disable && !user.disabled_date) {
-                    await client.query.updateQuery('humans', { admin_disable: 0 }, { id: msg.author.id })
-                    client.logs.discord.log({ level: 'debug', message: `user ${member.tag} used poracle command to remove admin_disable flag`, event: 'discord:registerCheck' })
-                } else if (user.admin_disable && user.disabled_date) {
-                    await msg.react('🙅')  // account was disabled by admin, don't let him re-enable
-                }
-            }
+			if (client.config.general.roleCheckMode == 2) {
+				const user = await client.query.selectOneQuery('humans', { id: msg.author.id })
+				if (user.admin_disable && !user.disabled_date) {
+					await client.query.updateQuery('humans', { admin_disable: 0 }, { id: msg.author.id })
+					client.logs.discord.log({ level: 'debug', message: `user ${msg.author.tag} used poracle command to remove admin_disable flag`, event: 'discord:registerCheck' })
+				} else if (user.admin_disable && user.disabled_date) {
+					await msg.react('🙅') // account was disabled by admin, don't let him re-enable
+				}
+			}
 
 			await msg.react('👌')
 			//			await client.query.updateQuery('humans', { language: language }, { id: msg.author.id })

--- a/src/lib/discord/commando/commands/poracle.js
+++ b/src/lib/discord/commando/commands/poracle.js
@@ -24,7 +24,7 @@ exports.run = async (client, msg) => {
 					await client.query.updateQuery('humans', { admin_disable: 0 }, { id: msg.author.id })
 					client.logs.discord.log({ level: 'debug', message: `user ${msg.author.tag} used poracle command to remove admin_disable flag`, event: 'discord:registerCheck' })
 				} else if (user.admin_disable && user.disabled_date) {
-					await msg.react('🙅') // account was disabled by admin, don't let him re-enable
+					return await msg.react('🙅') // account was disabled by admin, don't let him re-enable
 				}
 			}
 

--- a/src/lib/discord/commando/commands/poracle.js
+++ b/src/lib/discord/commando/commands/poracle.js
@@ -18,7 +18,7 @@ exports.run = async (client, msg) => {
 
 		const isRegistered = await client.query.countQuery('humans', { id: msg.author.id })
 		if (isRegistered) {
-			if (client.config.general.roleCheckMode == 2) {
+			if (client.config.general.roleCheckMode == "disable") {
 				const user = await client.query.selectOneQuery('humans', { id: msg.author.id })
 				if (user.admin_disable && !user.disabled_date) {
 					await client.query.updateQuery('humans', { admin_disable: 0 }, { id: msg.author.id })

--- a/src/lib/discord/commando/events/guildMemberRemove.js
+++ b/src/lib/discord/commando/events/guildMemberRemove.js
@@ -2,14 +2,19 @@ module.exports = async (client, member) => {
 	try {
 		const isRegistered = await client.query.countQuery('humans', { id: member.id })
 		if (isRegistered) {
-			await client.query.deleteQuery('egg', { id: member.id })
-			await client.query.deleteQuery('monsters', { id: member.id })
-			await client.query.deleteQuery('raid', { id: member.id })
-			await client.query.deleteQuery('quest', { id: member.id })
-			await client.query.deleteQuery('humans', { id: member.id })
-			client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-unregistered`, event: 'discord:registerCheck' })
+            if (client.config.discord.userDisableInstead) {
+                await client.query.updateQuery('humans', { admin_disable: 1 }, { id: member.id })
+                client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-disabled`, event: 'discord:registerCheck' })
+            } else {
+                await client.query.deleteQuery('egg', { id: member.id })
+                await client.query.deleteQuery('monsters', { id: member.id })
+                await client.query.deleteQuery('raid', { id: member.id })
+                await client.query.deleteQuery('quest', { id: member.id })
+                await client.query.deleteQuery('humans', { id: member.id })
+                client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-unregistered`, event: 'discord:registerCheck' })
+            }
 		}
 	} catch (e) {
-		client.logs.discord.error('Discord event: guildMemberRemove - was unable to remove human', e)
+		client.logs.discord.error('Discord event: guildMemberRemove - was unable to remove/disable human', e)
 	}
 }

--- a/src/lib/discord/commando/events/guildMemberRemove.js
+++ b/src/lib/discord/commando/events/guildMemberRemove.js
@@ -2,22 +2,22 @@ module.exports = async (client, member) => {
 	try {
 		const isRegistered = await client.query.countQuery('humans', { id: member.id })
 		if (isRegistered) {
-            if (client.config.general.roleCheckDeletionsMode == 2) {
-                const user = await client.query.selectOneQuery('humans', { id: member.id })
-                if (!user.admin_disable) {
-                    await client.query.updateQuery('humans', { admin_disable: 1 }, { id: member.id })
-                    client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-disabled`, event: 'discord:registerCheck' })
-                }
-            } else if (client.config.general.roleCheckDeletionsMode == 1) {
-                await client.query.deleteQuery('egg', { id: member.id })
-                await client.query.deleteQuery('monsters', { id: member.id })
-                await client.query.deleteQuery('raid', { id: member.id })
-                await client.query.deleteQuery('quest', { id: member.id })
-                await client.query.deleteQuery('humans', { id: member.id })
-                client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-unregistered`, event: 'discord:registerCheck' })
-            } else {
-                client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server but wasnt auto unregistered/disabled due to configuration`, event: 'discord:registerCheck' })
-            }
+			if (client.config.general.roleCheckMode == 2) {
+				const user = await client.query.selectOneQuery('humans', { id: member.id })
+				if (!user.admin_disable) {
+					await client.query.updateQuery('humans', { admin_disable: 1 }, { id: member.id })
+					client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-disabled`, event: 'discord:registerCheck' })
+				}
+			} else if (client.config.general.roleCheckMode == 1) {
+				await client.query.deleteQuery('egg', { id: member.id })
+				await client.query.deleteQuery('monsters', { id: member.id })
+				await client.query.deleteQuery('raid', { id: member.id })
+				await client.query.deleteQuery('quest', { id: member.id })
+				await client.query.deleteQuery('humans', { id: member.id })
+				client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-unregistered`, event: 'discord:registerCheck' })
+			} else {
+				client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server but wasnt auto unregistered/disabled due to configuration`, event: 'discord:registerCheck' })
+			}
 		}
 	} catch (e) {
 		client.logs.discord.error('Discord event: guildMemberRemove - was unable to remove/disable human', e)

--- a/src/lib/discord/commando/events/guildMemberRemove.js
+++ b/src/lib/discord/commando/events/guildMemberRemove.js
@@ -2,13 +2,13 @@ module.exports = async (client, member) => {
 	try {
 		const isRegistered = await client.query.countQuery('humans', { id: member.id })
 		if (isRegistered) {
-			if (client.config.general.roleCheckMode == 2) {
+			if (client.config.general.roleCheckMode == "disable") {
 				const user = await client.query.selectOneQuery('humans', { id: member.id })
 				if (!user.admin_disable) {
 					await client.query.updateQuery('humans', { admin_disable: 1 }, { id: member.id })
 					client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-disabled`, event: 'discord:registerCheck' })
 				}
-			} else if (client.config.general.roleCheckMode == 1) {
+			} else if (client.config.general.roleCheckMode == "delete") {
 				await client.query.deleteQuery('egg', { id: member.id })
 				await client.query.deleteQuery('monsters', { id: member.id })
 				await client.query.deleteQuery('raid', { id: member.id })

--- a/src/lib/discord/commando/events/guildMemberRemove.js
+++ b/src/lib/discord/commando/events/guildMemberRemove.js
@@ -2,16 +2,21 @@ module.exports = async (client, member) => {
 	try {
 		const isRegistered = await client.query.countQuery('humans', { id: member.id })
 		if (isRegistered) {
-            if (client.config.discord.userDisableInstead) {
-                await client.query.updateQuery('humans', { admin_disable: 1 }, { id: member.id })
-                client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-disabled`, event: 'discord:registerCheck' })
-            } else {
+            if (client.config.general.roleCheckDeletionsMode == 2) {
+                const user = await client.query.selectOneQuery('humans', { id: member.id })
+                if (!user.admin_disable) {
+                    await client.query.updateQuery('humans', { admin_disable: 1 }, { id: member.id })
+                    client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-disabled`, event: 'discord:registerCheck' })
+                }
+            } else if (client.config.general.roleCheckDeletionsMode == 1) {
                 await client.query.deleteQuery('egg', { id: member.id })
                 await client.query.deleteQuery('monsters', { id: member.id })
                 await client.query.deleteQuery('raid', { id: member.id })
                 await client.query.deleteQuery('quest', { id: member.id })
                 await client.query.deleteQuery('humans', { id: member.id })
                 client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server and was auto-unregistered`, event: 'discord:registerCheck' })
+            } else {
+                client.logs.discord.log({ level: 'debug', message: `user ${member.tag} left the server but wasnt auto unregistered/disabled due to configuration`, event: 'discord:registerCheck' })
             }
 		}
 	} catch (e) {

--- a/src/lib/discord/commando/events/guildMemberUpdate.js
+++ b/src/lib/discord/commando/events/guildMemberUpdate.js
@@ -21,33 +21,33 @@ module.exports = async (client, oldPresence, newPresence) => {
 				}
 
 				client.logs.discord.log({ level: 'info', message: `registered ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
-			} else if (isRegistered && client.config.general.roleCheckDeletionsMode == 2) {
-			    const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
-			    if (user.admin_disable && !user.disabled_date) {
-			        await client.query.updateQuery('humans', { admin_disable: 0 }, { id: oldPresence.user.id })
-				    client.logs.discord.log({ level: 'info', message: `enabled ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
-			    }
+			} else if (isRegistered && client.config.general.roleCheckMode == 2) {
+				const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
+				if (user.admin_disable && !user.disabled_date) {
+					await client.query.updateQuery('humans', { admin_disable: 0 }, { id: oldPresence.user.id })
+					client.logs.discord.log({ level: 'info', message: `enabled ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
+				}
 			}
 		}
 		if (before && !after) {
 			const isRegistered = await client.query.countQuery('humans', { id: oldPresence.user.id })
 			if (isRegistered) {
-			    if (client.config.general.roleCheckDeletionsMode == 2) {
-			        const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
-			        if (!user.admin_disable) {
-                        await client.query.updateQuery('humans', { admin_disable: 1 }, { id: oldPresence.user.id })
-                        client.logs.discord.log({ level: 'info', message: `disabled ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
-                    }
-			    } else if (client.config.general.roleCheckDeletionsMode == 1) {
-                    await client.query.deleteQuery('egg', { id: oldPresence.user.id })
-                    await client.query.deleteQuery('monsters', { id: oldPresence.user.id })
-                    await client.query.deleteQuery('raid', { id: oldPresence.user.id })
-                    await client.query.deleteQuery('quest', { id: oldPresence.user.id })
-                    await client.query.deleteQuery('humans', { id: oldPresence.user.id })
-                    client.logs.discord.log({ level: 'info', message: `unregistered ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
-			    } else {
-                    client.logs.discord.log({ level: 'info', message: `${oldPresence.user.username} lost ${roleBefore.name} role but wasnt unregistered/disabled due to configuration`, event: 'discord:roleCheck' })
-                }
+				if (client.config.general.roleCheckMode == 2) {
+					const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
+					if (!user.admin_disable) {
+						await client.query.updateQuery('humans', { admin_disable: 1 }, { id: oldPresence.user.id })
+						client.logs.discord.log({ level: 'info', message: `disabled ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
+					}
+				} else if (client.config.general.roleCheckMode == 1) {
+					await client.query.deleteQuery('egg', { id: oldPresence.user.id })
+					await client.query.deleteQuery('monsters', { id: oldPresence.user.id })
+					await client.query.deleteQuery('raid', { id: oldPresence.user.id })
+					await client.query.deleteQuery('quest', { id: oldPresence.user.id })
+					await client.query.deleteQuery('humans', { id: oldPresence.user.id })
+					client.logs.discord.log({ level: 'info', message: `unregistered ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
+				} else {
+					client.logs.discord.log({ level: 'info', message: `${oldPresence.user.username} lost ${roleBefore.name} role but wasnt unregistered/disabled due to configuration`, event: 'discord:roleCheck' })
+				}
 			}
 		}
 	} catch (e) {

--- a/src/lib/discord/commando/events/guildMemberUpdate.js
+++ b/src/lib/discord/commando/events/guildMemberUpdate.js
@@ -21,7 +21,7 @@ module.exports = async (client, oldPresence, newPresence) => {
 				}
 
 				client.logs.discord.log({ level: 'info', message: `registered ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
-			} else if (client.config.general.roleCheckDeletionsMode == 2) {
+			} else if (isRegistered && client.config.general.roleCheckDeletionsMode == 2) {
 			    const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
 			    if (user.admin_disable && !user.disabled_date) {
 			        await client.query.updateQuery('humans', { admin_disable: 0 }, { id: oldPresence.user.id })

--- a/src/lib/discord/commando/events/guildMemberUpdate.js
+++ b/src/lib/discord/commando/events/guildMemberUpdate.js
@@ -21,17 +21,28 @@ module.exports = async (client, oldPresence, newPresence) => {
 				}
 
 				client.logs.discord.log({ level: 'info', message: `registered ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
+			} else {
+			    const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
+			    if (user.admin_disable && client.config.discord.userDisableInstead) {
+			        await client.query.updateQuery('humans', { admin_disable: 0 }, { id: oldPresence.user.id })
+				    client.logs.discord.log({ level: 'info', message: `enabled ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
+			    }
 			}
 		}
 		if (before && !after) {
 			const isRegistered = await client.query.countQuery('humans', { id: oldPresence.user.id })
 			if (isRegistered) {
-				await client.query.deleteQuery('egg', { id: oldPresence.user.id })
-				await client.query.deleteQuery('monsters', { id: oldPresence.user.id })
-				await client.query.deleteQuery('raid', { id: oldPresence.user.id })
-				await client.query.deleteQuery('quest', { id: oldPresence.user.id })
-				await client.query.deleteQuery('humans', { id: oldPresence.user.id })
-				client.logs.discord.log({ level: 'info', message: `unregistered ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
+			    if (client.config.discord.userDisableInstead) {
+			        await client.query.updateQuery('humans', { admin_disable: 1 }, { id: oldPresence.user.id })
+                    client.logs.discord.log({ level: 'info', message: `disabled ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
+			    } else {
+                    await client.query.deleteQuery('egg', { id: oldPresence.user.id })
+                    await client.query.deleteQuery('monsters', { id: oldPresence.user.id })
+                    await client.query.deleteQuery('raid', { id: oldPresence.user.id })
+                    await client.query.deleteQuery('quest', { id: oldPresence.user.id })
+                    await client.query.deleteQuery('humans', { id: oldPresence.user.id })
+                    client.logs.discord.log({ level: 'info', message: `unregistered ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
+			    }
 			}
 		}
 	} catch (e) {

--- a/src/lib/discord/commando/events/guildMemberUpdate.js
+++ b/src/lib/discord/commando/events/guildMemberUpdate.js
@@ -21,7 +21,7 @@ module.exports = async (client, oldPresence, newPresence) => {
 				}
 
 				client.logs.discord.log({ level: 'info', message: `registered ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
-			} else if (isRegistered && client.config.general.roleCheckMode == 2) {
+			} else if (isRegistered && client.config.general.roleCheckMode == "disable") {
 				const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
 				if (user.admin_disable && !user.disabled_date) {
 					await client.query.updateQuery('humans', { admin_disable: 0 }, { id: oldPresence.user.id })
@@ -32,13 +32,13 @@ module.exports = async (client, oldPresence, newPresence) => {
 		if (before && !after) {
 			const isRegistered = await client.query.countQuery('humans', { id: oldPresence.user.id })
 			if (isRegistered) {
-				if (client.config.general.roleCheckMode == 2) {
+				if (client.config.general.roleCheckMode == "disable") {
 					const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
 					if (!user.admin_disable) {
 						await client.query.updateQuery('humans', { admin_disable: 1 }, { id: oldPresence.user.id })
 						client.logs.discord.log({ level: 'info', message: `disabled ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
 					}
-				} else if (client.config.general.roleCheckMode == 1) {
+				} else if (client.config.general.roleCheckMode == "delete") {
 					await client.query.deleteQuery('egg', { id: oldPresence.user.id })
 					await client.query.deleteQuery('monsters', { id: oldPresence.user.id })
 					await client.query.deleteQuery('raid', { id: oldPresence.user.id })

--- a/src/lib/discord/commando/events/guildMemberUpdate.js
+++ b/src/lib/discord/commando/events/guildMemberUpdate.js
@@ -21,9 +21,9 @@ module.exports = async (client, oldPresence, newPresence) => {
 				}
 
 				client.logs.discord.log({ level: 'info', message: `registered ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
-			} else {
+			} else if (client.config.general.roleCheckDeletionsMode == 2) {
 			    const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
-			    if (user.admin_disable && client.config.discord.userDisableInstead) {
+			    if (user.admin_disable && !user.disabled_date) {
 			        await client.query.updateQuery('humans', { admin_disable: 0 }, { id: oldPresence.user.id })
 				    client.logs.discord.log({ level: 'info', message: `enabled ${oldPresence.user.username} because ${roleAfter.name} added`, event: 'discord:roleCheck' })
 			    }
@@ -32,17 +32,22 @@ module.exports = async (client, oldPresence, newPresence) => {
 		if (before && !after) {
 			const isRegistered = await client.query.countQuery('humans', { id: oldPresence.user.id })
 			if (isRegistered) {
-			    if (client.config.discord.userDisableInstead) {
-			        await client.query.updateQuery('humans', { admin_disable: 1 }, { id: oldPresence.user.id })
-                    client.logs.discord.log({ level: 'info', message: `disabled ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
-			    } else {
+			    if (client.config.general.roleCheckDeletionsMode == 2) {
+			        const user = await client.query.selectOneQuery('humans', { id: oldPresence.user.id })
+			        if (!user.admin_disable) {
+                        await client.query.updateQuery('humans', { admin_disable: 1 }, { id: oldPresence.user.id })
+                        client.logs.discord.log({ level: 'info', message: `disabled ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
+                    }
+			    } else if (client.config.general.roleCheckDeletionsMode == 1) {
                     await client.query.deleteQuery('egg', { id: oldPresence.user.id })
                     await client.query.deleteQuery('monsters', { id: oldPresence.user.id })
                     await client.query.deleteQuery('raid', { id: oldPresence.user.id })
                     await client.query.deleteQuery('quest', { id: oldPresence.user.id })
                     await client.query.deleteQuery('humans', { id: oldPresence.user.id })
                     client.logs.discord.log({ level: 'info', message: `unregistered ${oldPresence.user.username} because ${roleBefore.name} role removed`, event: 'discord:roleCheck' })
-			    }
+			    } else {
+                    client.logs.discord.log({ level: 'info', message: `${oldPresence.user.username} lost ${roleBefore.name} role but wasnt unregistered/disabled due to configuration`, event: 'discord:roleCheck' })
+                }
 			}
 		}
 	} catch (e) {

--- a/src/lib/poracleMessage/commands/disable.js
+++ b/src/lib/poracleMessage/commands/disable.js
@@ -22,7 +22,7 @@ exports.run = async (client, msg, args, options) => {
 		for (const id of targets) {
 			client.log.info(`Disable ${id}`)
 
-			await client.query.updateQuery('humans', { admin_disable: 1 }, { id })
+			await client.query.updateQuery('humans', { admin_disable: 1, disabled_date: new Date().toUTCString() }, { id })
 		}
 		await msg.react('✅')
 	} catch (err) {

--- a/src/lib/poracleMessage/commands/enable.js
+++ b/src/lib/poracleMessage/commands/enable.js
@@ -22,7 +22,7 @@ exports.run = async (client, msg, args, options) => {
 		for (const id of targets) {
 			client.log.info(`Enable ${id}`)
 
-			await client.query.updateQuery('humans', { admin_disable: 0 }, { id })
+			await client.query.updateQuery('humans', { admin_disable: 0, disabled_date: null }, { id })
 		}
 		await msg.react('✅')
 	} catch (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In case where user (and all of his settings) would get removed from database we will use `admin_disable` flag to switch his state. This way user configuration won't be deleted. Keep in mind that auto-register event will overwrite state of manually issued command `!disable`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removing user role by mistake might hurt his feelings :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wasn't! needs testers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.