### PR TITLE
March Quality of Life #7

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -210,7 +210,7 @@
         "#FF8000"
     ],
       "dmLogChannelID": "",                           // an ID of a channel to use to log all poracle commands to (to watch users)
-      "dmLogChannelDeletionTime": 0,                  // time to clean up after (seconds) - 0 do not delete
+      "dmLogChannelDeletionTime": 0,                  // time to clean up after (minutes) - 0 do not delete
       "messageDeleteDelay": 0,                        // extra time to add on to a message 'clean' to leave behind (in ms)
     // unrecognisedCommandMessage - message to reply to users who send an unrecognised command in DM
       "unrecognisedCommandMessage": "",

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -125,7 +125,7 @@ class Quest extends Controller {
 				return []
 			}
 
-			data.questString = await this.getQuest(data)
+			data.questStringEng = await this.getQuest(data)
 			data.rewardData = await this.getReward(data)
 			// this.log.error('[DEBUG] Quest : data.questString: '+data.questString)
 			// this.log.error('[DEBUG] Quest : data.rewardData: ', data.rewardData)
@@ -207,14 +207,21 @@ class Quest extends Controller {
 				const language = cares.language || this.config.general.locale
 				const translator = this.translatorFactory.Translator(language)
 
-				data.questString = translator.translate(data.questString)
+				data.questString = translator.translate(data.questStringEng)
 				data.monsterNames = Object.values(this.GameData.monsters).filter((mon) => data.monsters.includes(mon.id) && !mon.form.id).map((m) => translator.translate(m.name)).join(', ')
+				data.monsterNamesEng = Object.values(this.GameData.monsters).filter((mon) => data.monsters.includes(mon.id) && !mon.form.id).map((m) => m.name).join(', ')
 				data.itemNames = Object.keys(this.GameData.items).filter((item) => data.items.includes(item)).map((i) => translator.translate(this.GameData.items[i].name)).join(', ')
+				data.itemNamesEng = Object.keys(this.GameData.items).filter((item) => data.items.includes(item)).map((i) => this.GameData.items[i].name).join(', ')
 				data.energyMonstersNames = Object.values(this.GameData.monsters).filter((mon) => data.energyMonsters.includes(mon.id) && !mon.form.id).map((m) => translator.translate(m.name)).join(', ')
+				data.energyMonstersNamesEng = Object.values(this.GameData.monsters).filter((mon) => data.energyMonsters.includes(mon.id) && !mon.form.id).map((m) => m.name).join(', ')
 				data.rewardString = data.monsterNames
 				data.rewardString = data.dustAmount > 0 ? `${data.dustAmount} ${translator.translate('Stardust')}` : data.rewardString
 				data.rewardString = data.itemAmount > 0 ? `${data.itemAmount} ${data.itemNames}` : data.rewardString
 				data.rewardString = data.energyAmount > 0 ? `${data.energyAmount} ${data.energyMonstersNames} ${translator.translate('Mega Energy')}` : data.rewardString
+				data.rewardStringEng = data.monsterNames
+				data.rewardStringEng = data.dustAmount > 0 ? `${data.dustAmount} Stardust` : data.rewardStringEng
+				data.rewardStringEng = data.itemAmount > 0 ? `${data.itemAmount} ${data.itemNamesEng}` : data.rewardStringEng
+				data.rewardStringEng = data.energyAmount > 0 ? `${data.energyAmount} ${data.energyMonstersNamesEng} Mega Energy}` : data.rewardStringEng
 
 				const view = {
 					...geoResult,
@@ -292,7 +299,7 @@ class Quest extends Controller {
 		let pstr = ''
 		let gstr = ''
 		let raidLevel
-		if (item.quest_task) {
+		if (item.quest_task && !this.config.general.ignoreMADQuestString) {
 			str = item.quest_task
 		} else {
 			const questinfo = item.conditions[0] ? item.conditions[0].info : ''

--- a/src/lib/handlebars.js
+++ b/src/lib/handlebars.js
@@ -43,8 +43,10 @@ module.exports = () => {
 
 	handlebars.registerHelper('moveName', (value, options) => (moves[value] ? userTranslator(options).translate(moves[value].name) : ''))
 	handlebars.registerHelper('moveNameAlt', (value) => (moves[value] ? translatorAlt().translate(moves[value].name) : ''))
+	handlebars.registerHelper('moveNameEng', (value) => (moves[value] ? moves[value].name : ''))
 	handlebars.registerHelper('moveType', (value, options) => (moves[value] ? userTranslator(options).translate(moves[value].type) : ''))
 	handlebars.registerHelper('moveTypeAlt', (value) => (moves[value] ? translatorAlt().translate(moves[value].type) : ''))
+	handlebars.registerHelper('moveTypeEng', (value) => (moves[value] ? moves[value].type : ''))
 	handlebars.registerHelper('moveEmoji', (value, options) => {
 		if (!moves[value]) return ''
 		return types[moves[value].type] ? userTranslator(options).translate(types[moves[value].type].emoji) : ''
@@ -52,6 +54,10 @@ module.exports = () => {
 	handlebars.registerHelper('moveEmojiAlt', (value) => {
 		if (!moves[value]) return ''
 		return types[moves[value].type] ? translatorAlt.translate(types[moves[value].type].emoji) : ''
+	})
+	handlebars.registerHelper('moveEmojiEng', (value) => {
+		if (!moves[value]) return ''
+		return types[moves[value].type] ? types[moves[value].type].emoji : ''
 	})
 
 	handlebars.registerHelper('pokemonName', (value, options) => {
@@ -68,6 +74,13 @@ module.exports = () => {
 		return translatorAlt().translate(monster.name)
 	})
 
+	handlebars.registerHelper('pokemonNameEng', (value) => {
+		if (!+value) return ''
+		const monster = Object.values(monsters).find((m) => m.id === +value)
+		if (!monster) return ''
+		return monster.name
+	})
+
 	handlebars.registerHelper('pokemonForm', (value, options) => {
 		if (!+value) return ''
 		const monster = Object.values(monsters).find((m) => m.form.id === +value)
@@ -80,6 +93,13 @@ module.exports = () => {
 		const monster = Object.values(monsters).find((m) => m.form.id === +value)
 		if (!monster) return ''
 		return translatorAlt().translate(monster.form.name)
+	})
+
+	handlebars.registerHelper('pokemonFormEng', (value) => {
+		if (!+value) return ''
+		const monster = Object.values(monsters).find((m) => m.form.id === +value)
+		if (!monster) return ''
+		return monster.form.name
 	})
 
 	handlebars.registerHelper('translateAlt', (value) => {

--- a/src/lib/poracleMessage/commands/userlist.js
+++ b/src/lib/poracleMessage/commands/userlist.js
@@ -18,7 +18,15 @@ exports.run = async (client, msg, args, options) => {
 
 		await msg.react('✅')
 
-		const humans = await client.query.selectAllQuery('humans', {})
+		const filterString = {}
+		if (args[0] === 'disabled') {
+			filterString.admin_disable = 1
+		}
+		if (args[0] === 'enabled') {
+			filterString.admin_disable = 0
+		}
+
+		const humans = await client.query.selectAllQuery('humans', filterString)
 		let response = ''
 		for (const human of humans) {
 			if (human.type === 'webhook') {


### PR DESCRIPTION
Running out of these small changes, so we must be on target for a push to master at the end of the month.
1. `/userlist` extended for enabled/disabled as parameters to filter
2. Log channel gets a message when users get stopped (hit their final rate limit)
3. handlebars available as Eng as well as Alt (so pokemonNameEng for example)
4. quest details available as Eng too (questStringEng and rewardStringEng)
5. new 'hidden' config option config.general.ignoreMADQuestString - now there is a PR from Joddie to add the extra data to the poracle quest from MAD we can generate this content internally to match the format of the string we generate for RDM (this simplifies translation).  Opt in for this if you are testing the MAD PR -- it will become the default later
