### PR TITLE
Load DTS template from external file, allowing handlebars to be used as part of JSON definition

### DIFF
--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -199,7 +199,7 @@ class Weather extends Controller {
 						data.forecastTimeout = forecastTimeout
 						data.lastCurrentWeatherCheck = currentHourTimestamp
 					} catch (err) {
-						this.log.error(`${id}: Fetching AccuWeather weather info errored with: ${err}`)
+						this.log.error(`${id}: Fetching AccuWeather weather info [${apiKeyWeatherInfo.substring(0, 5)}...] errored with: ${err}`)
 					}
 				} else {
 					this.log.warn(`${id}: Couldn't fetch weather forecast - no API key available`)


### PR DESCRIPTION
DTS can now indicate that a template should be loaded from an external file using templateFile (instead of template)

```
	{
		"id": 1,
		"type": "monster",
		"default": true,
		"platform": "discord",
		"templateFile": "monster.txt"
	},
```

This will be based off the config path, and allows use of handlebars as part of the JSON data structure

The file will be a complete JSON object, as would have been present under the template heading, when processed

```
{
    "username": "{{name}}",
    "avatar_url": "{{{imgUrl}}}",
    "content": "This is a Poracle alert",
    "embed": {
        "color": "{{ivColor}}",
        "title": "...",
        "fields": [
        {{#if form}}
            {
                "name": "...",
                "value": "..."
            },
        {{/if}}
            {
                "name": "‎...",
                "value": "‎..."
            }
        ],
        "thumbnail": {
            "url": "{{{imgUrl}}}"
        },
        "image": {
            "url": "{{{staticmap}}}"
        }
    }
}```