### PR TITLE
Improve tracking reporting, pokemon alias

### DIFF
--- a/config/defaults/pokemonAlias.json
+++ b/config/defaults/pokemonAlias.json
@@ -1,0 +1,26 @@
+{
+  "laketrio": [
+    479,
+    480,
+    481
+  ],
+  "nidoran f": 29,
+  "nidoran-f": 29,
+  "nidoran female": 29,
+  "nidoran m": 32,
+  "nidoran-m": 32,
+  "nidoran male": 32,
+  "farfetchd": 83,
+  "sirfetchd": 865,
+  "sirfetch'd": 865,
+  "mrmime": 122,
+  "mr mime": 122,
+  "mrrime": 866,
+  "mr rime": 866,
+  "mime jr": 439,
+  "minejr": 439,
+  "hooh": 250,
+  "ho oh": 250,
+  "porygonz": 474,
+  "porygon2": 233
+}

--- a/config/defaults/pokemonAlias.json
+++ b/config/defaults/pokemonAlias.json
@@ -18,7 +18,7 @@
   "mrrime": 866,
   "mr rime": 866,
   "mime jr": 439,
-  "minejr": 439,
+  "mimejr": 439,
   "hooh": 250,
   "ho oh": 250,
   "porygonz": 474,

--- a/config/locale/fr.json
+++ b/config/locale/fr.json
@@ -509,5 +509,11 @@
 	"Valid commands are e.g. `{0}untrack charmander`, `{0}untrack everything`":"Les commandes valides sont par exemple `{0}ignorer reptincel`, `{0}ignorer tous`",
 	"The {0}{1} command is used to stop all alert messages, is that what you want?":"La commande {0}{1} est utilisée pour arrêter toutes vos alertes, est-ce bien ce que vous voulez ?",
 	"All alert messages have been stopped, you can resume them with {0}{1}":"Toutes vos alertes sont arrêtées, vous pouvez les réactiver avec {0}{1}",
-	"You can start receiving alerts again using {0}{1}":"Vous pouvez réactiver vos alertes avec {0}{1}"
+	"You can start receiving alerts again using {0}{1}":"Vous pouvez réactiver vos alertes avec {0}{1}",
+	"Unchanged: ": "Non modifié: ",
+	"Updated: ": "Modifié: ",
+	"New: ": "Nouveau: ",
+	"I removed 1 entry": "J'ai retiré 1 entrée",
+	"I removed {0} entries": "J'ai retiré {0} entrées",
+	"use `{0}{1}` to see what you are currently tracking": "utiliser {0}{1} pour voir vos suivis configurés"
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/KartulUdus/reference#readme",
   "dependencies": {
-    "node-schedule": "^2.0.0",
     "async-mutex": "^0.3.0",
     "axios": "^0.21.1",
     "config": "^3.3.3",
@@ -54,6 +53,7 @@
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.1",
     "node-geocoder": "^3.27.0",
+    "node-schedule": "^2.0.0",
     "nodes2ts": "^2.0.0",
     "pg": "^8.5.1",
     "pogo-protos": "git+https://github.com/Furtif/pogo-protos.git",

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -168,6 +168,7 @@ class Raid extends Controller {
 			}
 			data.teamId = data.team_id ? data.team_id : 0
 			data.teamName = data.team_id ? this.GameData.utilData.teams[data.team_id].name : 'Harmony'
+			data.teamEmoji = data.team_id ? this.GameData.utilData.teams[data.team_id].emoji : ''
 			data.gymColor = data.team_id ? this.GameData.utilData.teams[data.team_id].color : 'BABABA'
 			data.ex = !!(data.ex_raid_eligible || data.is_ex_raid_eligible)
 			data.gymUrl = data.gym_url ? data.gym_url : ''

--- a/src/lib/configFileCreator.js
+++ b/src/lib/configFileCreator.js
@@ -10,9 +10,12 @@ module.exports = () => {
 		const defaultDtsConfig = fs.readFileSync(path.join(__dirname, '../../config/defaults/dts.json'), 'utf8')
 		fs.writeFileSync(path.join(__dirname, '../../config/dts.json'), defaultDtsConfig)
 	}
-
 	if (!fs.existsSync(path.join(__dirname, '../../config/geofence.json'))) {
 		const defaultGeofConfig = fs.readFileSync(path.join(__dirname, '../../config/defaults/geofence.json'), 'utf8')
 		fs.writeFileSync(path.join(__dirname, '../../config/geofence.json'), defaultGeofConfig)
+	}
+	if (!fs.existsSync(path.join(__dirname, '../../config/pokemonAlias.json'))) {
+		const defaultGeofConfig = fs.readFileSync(path.join(__dirname, '../../config/defaults/pokemonAlias.json'), 'utf8')
+		fs.writeFileSync(path.join(__dirname, '../../config/pokemonAlias.json'), defaultGeofConfig)
 	}
 }

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -47,7 +47,7 @@ exports.run = async (client, msg, [args]) => {
 		}
 
 		// Remove arguments that we don't want to keep
-		for (let i = 0; i < args.length; i++) {
+		for (let i = args.length - 1; i >= 0; i--) {
 			if (args[i].match(client.re.guildRe)) args.splice(i, 1)
 		}
 

--- a/src/lib/objectDiff.js
+++ b/src/lib/objectDiff.js
@@ -1,0 +1,29 @@
+// https://stackoverflow.com/questions/33232823/how-to-compare-two-objects-and-get-key-value-pairs-of-their-differences
+// modified to allow type coercion
+
+const empty =	{}
+
+const isObject = (x) => Object(x) === x
+
+const diff1 = (left = {}, right = {}, rel = 'left') => Object.entries(left)
+	// eslint-disable-next-line no-nested-ternary
+	.map(([k, v]) => (isObject(v) && isObject(right[k])
+		? [k, diff1(v, right[k], rel)]
+		: right[k] != v
+			? [k, { [rel]: v }]
+			: [k, empty]))
+	.reduce((acc, [k, v]) => (v === empty
+		? acc
+		: { ...acc, [k]: v }),
+	empty)
+
+const merge = (left = {}, right = {}) => Object.entries(right)
+	.reduce((acc, [k, v]) => (isObject(v) && isObject(left[k])
+		? { ...acc, [k]: merge(left[k], v) }
+		: { ...acc, [k]: v }),
+	left)
+
+const diff = (x = {}, y = {}) => merge(diff1(x, y, 'left'),
+	diff1(y, x, 'right'))
+
+module.exports = { diff }

--- a/src/lib/poracleMessage/commands/area.js
+++ b/src/lib/poracleMessage/commands/area.js
@@ -25,7 +25,7 @@ exports.run = async (client, msg, args, options) => {
 		const confUse = confAreas2.join('\n')
 
 		// Remove arguments that we don't want to keep for area processing
-		for (let i = 0; i < args.length; i++) {
+		for (let i = args.length - 1; i >= 0; i--) {
 			if (args[i].match(client.re.nameRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.channelRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.userRe)) args.splice(i, 1)
@@ -77,12 +77,16 @@ exports.run = async (client, msg, args, options) => {
 				await msg.reply(`${translator.translate('Current configured areas are:')}\n\`\`\`\n${confUse}\`\`\` `, { style: 'markdown' })
 				break
 			}
-			default:
+			default: {
+				const human = await client.query.selectOneQuery('humans', { id: target.id })
+				await msg.reply(`${translator.translate('You are currently set to receive alarms in')} ${human.area}`)
+
 				await msg.reply(translator.translateFormat('Valid commands are `{0}area list`, `{0}area add <areaname>`, `{0}area remove <areaname>`', util.prefix),
 					{ style: 'markdown' })
 				await helpCommand.provideSingleLineHelp(client, msg, util, language, target, commandName)
 
 				break
+			}
 		}
 	} catch (err) {
 		client.log.error(`area command ${msg.content} unhappy:`, err)

--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -159,7 +159,15 @@ exports.run = async (client, msg, args, options) => {
 				client.log.info(`${logReference}: ${target.name} stopped tracking all eggs`)
 				result += everythingResult
 			}
-			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+			msg.reply(
+				''.concat(
+					result == 1 ? translator.translate('I removed 1 entry')
+						: translator.translateFormat('I removed {0} entries', result),
+					', ',
+					translator.translateFormat('use `{0}{1}` to see what you are currently tracking', util.prefix, translator.translate('tracked')),
+				),
+				{ style: 'markdown' },
+			)
 			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 

--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -3,6 +3,8 @@ const trackedCommand = require('./tracked.js')
 const objectDiff = require('../../objectDiff')
 
 exports.run = async (client, msg, args, options) => {
+	const logReference = Math.random().toString().slice(2, 11)
+
 	try {
 		const util = client.createUtil(msg, options)
 
@@ -12,7 +14,7 @@ exports.run = async (client, msg, args, options) => {
 
 		if (!canContinue) return
 		const commandName = __filename.slice(__dirname.length + 1, -3)
-		client.log.info(`${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
+		client.log.info(`${logReference}: ${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
 
 		if (args[0] === 'help') {
 			return helpCommand.run(client, msg, [commandName], options)
@@ -136,7 +138,7 @@ exports.run = async (client, msg, args, options) => {
 				await client.query.updateQuery('egg', row, { uid: row.uid })
 			}
 
-			client.log.info(`${target.name} started tracking level ${levels.join(', ')} eggs`)
+			client.log.info(`${logReference}: ${target.name} started tracking level ${levels.join(', ')} eggs`)
 			await msg.reply(message)
 			reaction = insert.length ? '✅' : reaction
 		} else {
@@ -146,7 +148,7 @@ exports.run = async (client, msg, args, options) => {
 					id: target.id,
 					profile_no: currentProfileNo,
 				}, levels, 'level')
-				client.log.info(`${target.name} stopped tracking level ${levels.join(', ')} eggs`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking level ${levels.join(', ')} eggs`)
 				result += lvlResult
 			}
 			if (commandEverything) {
@@ -154,14 +156,16 @@ exports.run = async (client, msg, args, options) => {
 					id: target.id,
 					profile_no: currentProfileNo,
 				})
-				client.log.info(`${target.name} stopped tracking all eggs`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking all eggs`)
 				result += everythingResult
 			}
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
+			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 
 		await msg.react(reaction)
 	} catch (err) {
-		client.log.error('egg command unhappy:', err)
+		client.log.error(`${logReference}: egg command unhappy:`, err)
+		msg.reply(`There was a problem making these changes, the administrator can find the details with reference ${logReference}`)
 	}
 }

--- a/src/lib/poracleMessage/commands/invasion.js
+++ b/src/lib/poracleMessage/commands/invasion.js
@@ -1,6 +1,10 @@
 const helpCommand = require('./help.js')
+const trackedCommand = require('./tracked.js')
+const objectDiff = require('../../objectDiff')
 
 exports.run = async (client, msg, args, options) => {
+	const logReference = Math.random().toString().slice(2, 11)
+
 	try {
 		// Check target
 		const util = client.createUtil(msg, options)
@@ -11,7 +15,7 @@ exports.run = async (client, msg, args, options) => {
 
 		if (!canContinue) return
 		const commandName = __filename.slice(__dirname.length + 1, -3)
-		client.log.info(`${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
+		client.log.info(`${logReference}: ${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
 
 		if (args[0] === 'help') {
 			return helpCommand.run(client, msg, [commandName], options)
@@ -35,7 +39,7 @@ exports.run = async (client, msg, args, options) => {
 		let template = client.config.general.defaultTemplateName
 		let gender = 0
 		let clean = false
-		const types = args.filter((arg) => typeArray.includes(arg))
+		const types = [] // args.filter((arg) => typeArray.includes(arg))
 		const pings = msg.getPings()
 
 		for (const element of args) {
@@ -65,7 +69,7 @@ exports.run = async (client, msg, args, options) => {
 		}
 
 		if (!remove) {
-			const insertData = types.map((o) => ({
+			const insert = types.map((o) => ({
 				id: target.id,
 				profile_no: currentProfileNo,
 				ping: pings,
@@ -75,27 +79,84 @@ exports.run = async (client, msg, args, options) => {
 				clean,
 				grunt_type: o,
 			}))
-			const result = await client.query.insertOrUpdateQuery('invasion', insertData)
-			client.log.info(`${target.name} started tracking ${types.join(', ')} invasions`)
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
+
+			const tracked = await client.query.selectAllQuery('invasion', { id: target.id, profile_no: currentProfileNo })
+			const updates = []
+			const alreadyPresent = []
+
+			for (let i = insert.length - 1; i >= 0; i--) {
+				const toInsert = insert[i]
+
+				for (const existing of tracked.filter((x) => x.grunt_type == toInsert.grunt_type)) {
+					const differences = objectDiff.diff(existing, toInsert)
+
+					switch (Object.keys(differences).length) {
+						case 1:		// No differences (only UID)
+							// No need to insert
+							alreadyPresent.push(toInsert)
+							insert.splice(i, 1)
+							break
+						case 2:		// One difference (something + uid)
+							if (Object.keys(differences).some((x) => ['distance', 'template', 'clean'].includes(x))) {
+								updates.push({
+									...toInsert,
+									uid: existing.uid,
+								})
+								insert.splice(i, 1)
+							}
+							break
+						default:	// more differences
+							break
+					}
+				}
+			}
+
+			let message = ''
+
+			if ((alreadyPresent.length + updates.length + insert.length) > 50) {
+				message = translator.translateFormat('I have made a lot of changes. See {0}{1} for details', util.prefix, translator.translate('tracked'))
+			} else {
+				alreadyPresent.forEach((invasion) => {
+					message = message.concat(translator.translate('Unchanged: '), trackedCommand.invasionRowText(translator, client.GameData, invasion), '\n')
+				})
+				updates.forEach((invasion) => {
+					message = message.concat(translator.translate('Updated: '), trackedCommand.invasionRowText(translator, client.GameData, invasion), '\n')
+				})
+				insert.forEach((invasion) => {
+					message = message.concat(translator.translate('New: '), trackedCommand.invasionRowText(translator, client.GameData, invasion), '\n')
+				})
+			}
+
+			await client.query.insertQuery('invasion', insert)
+			for (const row of updates) {
+				await client.query.updateQuery('invasion', row, { uid: row.uid })
+			}
+
+			client.log.info(`${logReference}: ${target.name} started tracking ${types.join(', ')} invasions`)
+			await msg.reply(message)
+			reaction = insert.length ? '✅' : reaction
 		} else {
 			let result = 0
 			if (commandEverything) {
 				result = await client.query.deleteQuery('invasion', { id: target.id, profile_no: currentProfileNo })
-				client.log.info(`${target.name} stopped tracking all invasions`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking all invasions`)
 			} else {
-				result = client.query.deleteWhereInQuery('invasion', {
+				result = await client.query.deleteWhereInQuery('invasion', {
 					id: target.id,
 					profile_no: currentProfileNo,
 				}, types, 'grunt_type')
 				client.log.info(`${target.name} stopped tracking ${types.join(', ')} invasions`)
 			}
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
-			client.log.info(`${target.name} deleted ${types.join(', ')} invasions`)
+
+			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+
+			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
+			client.log.info(`${logReference}: ${target.name} deleted ${types.join(', ')} invasions`)
 		}
 
 		await msg.react(reaction)
 	} catch (err) {
-		client.log.error('invasion command unhappy:', err)
+		client.log.error(`${logReference}: invasion command unhappy:`, err)
+		msg.reply(`There was a problem making these changes, the administrator can find the details with reference ${logReference}`)
 	}
 }

--- a/src/lib/poracleMessage/commands/invasion.js
+++ b/src/lib/poracleMessage/commands/invasion.js
@@ -148,8 +148,15 @@ exports.run = async (client, msg, args, options) => {
 				client.log.info(`${target.name} stopped tracking ${types.join(', ')} invasions`)
 			}
 
-			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
-
+			msg.reply(
+				''.concat(
+					result == 1 ? translator.translate('I removed 1 entry')
+						: translator.translateFormat('I removed {0} entries', result),
+					', ',
+					translator.translateFormat('use `{0}{1}` to see what you are currently tracking', util.prefix, translator.translate('tracked')),
+				),
+				{ style: 'markdown' },
+			)
 			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 			client.log.info(`${logReference}: ${target.name} deleted ${types.join(', ')} invasions`)
 		}

--- a/src/lib/poracleMessage/commands/language.js
+++ b/src/lib/poracleMessage/commands/language.js
@@ -13,7 +13,7 @@ exports.run = async (client, msg, args, options) => {
 		const translator = client.translatorFactory.Translator(language)
 
 		// Remove arguments that we don't want to keep for processing
-		for (let i = 0; i < args.length; i++) {
+		for (let i = args.length - 1; i >= 0; i--) {
 			if (args[i].match(client.re.nameRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.channelRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.userRe)) args.splice(i, 1)

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -30,7 +30,7 @@ exports.run = async (client, msg, args, options) => {
 		if (platform === 'webhook') platform = 'discord'
 
 		// Remove arguments that we don't want to keep for area processing
-		for (let i = 0; i < args.length; i++) {
+		for (let i = args.length - 1; i >= 0; i--) {
 			if (args[i].match(client.re.nameRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.channelRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.userRe)) args.splice(i, 1)

--- a/src/lib/poracleMessage/commands/lure.js
+++ b/src/lib/poracleMessage/commands/lure.js
@@ -1,6 +1,10 @@
 const helpCommand = require('./help.js')
+const trackedCommand = require('./tracked.js')
+const objectDiff = require('../../objectDiff')
 
 exports.run = async (client, msg, args, options) => {
+	const logReference = Math.random().toString().slice(2, 11)
+
 	try {
 		const util = client.createUtil(msg, options)
 
@@ -10,7 +14,7 @@ exports.run = async (client, msg, args, options) => {
 
 		if (!canContinue) return
 		const commandName = __filename.slice(__dirname.length + 1, -3)
-		client.log.info(`${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
+		client.log.info(`${logReference}: ${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
 
 		if (args[0] === 'help') {
 			return helpCommand.run(client, msg, [commandName], options)
@@ -76,10 +80,61 @@ exports.run = async (client, msg, args, options) => {
 				lure_id: lureId,
 			}))
 
-			const result = await client.query.insertOrUpdateQuery('lures', insert)
-			client.log.info(`${target.name} started tracking lures ${lures.join(', ')}`)
+			const tracked = await client.query.selectAllQuery('lures', { id: target.id, profile_no: currentProfileNo })
+			const updates = []
+			const alreadyPresent = []
 
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
+			for (let i = insert.length - 1; i >= 0; i--) {
+				const toInsert = insert[i]
+
+				for (const existing of tracked.filter((x) => x.lure_id == toInsert.lure_id)) {
+					const differences = objectDiff.diff(existing, toInsert)
+
+					switch (Object.keys(differences).length) {
+						case 1:		// No differences (only UID)
+							// No need to insert
+							alreadyPresent.push(toInsert)
+							insert.splice(i, 1)
+							break
+						case 2:		// One difference (something + uid)
+							if (Object.keys(differences).some((x) => ['distance', 'template', 'clean'].includes(x))) {
+								updates.push({
+									...toInsert,
+									uid: existing.uid,
+								})
+								insert.splice(i, 1)
+							}
+							break
+						default:	// more differences
+							break
+					}
+				}
+			}
+
+			let message = ''
+
+			if ((alreadyPresent.length + updates.length + insert.length) > 50) {
+				message = translator.translateFormat('I have made a lot of changes. See {0}{1} for details', util.prefix, translator.translate('tracked'))
+			} else {
+				alreadyPresent.forEach((lure) => {
+					message = message.concat(translator.translate('Unchanged: '), trackedCommand.lureRowText(translator, client.GameData, lure), '\n')
+				})
+				updates.forEach((lure) => {
+					message = message.concat(translator.translate('Updated: '), trackedCommand.lureRowText(translator, client.GameData, lure), '\n')
+				})
+				insert.forEach((lure) => {
+					message = message.concat(translator.translate('New: '), trackedCommand.lureRowText(translator, client.GameData, lure), '\n')
+				})
+			}
+
+			await client.query.insertQuery('lures', insert)
+			for (const row of updates) {
+				await client.query.updateQuery('lures', row, { uid: row.uid })
+			}
+			client.log.info(`${logReference}: ${target.name} started tracking lures ${lures.join(', ')}`)
+			await msg.reply(message)
+
+			reaction = insert.length ? '✅' : reaction
 		} else {
 			let result = 0
 			if (lures.length) {
@@ -87,7 +142,7 @@ exports.run = async (client, msg, args, options) => {
 					id: target.id,
 					profile_no: currentProfileNo,
 				}, lures, 'lure_id')
-				client.log.info(`${target.name} stopped tracking lures ${lures.join(', ')}`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking lures ${lures.join(', ')}`)
 				result += lvlResult
 			}
 			if (commandEverything) {
@@ -95,14 +150,18 @@ exports.run = async (client, msg, args, options) => {
 					id: target.id,
 					profile_no: currentProfileNo,
 				})
-				client.log.info(`${target.name} stopped tracking all lures`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking all lures`)
 				result += everythingResult
 			}
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
+
+			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+
+			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 
 		await msg.react(reaction)
 	} catch (err) {
-		client.log.error('lure command unhappy:', err)
+		client.log.error(`${logReference}: lure command unhappy:`, err)
+		msg.reply(`There was a problem making these changes, the administrator can find the details with reference ${logReference}`)
 	}
 }

--- a/src/lib/poracleMessage/commands/lure.js
+++ b/src/lib/poracleMessage/commands/lure.js
@@ -154,7 +154,15 @@ exports.run = async (client, msg, args, options) => {
 				result += everythingResult
 			}
 
-			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+			msg.reply(
+				''.concat(
+					result == 1 ? translator.translate('I removed 1 entry')
+						: translator.translateFormat('I removed {0} entries', result),
+					', ',
+					translator.translateFormat('use `{0}{1}` to see what you are currently tracking', util.prefix, translator.translate('tracked')),
+				),
+				{ style: 'markdown' },
+			)
 
 			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}

--- a/src/lib/poracleMessage/commands/profile.js
+++ b/src/lib/poracleMessage/commands/profile.js
@@ -22,7 +22,7 @@ exports.run = async (client, msg, args, options) => {
 		const profiles = await client.query.selectAllQuery('profiles', { id: target.id })
 
 		// Remove arguments that we don't want to keep for area processing
-		for (let i = 0; i < args.length; i++) {
+		for (let i = args.length - 1; i >= 0; i--) {
 			if (args[i].match(client.re.nameRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.channelRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.userRe)) args.splice(i, 1)
@@ -155,11 +155,11 @@ exports.run = async (client, msg, args, options) => {
 							const dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 
 							for (const t of times) {
-								timeString = timeString.concat(`    ${translator.translate(dayNames[t.day - 1])} ${t.hours}:${t.mins}\n`)
+								timeString = timeString.concat(`    ${translator.translate(dayNames[t.day - 1])} ${t.hours}:${`00${t.mins}`.slice(-2)}\n`)
 							}
 						}
 
-						response = response.concat(`${profile.profile_no}. ${profile.name}${profile.area != '[]' ? ` - ${translator.translate('areas')}: ${profile.area}` : ''}${profile.latitude ? ` - ${translator.translate('location')}: ${profile.latitude},${profile.longitude}` : ''}\n${timeString}`)
+						response = response.concat(`${profile.profile_no}${profile.profile_no == currentProfileNo ? '*' : '.'} ${profile.name}${profile.area != '[]' ? ` - ${translator.translate('areas')}: ${profile.area}` : ''}${profile.latitude ? ` - ${translator.translate('location')}: ${profile.latitude.toFixed(5)},${profile.longitude.toFixed(5)}` : ''}\n${timeString}`)
 					}
 					await msg.reply(`${translator.translate('Currently configured profiles are:')}\n${response}`)
 				}

--- a/src/lib/poracleMessage/commands/quest.js
+++ b/src/lib/poracleMessage/commands/quest.js
@@ -250,8 +250,15 @@ exports.run = async (client, msg, args, options) => {
 
 			result = result ? result.affectedRows : 0
 
-			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
-
+			msg.reply(
+				''.concat(
+					result == 1 ? translator.translate('I removed 1 entry')
+						: translator.translateFormat('I removed {0} entries', result),
+					', ',
+					translator.translateFormat('use `{0}{1}` to see what you are currently tracking', util.prefix, translator.translate('tracked')),
+				),
+				{ style: 'markdown' },
+			)
 			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 		await msg.react(reaction)

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -48,6 +48,16 @@ exports.run = async (client, msg, args, options) => {
 		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase())
 		const argTypes = args.filter((arg) => typeArray.includes(arg))
 
+		// Substitute aliases
+		const pokemonAlias = require('../../../../config/pokemonAlias.json')
+		for (let i = args.length - 1; i >= 0; i--) {
+			let alias = pokemonAlias[args]
+			if (alias) {
+				if (!Array.isArray(alias)) alias = [alias]
+				args.splice(i, 1, ...alias.map((x) => x.toString()))
+			}
+		}
+
 		if (formNames.length) {
 			monsters = Object.values(client.GameData.monsters).filter((mon) => (
 				(args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString()))

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -214,7 +214,8 @@ exports.run = async (client, msg, args, options) => {
 				client.log.info(`${logReference}: ${target.name} stopped tracking all raids`)
 				result += everythingResult
 			}
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
+			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 		await msg.react(reaction)
 	} catch (err) {

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -1,6 +1,10 @@
 const helpCommand = require('./help.js')
+const trackedCommand = require('./tracked.js')
+const objectDiff = require('../../objectDiff')
 
 exports.run = async (client, msg, args, options) => {
+	const logReference = Math.random().toString().slice(2, 11)
+
 	try {
 		// Check target
 		const util = client.createUtil(msg, options)
@@ -11,7 +15,7 @@ exports.run = async (client, msg, args, options) => {
 
 		if (!canContinue) return
 		const commandName = __filename.slice(__dirname.length + 1, -3)
-		client.log.info(`${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
+		client.log.info(`${logReference}: ${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
 
 		if (args[0] === 'help') {
 			return helpCommand.run(client, msg, [commandName], options)
@@ -121,9 +125,62 @@ exports.run = async (client, msg, args, options) => {
 				})
 			})
 
-			const result = await client.query.insertOrUpdateQuery('raid', insert)
-			client.log.info(`${target.name} started tracking level ${levels.join(', ')} raids`)
-			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
+			const tracked = await client.query.selectAllQuery('raid', { id: target.id, profile_no: currentProfileNo })
+			const updates = []
+			const alreadyPresent = []
+
+			for (let i = insert.length - 1; i >= 0; i--) {
+				const toInsert = insert[i]
+
+				for (const existing of tracked.filter((x) => x.pokemon_id == toInsert.pokemon_id && x.level == toInsert.level)) {
+					const differences = objectDiff.diff(existing, toInsert)
+
+					switch (Object.keys(differences).length) {
+						case 1:		// No differences (only UID)
+							// No need to insert
+							alreadyPresent.push(toInsert)
+							insert.splice(i, 1)
+							break
+						case 2:		// One difference (something + uid)
+							if (Object.keys(differences).some((x) => ['distance', 'template', 'clean'].includes(x))) {
+								updates.push({
+									...toInsert,
+									uid: existing.uid,
+								})
+								insert.splice(i, 1)
+							}
+							break
+						default:	// more differences
+							break
+					}
+				}
+			}
+
+			let message = ''
+
+			if ((alreadyPresent.length + updates.length + insert.length) > 50) {
+				message = translator.translateFormat('I have made a lot of changes. See {0}{1} for details', util.prefix, translator.translate('tracked'))
+			} else {
+				alreadyPresent.forEach((raid) => {
+					message = message.concat(translator.translate('Unchanged: '), trackedCommand.raidRowText(translator, client.GameData, raid), '\n')
+				})
+				updates.forEach((raid) => {
+					message = message.concat(translator.translate('Updated: '), trackedCommand.raidRowText(translator, client.GameData, raid), '\n')
+				})
+				insert.forEach((raid) => {
+					message = message.concat(translator.translate('New: '), trackedCommand.raidRowText(translator, client.GameData, raid), '\n')
+				})
+			}
+
+			await client.query.insertQuery('raid', insert)
+			for (const row of updates) {
+				await client.query.updateQuery('raid', row, { uid: row.uid })
+			}
+
+			//			const result = await client.query.insertOrUpdateQuery('raid', insert)
+			client.log.info(`${logReference}: ${target.name} started tracking level ${levels.join(', ')} raids`)
+			await msg.reply(message)
+			reaction = insert.length ? '✅' : reaction
 		} else {
 			const monsterIds = monsters.map((mon) => mon.id)
 			let result = 0
@@ -139,18 +196,19 @@ exports.run = async (client, msg, args, options) => {
 					id: target.id,
 					profile_no: currentProfileNo,
 				}, levels, 'level')
-				client.log.info(`${target.name} stopped tracking level ${levels.join(', ')} raids`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking level ${levels.join(', ')} raids`)
 				result += lvlResult
 			}
 			if (commandEverything) {
 				const everythingResult = await client.query.deleteQuery('raid', { id: target.id, profile_no: currentProfileNo })
-				client.log.info(`${target.name} stopped tracking all raids`)
+				client.log.info(`${logReference}: ${target.name} stopped tracking all raids`)
 				result += everythingResult
 			}
 			reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 		await msg.react(reaction)
 	} catch (err) {
-		client.log.error('raid command unhappy:', err)
+		client.log.error(`${logReference} Raid command unhappy:`, err)
+		msg.reply(`There was a problem making these changes, the administrator can find the details with reference ${logReference}`)
 	}
 }

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -214,7 +214,15 @@ exports.run = async (client, msg, args, options) => {
 				client.log.info(`${logReference}: ${target.name} stopped tracking all raids`)
 				result += everythingResult
 			}
-			msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+			msg.reply(
+				''.concat(
+					result == 1 ? translator.translate('I removed 1 entry')
+						: translator.translateFormat('I removed {0} entries', result),
+					', ',
+					translator.translateFormat('use `{0}{1}` to see what you are currently tracking', util.prefix, translator.translate('tracked')),
+				),
+				{ style: 'markdown' },
+			)
 			reaction = result || client.config.database.client === 'sqlite' ? '✅' : reaction
 		}
 		await msg.react(reaction)

--- a/src/lib/poracleMessage/commands/stop.js
+++ b/src/lib/poracleMessage/commands/stop.js
@@ -19,7 +19,7 @@ exports.run = async (client, msg, args, options) => {
 		const translator = client.translatorFactory.Translator(language)
 
 		// Remove arguments that are part of overrides
-		for (let i = 0; i < args.length; i++) {
+		for (let i = args.length - 1; i >= 0; i--) {
 			if (args[i].match(client.re.nameRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.channelRe)) args.splice(i, 1)
 			else if (args[i].match(client.re.userRe)) args.splice(i, 1)

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -1,6 +1,10 @@
 const helpCommand = require('./help.js')
+const trackedCommand = require('./tracked.js')
+const objectDiff = require('../../objectDiff')
 
 exports.run = async (client, msg, args, options) => {
+	const logReference = Math.random().toString().slice(2, 11)
+
 	try {
 		const util = client.createUtil(msg, options)
 
@@ -10,7 +14,7 @@ exports.run = async (client, msg, args, options) => {
 
 		if (!canContinue) return
 		const commandName = __filename.slice(__dirname.length + 1, -3)
-		client.log.info(`${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
+		client.log.info(`${logReference} ${target.name}/${target.type}-${target.id}: ${commandName} ${args}`)
 
 		if (args[0] === 'help') {
 			return helpCommand.run(client, msg, [commandName], options)
@@ -243,14 +247,67 @@ exports.run = async (client, msg, args, options) => {
 		if (!insert.length) {
 			return await msg.reply(translator.translate('404 No monsters found'))
 		}
-		const result = await client.query.insertOrUpdateQuery('monsters', insert)
-		reaction = result.length || client.config.database.client === 'sqlite' ? '✅' : reaction
-		client.log.info(`${target.name} started tracking monsters: ${monsters.map((m) => m.name).join(', ')}`)
 
-		// }
+		const tracked = await client.query.selectAllQuery('monsters', { id: target.id, profile_no: currentProfileNo })
+		const updates = []
+		const alreadyPresent = []
 
+		for (let i = insert.length - 1; i >= 0; i--) {
+			const toInsert = insert[i]
+
+			for (const existing of tracked.filter((x) => x.pokemon_id == toInsert.pokemon_id)) {
+				const differences = objectDiff.diff(existing, toInsert)
+
+				switch (Object.keys(differences).length) {
+					case 1:		// No differences (only UID)
+						// No need to insert
+						alreadyPresent.push(toInsert)
+						insert.splice(i, 1)
+						break
+					case 2:		// One difference (something + uid)
+						if (Object.keys(differences).some((x) => ['min_iv', 'distance', 'template', 'clean'].includes(x))) {
+							updates.push({
+								...toInsert,
+								uid: existing.uid,
+							})
+							insert.splice(i, 1)
+						}
+						break
+					default:	// more differences
+						break
+				}
+			}
+		}
+
+		let message = ''
+
+		if ((alreadyPresent.length + updates.length + insert.length) > 50) {
+			message = translator.translateFormat('I have made a lot of changes. See {0}{1} for details', util.prefix, translator.translate('tracked'))
+		} else {
+			alreadyPresent.forEach((monster) => {
+				message = message.concat(translator.translate('Unchanged: '), trackedCommand.monsterRowText(translator, client.GameData, monster), '\n')
+			})
+			updates.forEach((monster) => {
+				message = message.concat(translator.translate('Updated: '), trackedCommand.monsterRowText(translator, client.GameData, monster), '\n')
+			})
+			insert.forEach((monster) => {
+				message = message.concat(translator.translate('New: '), trackedCommand.monsterRowText(translator, client.GameData, monster), '\n')
+			})
+		}
+
+		await client.query.insertQuery('monsters', insert)
+		for (const row of updates) {
+			await client.query.updateQuery('monsters', row, { uid: row.uid })
+		}
+
+		// const result = await client.query.insertOrUpdateQuery('monsters', insert)
+		reaction = insert.length ? '✅' : reaction
+		await msg.reply(message)
 		await msg.react(reaction)
+
+		client.log.info(`${logReference} ${target.name} started tracking monsters: ${monsters.map((m) => m.name).join(', ')}`)
 	} catch (err) {
-		client.log.error('Track command unhappy:', err)
+		client.log.error(`${logReference} Track command unhappy:`, err)
+		msg.reply(`There was a problem making these changes, the administrator can find the details with reference ${logReference}`)
 	}
 }

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -94,6 +94,16 @@ exports.run = async (client, msg, args, options) => {
 			}
 		}
 
+		// Substitute aliases
+		const pokemonAlias = require('../../../../config/pokemonAlias.json')
+		for (let i = args.length - 1; i >= 0; i--) {
+			let alias = pokemonAlias[args]
+			if (alias) {
+				if (!Array.isArray(alias)) alias = [alias]
+				args.splice(i, 1, ...alias.map((x) => x.toString()))
+			}
+		}
+
 		// Check for monsters or forms
 		const formArgs = args.filter((arg) => arg.match(client.re.formRe))
 		const formNames = formArgs ? formArgs.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase()) : []

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -69,10 +69,44 @@ function questRowText(translator, GameData, quest) {
 	return `${translator.translate('reward').charAt(0).toUpperCase() + translator.translate('reward').slice(1)}: **${rewardThing}**${quest.distance ? ` | ${translator.translate('distance')}: ${quest.distance}m` : ''}`
 }
 
+function invasionRowText(translator, GameData, invasion) {
+	let genderText = ''
+	let typeText = ''
+	if (!invasion.gender || invasion.gender === '') {
+		genderText = translator.translate('any')
+	} else if (invasion.gender === 1) {
+		genderText = translator.translate('male')
+	} else if (invasion.gender === 2) {
+		genderText = translator.translate('female')
+	}
+	if (!invasion.grunt_type || invasion.grunt_type === '') {
+		typeText = 'any'
+	} else {
+		typeText = invasion.grunt_type
+	}
+	return `${translator.translate('grunt type')
+		.charAt(0)
+		.toUpperCase() + translator.translate('grunt type')
+		.slice(1)}: **${translator.translate(typeText, true)}**${invasion.distance ? ` | ${translator.translate('distance')}: ${invasion.distance}m` : ''} | ${translator.translate('gender')}: ${genderText}`
+}
+
+function lureRowText(translator, GameData, lure) {
+	let typeText = ''
+
+	if (lure.lure_id === 0) {
+		typeText = 'any'
+	} else {
+		typeText = GameData.utilData.lures[lure.lure_id].name
+	}
+	return `${translator.translate('Lure type')}: **${translator.translate(typeText, true)}**${lure.distance ? ` | ${translator.translate('distance')}: ${lure.distance}m` : ''} `
+}
+
 exports.monsterRowText = monsterRowText
 exports.raidRowText = raidRowText
 exports.eggRowText = eggRowText
 exports.questRowText = questRowText
+exports.invasionRowText = invasionRowText
+exports.lureRowText = lureRowText
 
 exports.run = async (client, msg, args, options) => {
 	try {
@@ -176,24 +210,7 @@ exports.run = async (client, msg, args, options) => {
 				} else message = message.concat('\n\n', translator.translate('You\'re not tracking any invasions'))
 
 				invasions.forEach((invasion) => {
-					let genderText = ''
-					let typeText = ''
-					if (!invasion.gender || invasion.gender === '') {
-						genderText = translator.translate('any')
-					} else if (invasion.gender === 1) {
-						genderText = translator.translate('male')
-					} else if (invasion.gender === 2) {
-						genderText = translator.translate('female')
-					}
-					if (!invasion.grunt_type || invasion.grunt_type === '') {
-						typeText = 'any'
-					} else {
-						typeText = invasion.grunt_type
-					}
-					message = message.concat(`\n${translator.translate('grunt type')
-						.charAt(0)
-						.toUpperCase() + translator.translate('grunt type')
-						.slice(1)}: **${translator.translate(typeText, true)}**${invasion.distance ? ` | ${translator.translate('distance')}: ${invasion.distance}m` : ''} | ${translator.translate('gender')}: ${genderText}`)
+					message = message.concat('\n', invasionRowText(translator, client.GameData, invasion))
 				})
 			}
 
@@ -203,14 +220,7 @@ exports.run = async (client, msg, args, options) => {
 				} else message = message.concat('\n\n', translator.translate('You\'re not tracking any lures'))
 
 				lures.forEach((lure) => {
-					let typeText = ''
-
-					if (lure.lure_id === 0) {
-						typeText = 'any'
-					} else {
-						typeText = client.GameData.utilData.lures[lure.lure_id].name
-					}
-					message = message.concat(`\n${translator.translate('Lure type')}: **${translator.translate(typeText, true)}**${lure.distance ? ` | ${translator.translate('distance')}: ${lure.distance}m` : ''} `)
+					message = message.concat('\n', lureRowText(translator, client.GameData, lure))
 				})
 			}
 		}

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -44,8 +44,35 @@ function raidRowText(translator, GameData, raid) {
 	return `**${monsterName}**${formName ? ` ${translator.translate('form')}: ${formName}` : ''}${raid.distance ? ` | ${translator.translate('distance')}: ${raid.distance}m` : ''}${raid.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${raid.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''}`
 }
 
+function eggRowText(translator, GameData, egg) {
+	const raidTeam = translator.translate(GameData.utilData.teams[egg.team].name)
+	return `**${translator.translate('level').charAt(0).toUpperCase() + translator.translate('level').slice(1)} ${egg.level} ${translator.translate('eggs')}** ${egg.distance ? ` | ${translator.translate('distance')}: ${egg.distance}m` : ''} ${egg.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${egg.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''}`
+}
+
+function questRowText(translator, GameData, quest) {
+	let rewardThing = ''
+	if (quest.reward_type === 7) {
+		rewardThing = Object.values(GameData.monsters).find((m) => m.id === quest.reward).name
+		rewardThing = translator.translate(rewardThing)
+	}
+	if (quest.reward_type === 3) rewardThing = `${quest.reward > 0 ? `${quest.reward} ${translator.translate('or more stardust')}` : `${translator.translate('stardust')}`}`
+	if (quest.reward_type === 2) rewardThing = translator.translate(GameData.items[quest.reward].name)
+	if (quest.reward_type === 12) {
+		if (quest.reward == 0) {
+			rewardThing = `${translator.translate('mega energy')}`
+		} else {
+			const mon = Object.values(GameData.monsters).find((m) => m.id === quest.reward && m.form.id === 0)
+			const monsterName = mon ? translator.translate(mon.name) : 'energyMon'
+			rewardThing = `${translator.translate('mega energy')} ${monsterName}`
+		}
+	}
+	return `${translator.translate('reward').charAt(0).toUpperCase() + translator.translate('reward').slice(1)}: **${rewardThing}**${quest.distance ? ` | ${translator.translate('distance')}: ${quest.distance}m` : ''}`
+}
+
 exports.monsterRowText = monsterRowText
 exports.raidRowText = raidRowText
+exports.eggRowText = eggRowText
+exports.questRowText = questRowText
 
 exports.run = async (client, msg, args, options) => {
 	try {
@@ -128,8 +155,7 @@ exports.run = async (client, msg, args, options) => {
 				message = message.concat('\n', raidRowText(translator, client.GameData, raid))
 			})
 			eggs.forEach((egg) => {
-				const raidTeam = translator.translate(client.GameData.utilData.teams[egg.team].name)
-				message = message.concat(`\n**${translator.translate('level').charAt(0).toUpperCase() + translator.translate('level').slice(1)} ${egg.level} ${translator.translate('eggs')}** ${egg.distance ? ` | ${translator.translate('distance')}: ${egg.distance}m` : ''} ${egg.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${egg.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''}`)
+				message = message.concat('\n', eggRowText(translator, client.GameData, egg))
 			})
 		}
 
@@ -139,23 +165,7 @@ exports.run = async (client, msg, args, options) => {
 			} else message = message.concat('\n\n', translator.translate('You\'re not tracking any quests'))
 
 			quests.forEach((quest) => {
-				let rewardThing = ''
-				if (quest.reward_type === 7) {
-					rewardThing = Object.values(client.GameData.monsters).find((m) => m.id === quest.reward).name
-					rewardThing = translator.translate(rewardThing)
-				}
-				if (quest.reward_type === 3) rewardThing = `${quest.reward > 0 ? `${quest.reward} ${translator.translate('or more stardust')}` : `${translator.translate('stardust')}`}`
-				if (quest.reward_type === 2) rewardThing = translator.translate(client.GameData.items[quest.reward].name)
-				if (quest.reward_type === 12) {
-					if (quest.reward == 0) {
-						rewardThing = `${translator.translate('mega energy')}`
-					} else {
-						const mon = Object.values(client.GameData.monsters).find((m) => m.id === quest.reward && m.form.id === 0)
-						const monsterName = mon ? translator.translate(mon.name) : 'energyMon'
-						rewardThing = `${translator.translate('mega energy')} ${monsterName}`
-					}
-				}
-				message = message.concat(`\n${translator.translate('reward').charAt(0).toUpperCase() + translator.translate('reward').slice(1)}: **${rewardThing}**${quest.distance ? ` | ${translator.translate('distance')}: ${quest.distance}m` : ''}`)
+				message = message.concat('\n', questRowText(translator, client.GameData, quest))
 			})
 		}
 

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -154,7 +154,7 @@ exports.run = async (client, msg, args, options) => {
 			locationText = `\n${translator.translate('You have not set a location yet')}`
 		}
 		if (!human.enabled) {
-			restartExplanation = `\n${translator.translateFormat('You can start receiving alerts again using {0}{1}', util.prefix, translator.translate('start'))}`
+			restartExplanation = `\n${translator.translateFormat('You can start receiving alerts again using `{0}{1}`', util.prefix, translator.translate('start'))}`
 		}
 		await msg.reply(`${adminExplanation}${translator.translate('Your alerts are currently')} **${human.enabled ? `${translator.translate('enabled')}` : `${translator.translate('disabled')}`}**${restartExplanation}${locationText}`, { style: 'markdown' })
 

--- a/src/lib/poracleMessage/commands/untrack.js
+++ b/src/lib/poracleMessage/commands/untrack.js
@@ -29,6 +29,16 @@ exports.run = async (client, msg, args, options) => {
 
 		const argTypes = args.filter((arg) => typeArray.includes(arg))
 
+		// Substitute aliases
+		const pokemonAlias = require('../../../../config/pokemonAlias.json')
+		for (let i = args.length - 1; i >= 0; i--) {
+			let alias = pokemonAlias[args]
+			if (alias) {
+				if (!Array.isArray(alias)) alias = [alias]
+				args.splice(i, 1, ...alias.map((x) => x.toString()))
+			}
+		}
+
 		let monsters = []
 		monsters = Object.values(client.GameData.monsters).filter((mon) => ((args.includes(mon.name.toLowerCase()) || args.includes(mon.id.toString()))
 			|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t)) || args.includes('everything'))

--- a/src/lib/poracleMessage/commands/untrack.js
+++ b/src/lib/poracleMessage/commands/untrack.js
@@ -54,7 +54,9 @@ exports.run = async (client, msg, args, options) => {
 		}, monsterIds, 'pokemon_id')
 		client.log.info(`${target.name} removed tracking for monsters: ${monsters.map((m) => m.name).join(', ')}`)
 
-		if (result.length || client.config.database.client === 'sqlite') {
+		msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+
+		if (result || client.config.database.client === 'sqlite') {
 			msg.react('✅')
 		} else {
 			msg.react('👌')

--- a/src/lib/poracleMessage/commands/untrack.js
+++ b/src/lib/poracleMessage/commands/untrack.js
@@ -54,7 +54,15 @@ exports.run = async (client, msg, args, options) => {
 		}, monsterIds, 'pokemon_id')
 		client.log.info(`${target.name} removed tracking for monsters: ${monsters.map((m) => m.name).join(', ')}`)
 
-		msg.reply(translator.translateFormat('I removed {0} entries, use {1}{2} to see what you are currently tracking', result, util.prefix, translator.translate('tracked')))
+		msg.reply(
+			''.concat(
+				result == 1 ? translator.translate('I removed 1 entry')
+					: translator.translateFormat('I removed {0} entries', result),
+				', ',
+				translator.translateFormat('use `{0}{1}` to see what you are currently tracking', util.prefix, translator.translate('tracked')),
+			),
+			{ style: 'markdown' },
+		)
 
 		if (result || client.config.database.client === 'sqlite') {
 			msg.react('✅')

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -556,19 +556,23 @@
 	"teams": {
 		"0": {
 			"name": "Uncontested",
-			"color": "BABABA"
+			"color": "BABABA",
+			"emoji": "\u26AA"
 		},
 		"1": {
 			"name": "Mystic",
-			"color": "3B4CCA"
+			"color": "3B4CCA",
+			"emoji": "\uD83D\uDD35"
 		},
 		"2": {
 			"name": "Valor",
-			"color": "CC0000"
+			"color": "CC0000",
+			"emoji": "\uD83D\uDD34"
 		},
 		"3": {
 			"name": "Instinct",
-			"color": "FFDE00"
+			"color": "FFDE00",
+			"emoji": "\uD83D\uDFE1"
 		},
 		"4": {
 			"name": "Any team",


### PR DESCRIPTION
* New pokemonAlias.json - alias hard to enter pokemon, or groups of mon (see discord).

* Tracking information display - when a track is entered get information about the pokemon
* Updates - when a track is changed and it is obviously meant to change an existing entry (eg distance or iv) then an update rather than a new entry created
![image](https://user-images.githubusercontent.com/1204736/114233997-0d1b0f80-9976-11eb-8f27-31ae19d22f24.png)

![image](https://user-images.githubusercontent.com/1204736/114234080-2f149200-9976-11eb-9de9-3afc6341fa0f.png)

Eggs, invasions and lures not updated with new track display logic - want to get this right on monsters and raids before copying elsewhere. I think it is pretty good, ready for comments.