### PR TITLE
Option to ignore raid hour eggs/raids

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -179,7 +179,8 @@
     //    deny: users cannot track for everything and must track against individual pokemon
       "everythingFlagPermissions": "allow-any",
       "defaultDistance": 0,                       // if you are doing distance tracking only (no areas), this is a default for users
-      "maxDistance": 0                            // restrict users from having too large a tracking circle
+      "maxDistance": 0,                           // restrict users from having too large a tracking circle
+      "ignoreRaidHourRaids": false                // ignore raids > 47m long to save raid hour spam
   },
   //
   // stats configuration

--- a/config/default.json
+++ b/config/default.json
@@ -21,6 +21,7 @@
   "general": {
       "environment": "production",              // leave as 'production'
       "alertMinimumTime" : 120,                 // time inside which alerts will not be generated (120s - 2mins before expiration no alert)
+      "ignoreLongRaids": false,                 // ignore raids > 47m long to save raid hour/special raid event spam
     // imgUrl - base url for poracle creation of {{imgUrl}} reference
       "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/",
     // stickerUrl - base url for poracle creation of {{stickerUrl}} reference for telegram webp stickers
@@ -179,8 +180,7 @@
     //    deny: users cannot track for everything and must track against individual pokemon
       "everythingFlagPermissions": "allow-any",
       "defaultDistance": 0,                       // if you are doing distance tracking only (no areas), this is a default for users
-      "maxDistance": 0,                           // restrict users from having too large a tracking circle
-      "ignoreRaidHourRaids": false                // ignore raids > 47m long to save raid hour spam
+      "maxDistance": 0                            // restrict users from having too large a tracking circle
   },
   //
   // stats configuration

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -200,7 +200,7 @@ class Raid extends Controller {
 
 			data.weather = this.weatherData.getCurrentWeatherInCell(this.weatherData.getWeatherCellId(data.latitude, data.longitude)) || 0		// complete weather data from weather cache
 
-			if (this.config.tracking.ignoreRaidHourRaids
+			if (this.config.general.ignoreLongRaids
 				&& (data.end - data.start) > 47 * 60) {
 				this.log.verbose(`${this.logReference}: Raid/Egg on ${data.gymName} will be longer than 47 minutes - ignored`)
 				return []

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -200,6 +200,12 @@ class Raid extends Controller {
 
 			data.weather = this.weatherData.getCurrentWeatherInCell(this.weatherData.getWeatherCellId(data.latitude, data.longitude)) || 0		// complete weather data from weather cache
 
+			if (this.config.tracking.ignoreRaidHourRaids
+				&& (data.end - data.start) > 47 * 60) {
+				this.log.verbose(`${this.logReference}: Raid/Egg on ${data.gymName} will be longer than 47 minutes - ignored`)
+				return []
+			}
+
 			if (data.pokemon_id) {
 				if (data.form === undefined || data.form === null) data.form = 0
 				const monster = this.GameData.monsters[`${data.pokemon_id}_${data.form}`] ? this.GameData.monsters[`${data.pokemon_id}_${data.form}`] : this.GameData.monsters[`${data.pokemon_id}_0`]


### PR DESCRIPTION
New option in general:
```
      "ignoreLongRaids": false                // ignore raids > 47m long to save raid hour spam
```
