### PR TITLE
Add support for megaName

### DIFF
--- a/config/locale/fr.json
+++ b/config/locale/fr.json
@@ -515,5 +515,8 @@
 	"New: ": "Nouveau: ",
 	"I removed 1 entry": "J'ai retiré 1 entrée",
 	"I removed {0} entries": "J'ai retiré {0} entrées",
-	"use `{0}{1}` to see what you are currently tracking": "utiliser {0}{1} pour voir vos suivis configurés"
+	"use `{0}{1}` to see what you are currently tracking": "utiliser {0}{1} pour voir vos suivis configurés",
+	"Mega {0}": "Méga-{0}",
+	"Mega {0} X": "Méga-{0} X",
+	"Mega {0} Y": "Méga-{0} Y"
 }

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -298,6 +298,7 @@ class Raid extends Controller {
 					data.name = translator.translate(data.nameEng)
 					data.formName = translator.translate(data.formNameEng)
 					data.evolutionName = translator.translate(data.evolutionNameEng)
+					data.megaName = data.evolution ? translator.translateFormat(this.GameData.utilData.megaName[data.evolution], data.name) : data.name
 					data.typeName = data.typeNameEng.map((type) => translator.translate(type)).join(', ')
 					data.typeEmoji = data.emoji.map((emoji) => translator.translate(emoji)).join('')
 					data.quickMoveName = this.GameData.moves[data.move_1] ? translator.translate(this.GameData.moves[data.move_1].name) : ''

--- a/src/lib/discord/commando/index.js
+++ b/src/lib/discord/commando/index.js
@@ -1,4 +1,4 @@
-const { Intents, Client } = require('discord.js')
+const { Client } = require('discord.js')
 const fs = require('fs')
 const { S2 } = require('s2-geometry')
 const mustache = require('handlebars')
@@ -23,17 +23,19 @@ class DiscordCommando {
 
 	async bounceWorker() {
 		delete this.client
-		const intents = new Intents([
-			Intents.NON_PRIVILEGED, // include all non-privileged intents, would be better to specify which ones you actually need
-			'GUILD_MEMBERS', // lets you request guild members (i.e. fixes the issue)
-		])
+		// This will be required in discord.js 13
+		// -- but causes an exception if intent not given in discord bot configuration
+		// const intents = new Intents([
+		// 	Intents.NON_PRIVILEGED, // include all non-privileged intents, would be better to specify which ones you actually need
+		// 	'GUILD_MEMBERS', // lets you request guild members (i.e. fixes the issue)
+		// ])
 
 		this.client = new Client({
 			messageCacheMaxSize: 1,
 			messsageCacheLifetime: 60,
 			messageSweepInterval: 120,
 			messageEditHistoryMaxSize: 1,
-			//ws: { intents },
+			// ws: { intents },
 		})
 		try {
 			this.client.on('error', (err) => {

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -540,6 +540,20 @@
 		"5": "Ultra-Rare",
 		"6": "Unseen"
 	},
+	"megaName": {
+		"0": {
+			"name": "{0}"
+		},
+		"1": {
+			"name": "Mega {0}"
+		},
+		"2": {
+			"name": "Mega {0} X"
+		},
+		"3": {
+			"name": "Mega {0} Y"
+		}
+	},
 	"evolution": {
 		"0": {
 			"name": ""


### PR DESCRIPTION
Support `megaName` in raids.  {{megaName}} will return the full Mega evolution name as appropriate to the current pokemon. Format is translatable - French provided (thanks petap0w)