### PR TITLE
UICONS support

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -26,9 +26,9 @@
       "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS",
     // stickerUrl - base url for poracle creation of {{stickerUrl}} reference for telegram webp stickers (uicons repository)
       "stickerUrl": "https://raw.githubusercontent.com/bbdoc/tgUICONS/main/Shuffle",
-    // images/stickers - override uicons repository per controller
+    // images/stickers - override uicons repository for each alert type
     //  "controllerType": "repositoryUrl"
-    //  controllerType one of monster, gym, nest, pokestop, pokestop_lure, quest, raid, weather
+    //  controllerType one of monster, gym, nest, invasion, lure, quest, raid, weather
       "images": {
       },
       "stickers": {

--- a/config/default.json
+++ b/config/default.json
@@ -23,9 +23,9 @@
       "alertMinimumTime" : 120,                 // time inside which alerts will not be generated (120s - 2mins before expiration no alert)
       "ignoreLongRaids": false,                 // ignore raids > 47m long to save raid hour/special raid event spam
     // imgUrl - base url for poracle creation of {{imgUrl}} reference
-      "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/",
+      "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS",
     // stickerUrl - base url for poracle creation of {{stickerUrl}} reference for telegram webp stickers
-      "stickerUrl": "https://raw.githubusercontent.com/whitewillem/PogoAssets/resized/icons_large/telegram/",
+      "stickerUrl": "https://raw.githubusercontent.com/bbdoc/tgUICONS/main",
       "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
     // disabledCommands - array of commands which will be disabled from use
       "disabledCommands": [],

--- a/config/default.json
+++ b/config/default.json
@@ -22,11 +22,18 @@
       "environment": "production",              // leave as 'production'
       "alertMinimumTime" : 120,                 // time inside which alerts will not be generated (120s - 2mins before expiration no alert)
       "ignoreLongRaids": false,                 // ignore raids > 47m long to save raid hour/special raid event spam
-    // imgUrl - base url for poracle creation of {{imgUrl}} reference
+    // imgUrl - base url for poracle creation of {{imgUrl}} reference (uicons repository)
       "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS",
-    // stickerUrl - base url for poracle creation of {{stickerUrl}} reference for telegram webp stickers
+    // stickerUrl - base url for poracle creation of {{stickerUrl}} reference for telegram webp stickers (uicons repository)
       "stickerUrl": "https://raw.githubusercontent.com/bbdoc/tgUICONS/main/Shuffle",
-      "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
+    // images/stickers - override uicons repository per controller
+    //  "controllerType": "repositoryUrl"
+    //  controllerType one of monster, gym, nest, pokestop, pokestop_lure, quest, raid, weather
+      "images": {
+      },
+      "stickers": {
+      },
+        "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
     // disabledCommands - array of commands which will be disabled from use
       "disabledCommands": [],
     // disableXXX - disables individual hook processing for particular scanner webhook types.  disablePokestop disables

--- a/config/default.json
+++ b/config/default.json
@@ -25,7 +25,7 @@
     // imgUrl - base url for poracle creation of {{imgUrl}} reference
       "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS",
     // stickerUrl - base url for poracle creation of {{stickerUrl}} reference for telegram webp stickers
-      "stickerUrl": "https://raw.githubusercontent.com/bbdoc/tgUICONS/main",
+      "stickerUrl": "https://raw.githubusercontent.com/bbdoc/tgUICONS/main/Shuffle",
       "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
     // disabledCommands - array of commands which will be disabled from use
       "disabledCommands": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "PoracleJS",
-  "version": "4.1.1",
+  "version": "4.1.5",
   "description": "Webhook processing and personalised discord|telegram alarms",
   "main": "src/app.js",
   "scripts": {

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -9,7 +9,7 @@ const pcache = require('flat-cache')
 
 const geoCache = pcache.load('geoCache', path.join(__dirname, '../../.cache'))
 const emojiFlags = require('emoji-flags')
-
+const Uicons = require('../lib/uicons')
 const TileserverPregen = require('../lib/tileserverPregen')
 const replaceAsync = require('../util/stringReplaceAsync')
 const urlShortener = require('../lib/urlShortener')
@@ -36,6 +36,8 @@ class Controller extends EventEmitter {
 		//		this.controllerData = weatherCacheData || {}
 		this.tileserverPregen = new TileserverPregen(this.config, this.log)
 		this.emojiLookup = new EmojiLookup(GameData.utilData.emojis)
+		this.imgUicons = new Uicons(this.config.general.imgUrl, 'png', this.log)
+		this.stickerUicons = new Uicons(this.config.general.stickerUrl, 'webp', this.log)
 		this.dtsCache = {}
 	}
 

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -36,8 +36,8 @@ class Controller extends EventEmitter {
 		//		this.controllerData = weatherCacheData || {}
 		this.tileserverPregen = new TileserverPregen(this.config, this.log)
 		this.emojiLookup = new EmojiLookup(GameData.utilData.emojis)
-		this.imgUicons = new Uicons(this.config.general.imgUrl, 'png', this.log)
-		this.stickerUicons = new Uicons(this.config.general.stickerUrl, 'webp', this.log)
+		this.imgUicons = new Uicons(this.config.general.images[this.constructor.name.toLowerCase()] || this.config.general.imgUrl, 'png', this.log)
+		this.stickerUicons = new Uicons(this.config.general.stickers[this.constructor.name.toLowerCase()] || this.config.general.stickerUrl, 'webp', this.log)
 		this.dtsCache = {}
 	}
 

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -1,6 +1,7 @@
 // const geoTz = require('geo-tz')
 // const moment = require('moment-timezone')
 const Controller = require('./controller')
+const uicons = require('../lib/uicons')
 
 /**
  * Controller for processing gym webhooks
@@ -125,7 +126,6 @@ class Gym extends Controller {
 			//			data.disappearTime = moment(lureExpiration * 1000).tz(geoTz(data.latitude, data.longitude).toString()).format(this.config.locale.time)
 			data.applemap = data.appleMapUrl // deprecated
 			data.mapurl = data.googleMapUrl // deprecated
-			data.imgUrl = data.pokestopUrl // deprecated
 			data.distime = data.disappearTime // deprecated
 
 			// Stop handling if it already disappeared or is about to go away
@@ -150,6 +150,8 @@ class Gym extends Controller {
 			data.oldSlotsAvailable = data.old_slots_available
 			data.ex = !!(data.ex_raid_eligible || data.is_ex_raid_eligible)
 			data.color = data.gymColor
+
+			data.imgUrl = await uicons.gymIcon(this.config.general.imgUrl, 'png', data.teamId, data.slotsAvailable, false, data.ex)
 
 			const whoCares = await this.gymWhoCares(data)
 

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -149,9 +149,6 @@ class Gym extends Controller {
 			data.ex = !!(data.ex_raid_eligible || data.is_ex_raid_eligible)
 			data.color = data.gymColor
 
-			data.imgUrl = await this.imgUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
-			data.stickerUrl = await this.stickerUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
-
 			const whoCares = await this.gymWhoCares(data)
 
 			if (whoCares.length) {
@@ -172,6 +169,9 @@ class Gym extends Controller {
 
 				return []
 			}
+
+			data.imgUrl = await this.imgUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
+			data.stickerUrl = await this.stickerUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -152,6 +152,7 @@ class Gym extends Controller {
 			data.color = data.gymColor
 
 			data.imgUrl = await uicons.gymIcon(this.config.general.imgUrl, 'png', data.teamId, data.slotsAvailable, false, data.ex)
+			data.stickerUrl = await uicons.gymIcon(this.config.general.stickerUrl, 'webp', data.teamId, data.slotsAvailable, false, data.ex)
 
 			const whoCares = await this.gymWhoCares(data)
 

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -1,7 +1,6 @@
 // const geoTz = require('geo-tz')
 // const moment = require('moment-timezone')
 const Controller = require('./controller')
-const uicons = require('../lib/uicons')
 
 /**
  * Controller for processing gym webhooks
@@ -150,8 +149,8 @@ class Gym extends Controller {
 			data.ex = !!(data.ex_raid_eligible || data.is_ex_raid_eligible)
 			data.color = data.gymColor
 
-			data.imgUrl = await uicons.gymIcon(this.config.general.imgUrl, 'png', data.teamId, data.slotsAvailable, false, data.ex)
-			data.stickerUrl = await uicons.gymIcon(this.config.general.stickerUrl, 'webp', data.teamId, data.slotsAvailable, false, data.ex)
+			data.imgUrl = await this.imgUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
+			data.stickerUrl = await this.stickerUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
 
 			const whoCares = await this.gymWhoCares(data)
 

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -3,6 +3,8 @@ const moment = require('moment-timezone')
 const Controller = require('./controller')
 require('moment-precise-range-plugin')
 
+const uicons = require('../lib/uicons')
+
 class Monster extends Controller {
 	getAlteringWeathers(types, boostStatus) {
 		const boostingWeathers = types.map((type) => parseInt(Object.keys(this.GameData.utilData.weatherTypeBoost).find((key) => this.GameData.utilData.weatherTypeBoost[key].includes(type)), 10))
@@ -84,7 +86,7 @@ class Monster extends Controller {
 					`)
 			//					group by humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, monsters.template, monsters.distance, monsters.clean, monsters.ping, monsters.great_league_ranking, monsters.ultra_league_ranking
 		}
-		// this.log.silly(`${data.encounter_id}: Query ${query}`)
+		this.log.debug(`${data.encounter_id}: Query ${query}`)
 
 		let result = await this.db.raw(query)
 
@@ -208,7 +210,9 @@ class Monster extends Controller {
 			data.mapurl = data.googleMapUrl // deprecated
 			data.ivcolor = data.ivColor // deprecated
 			//			data.gif = pokemonGif(Number(data.pokemon_id)) // deprecated
-			data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
+			// should be moved after the fold as is more expensive now
+			data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form, 0, data.gender, data.costume, false)
+			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
 			data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 			data.types = this.getPokemonTypes(data.pokemon_id, data.form)
 			data.alteringWeathers = this.getAlteringWeathers(data.types, data.weather)

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -212,8 +212,9 @@ class Monster extends Controller {
 			//			data.gif = pokemonGif(Number(data.pokemon_id)) // deprecated
 			// should be moved after the fold as is more expensive now
 			data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form, 0, data.gender, data.costume, false)
+			data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.pokemon_id, data.form, 0, data.gender, data.costume, false)
 			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
-			data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
+			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 			data.types = this.getPokemonTypes(data.pokemon_id, data.form)
 			data.alteringWeathers = this.getAlteringWeathers(data.types, data.weather)
 			data.rarityGroup = Object.keys(this.statsData.rarityGroups).find((x) => this.statsData.rarityGroups[x].includes(data.pokemonId)) || -1

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -4,8 +4,6 @@ const Ohbem = require('ohbem')
 const Controller = require('./controller')
 require('moment-precise-range-plugin')
 
-const uicons = require('../lib/uicons')
-
 class Monster extends Controller {
 	getAlteringWeathers(types, boostStatus) {
 		const boostingWeathers = types.map((type) => parseInt(Object.keys(this.GameData.utilData.weatherTypeBoost).find((key) => this.GameData.utilData.weatherTypeBoost[key].includes(type)), 10))
@@ -247,11 +245,6 @@ class Monster extends Controller {
 			data.mapurl = data.googleMapUrl // deprecated
 			data.ivcolor = data.ivColor // deprecated
 			//			data.gif = pokemonGif(Number(data.pokemon_id)) // deprecated
-			// should be moved after the fold as is more expensive now
-			data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form, 0, data.gender, data.costume, false)
-			data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.pokemon_id, data.form, 0, data.gender, data.costume, false)
-			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
-			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 			data.types = this.getPokemonTypes(data.pokemon_id, data.form)
 			data.alteringWeathers = this.getAlteringWeathers(data.types, data.weather)
 			data.rarityGroup = Object.keys(this.statsData.rarityGroups).find((x) => this.statsData.rarityGroups[x].includes(data.pokemonId)) || -1
@@ -404,6 +397,11 @@ class Monster extends Controller {
 
 				return []
 			}
+
+			data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form, 0, data.gender, data.costume, false)
+			data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form, 0, data.gender, data.costume, false)
+			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
+			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []

--- a/src/controllers/nest.js
+++ b/src/controllers/nest.js
@@ -1,7 +1,7 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
-const uicons = require('../lib/uicons')
+
 /**
  * Controller for processing nest webhooks
  */
@@ -110,7 +110,6 @@ class Nest extends Controller {
 
 			data.applemap = data.appleMapUrl // deprecated
 			data.mapurl = data.googleMapUrl // deprecated
-			data.imgUrl = data.pokestopUrl // deprecated
 			data.distime = data.disappearTime // deprecated
 
 			// Stop handling if it already disappeared or is about to go away
@@ -134,11 +133,6 @@ class Nest extends Controller {
 			data.nameEng = monster.name
 			data.formId = monster.form.id
 			data.formNameEng = monster.form.name
-			// should be moved after the fold as is more expensive now
-			data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form)
-			data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.pokemon_id, data.form)
-			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
-			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 			data.color = this.GameData.utilData.types[monster.types[0].name].color
 			data.pokemonCount = data.pokemon_count
 			data.pokemonSpawnAvg = data.pokemon_avg
@@ -163,6 +157,11 @@ class Nest extends Controller {
 
 				return []
 			}
+
+			data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form)
+			data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form)
+			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
+			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []

--- a/src/controllers/nest.js
+++ b/src/controllers/nest.js
@@ -1,7 +1,7 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
-
+const uicons = require('../lib/uicons')
 /**
  * Controller for processing nest webhooks
  */
@@ -134,8 +134,11 @@ class Nest extends Controller {
 			data.nameEng = monster.name
 			data.formId = monster.form.id
 			data.formNameEng = monster.form.name
-			data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
-			data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
+			// should be moved after the fold as is more expensive now
+			data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form)
+			data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.pokemon_id, data.form)
+			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
+			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 			data.color = this.GameData.utilData.types[monster.types[0].name].color
 			data.pokemonCount = data.pokemon_count
 			data.pokemonSpawnAvg = data.pokemon_avg

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -1,6 +1,7 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
+const uicons = require('../lib/uicons')
 
 class Pokestop extends Controller {
 	async invasionWhoCares(obj) {
@@ -103,7 +104,6 @@ class Pokestop extends Controller {
 			data.disappearTime = moment(incidentExpiration * 1000).tz(geoTz(data.latitude, data.longitude).toString()).format(this.config.locale.time)
 			data.applemap = data.appleMapUrl // deprecated
 			data.mapurl = data.googleMapUrl // deprecated
-			data.imgUrl = data.pokestopUrl // deprecated
 			data.distime = data.disappearTime // deprecated
 
 			// Stop handling if it already disappeared or is about to go away
@@ -121,6 +121,9 @@ class Pokestop extends Controller {
 			} else if (data.grunt_type) {
 				data.gruntTypeId = data.grunt_type
 			}
+
+			// should be moved after the fold as is more expensive now
+			data.imgUrl = await uicons.invasionIcon(this.config.general.imgUrl, 'png', data.gruntTypeId)
 
 			data.gruntTypeEmoji = '❓'
 			data.gruntTypeColor = 'BABABA'

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -2,7 +2,7 @@ const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
 
-class Pokestop extends Controller {
+class Invasion extends Controller {
 	async invasionWhoCares(obj) {
 		const data = obj
 		let areastring = `humans.area like '%"${data.matched[0] || 'doesntexist'}"%' `
@@ -344,4 +344,4 @@ class Pokestop extends Controller {
 	}
 }
 
-module.exports = Pokestop
+module.exports = Invasion

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -124,6 +124,7 @@ class Pokestop extends Controller {
 
 			// should be moved after the fold as is more expensive now
 			data.imgUrl = await uicons.invasionIcon(this.config.general.imgUrl, 'png', data.gruntTypeId)
+			data.stickerUrl = await uicons.invasionIcon(this.config.general.stickerUrl, 'webp', data.gruntTypeId)
 
 			data.gruntTypeEmoji = '❓'
 			data.gruntTypeColor = 'BABABA'

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -1,7 +1,6 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
-const uicons = require('../lib/uicons')
 
 class Pokestop extends Controller {
 	async invasionWhoCares(obj) {
@@ -122,10 +121,6 @@ class Pokestop extends Controller {
 				data.gruntTypeId = data.grunt_type
 			}
 
-			// should be moved after the fold as is more expensive now
-			data.imgUrl = await uicons.invasionIcon(this.config.general.imgUrl, 'png', data.gruntTypeId)
-			data.stickerUrl = await uicons.invasionIcon(this.config.general.stickerUrl, 'webp', data.gruntTypeId)
-
 			data.gruntTypeColor = 'BABABA'
 
 			data.gender = 0
@@ -169,6 +164,9 @@ class Pokestop extends Controller {
 
 				return []
 			}
+
+			data.imgUrl = await this.imgUicons.invasionIcon(data.gruntTypeId)
+			data.stickerUrl = await this.stickerUicons.invasionIcon(data.gruntTypeId)
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -1,7 +1,7 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
-
+const uicons = require('../lib/uicons')
 /**
  * Controller for processing pokestop webhooks
  * Alerts on lures
@@ -106,7 +106,6 @@ class PokestopLure extends Controller {
 			data.disappearTime = moment(lureExpiration * 1000).tz(geoTz(data.latitude, data.longitude).toString()).format(this.config.locale.time)
 			data.applemap = data.appleMapUrl // deprecated
 			data.mapurl = data.googleMapUrl // deprecated
-			data.imgUrl = data.pokestopUrl // deprecated
 			data.distime = data.disappearTime // deprecated
 
 			// Stop handling if it already disappeared or is about to go away
@@ -122,6 +121,9 @@ class PokestopLure extends Controller {
 			if (data.lure_id) {
 				data.lureTypeId = data.lure_id
 			}
+
+			// should be moved after the fold as is more expensive now
+			data.imgUrl = await uicons.pokestopIcon(this.config.general.imgUrl, 'png', data.lureTypeId)
 
 			data.lureTypeEmoji = this.GameData.utilData.lures[data.lure_id].emoji
 			data.lureTypeColor = this.GameData.utilData.lures[data.lure_id].color

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -5,7 +5,7 @@ const Controller = require('./controller')
  * Controller for processing pokestop webhooks
  * Alerts on lures
  */
-class PokestopLure extends Controller {
+class Lure extends Controller {
 	async lureWhoCares(obj) {
 		const data = obj
 		let areastring = `humans.area like '%"${data.matched[0] || 'doesntexist'}"%' `
@@ -242,4 +242,4 @@ class PokestopLure extends Controller {
 	}
 }
 
-module.exports = PokestopLure
+module.exports = Lure

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -124,6 +124,7 @@ class PokestopLure extends Controller {
 
 			// should be moved after the fold as is more expensive now
 			data.imgUrl = await uicons.pokestopIcon(this.config.general.imgUrl, 'png', data.lureTypeId)
+			data.stickerUrl = await uicons.pokestopIcon(this.config.general.stickerUrl, 'webp', data.lureTypeId)
 
 			data.lureTypeEmoji = this.GameData.utilData.lures[data.lure_id].emoji
 			data.lureTypeColor = this.GameData.utilData.lures[data.lure_id].color

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -1,7 +1,6 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
-const uicons = require('../lib/uicons')
 /**
  * Controller for processing pokestop webhooks
  * Alerts on lures
@@ -122,10 +121,6 @@ class PokestopLure extends Controller {
 				data.lureTypeId = data.lure_id
 			}
 
-			// should be moved after the fold as is more expensive now
-			data.imgUrl = await uicons.pokestopIcon(this.config.general.imgUrl, 'png', data.lureTypeId)
-			data.stickerUrl = await uicons.pokestopIcon(this.config.general.stickerUrl, 'webp', data.lureTypeId)
-
 			data.lureTypeColor = this.GameData.utilData.lures[data.lure_id].color
 			data.lureTypeNameEng = this.GameData.utilData.lures[data.lure_id].name
 
@@ -149,6 +144,9 @@ class PokestopLure extends Controller {
 
 				return []
 			}
+
+			data.imgUrl = await this.imgUicons.pokestopIcon(data.lureTypeId)
+			data.stickerUrl = await this.stickerUicons.pokestopIcon(data.lureTypeId)
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -180,8 +180,8 @@ class Quest extends Controller {
 			}
 
 			if (data.rewardData.items.length > 0) {
-				data.imgUrl = await uicons.rewardItemIcon(this.config.general.imgUrl, 'png', data.rewardData.items[0].id)
-				data.stickerUrl = await uicons.rewardItemIcon(this.config.general.stickerUrl, 'webp', data.rewardData.items[0].id)
+				data.imgUrl = await uicons.rewardItemIcon(this.config.general.imgUrl, 'png', data.rewardData.items[0].id, data.rewardData.items[0].amount)
+				data.stickerUrl = await uicons.rewardItemIcon(this.config.general.stickerUrl, 'webp', data.rewardData.items[0].id, data.rewardData.items[0].amount)
 
 				// data.imgUrl = `${this.config.general.imgUrl}rewards/reward_${data.rewardData.items[0].id}_1.png`
 				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_${data.rewardData.items[0].id}_1.webp`

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -170,34 +170,40 @@ class Quest extends Controller {
 
 			if (data.rewardData.monsters.length > 0) {
 				data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
+				data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
 				// data.imgUrl = data.rewardData.monsters.length > 0
 				// 	? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
 				// 	: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
-				data.stickerUrl = data.rewardData.monsters.length > 0
-					? `${this.config.general.stickerUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.webp`
-					: ''
+				// data.stickerUrl = data.rewardData.monsters.length > 0
+				// 	? `${this.config.general.stickerUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.webp`
+				// 	: ''
 			}
 
 			if (data.rewardData.items.length > 0) {
 				data.imgUrl = await uicons.rewardItemIcon(this.config.general.imgUrl, 'png', data.rewardData.items[0].id)
+				data.stickerUrl = await uicons.rewardItemIcon(this.config.general.stickerUrl, 'webp', data.rewardData.items[0].id)
+
 				// data.imgUrl = `${this.config.general.imgUrl}rewards/reward_${data.rewardData.items[0].id}_1.png`
-				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_${data.rewardData.items[0].id}_1.webp`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_${data.rewardData.items[0].id}_1.webp`
 			}
 			if (data.dustAmount) {
 				data.imgUrl = await uicons.rewardStardustIcon(this.config.general.imgUrl, 'png', data.rewardData.dustAmount)
+				data.stickerUrl = await uicons.rewardStardustIcon(this.config.general.stickerUrl, 'webp', data.rewardData.dustAmount)
 				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_stardust.png`
-				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_stardust.webp`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_stardust.webp`
 			}
 			if (data.rewardData.energyMonsters.length > 0) {
 				data.imgUrl = await uicons.rewardMegaEnergyIcon(this.config.general.imgUrl, 'png', data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
+				data.stickerUrl = await uicons.rewardMegaEnergyIcon(this.config.general.stickerUrl, 'webp', data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
 				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.png`
-				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.webp`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.webp`
 			}
 			if (data.rewardData.candy.length > 0) {
 				data.imgUrl = await uicons.rewardCandyIcon(this.config.general.imgUrl, 'png', data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
+				data.stickerUrl = await uicons.rewardCandyIcon(this.config.general.stickerUrl, 'webp', data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
 
 				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.png`
-				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.webp`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.webp`
 			}
 
 			const whoCares = await this.questWhoCares(data)

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -8,7 +8,6 @@ const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
 const { log } = require('../lib/logger')
-const uicons = require('../lib/uicons')
 const questTypeList = require('../util/questTypeList.json')
 // const itemList = require('../util/quests/items')
 const pokemonTypes = ['unset', 'Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark', 'Fairy']
@@ -165,46 +164,6 @@ class Quest extends Controller {
 
 			data.matchedAreas = this.pointInArea([data.latitude, data.longitude])
 			data.matched = data.matchedAreas.map((x) => x.name.toLowerCase())
-			data.imgUrl = 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
-			data.stickerUrl = ''
-
-			if (data.rewardData.monsters.length > 0) {
-				data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
-				data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
-				// data.imgUrl = data.rewardData.monsters.length > 0
-				// 	? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
-				// 	: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
-				// data.stickerUrl = data.rewardData.monsters.length > 0
-				// 	? `${this.config.general.stickerUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.webp`
-				// 	: ''
-			}
-
-			if (data.rewardData.items.length > 0) {
-				data.imgUrl = await uicons.rewardItemIcon(this.config.general.imgUrl, 'png', data.rewardData.items[0].id, data.rewardData.items[0].amount)
-				data.stickerUrl = await uicons.rewardItemIcon(this.config.general.stickerUrl, 'webp', data.rewardData.items[0].id, data.rewardData.items[0].amount)
-
-				// data.imgUrl = `${this.config.general.imgUrl}rewards/reward_${data.rewardData.items[0].id}_1.png`
-				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_${data.rewardData.items[0].id}_1.webp`
-			}
-			if (data.dustAmount) {
-				data.imgUrl = await uicons.rewardStardustIcon(this.config.general.imgUrl, 'png', data.rewardData.dustAmount)
-				data.stickerUrl = await uicons.rewardStardustIcon(this.config.general.stickerUrl, 'webp', data.rewardData.dustAmount)
-				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_stardust.png`
-				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_stardust.webp`
-			}
-			if (data.rewardData.energyMonsters.length > 0) {
-				data.imgUrl = await uicons.rewardMegaEnergyIcon(this.config.general.imgUrl, 'png', data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
-				data.stickerUrl = await uicons.rewardMegaEnergyIcon(this.config.general.stickerUrl, 'webp', data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
-				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.png`
-				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.webp`
-			}
-			if (data.rewardData.candy.length > 0) {
-				data.imgUrl = await uicons.rewardCandyIcon(this.config.general.imgUrl, 'png', data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
-				data.stickerUrl = await uicons.rewardCandyIcon(this.config.general.stickerUrl, 'webp', data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
-
-				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.png`
-				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.webp`
-			}
 
 			const whoCares = await this.questWhoCares(data)
 			if (whoCares.length) {
@@ -226,6 +185,47 @@ class Quest extends Controller {
 				})
 
 				return []
+			}
+
+			data.imgUrl = 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
+			data.stickerUrl = ''
+
+			if (data.rewardData.monsters.length > 0) {
+				data.imgUrl = await this.imgUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
+				data.stickerUrl = await this.stickerUicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
+				// data.imgUrl = data.rewardData.monsters.length > 0
+				// 	? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
+				// 	: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
+				// data.stickerUrl = data.rewardData.monsters.length > 0
+				// 	? `${this.config.general.stickerUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.webp`
+				// 	: ''
+			}
+
+			if (data.rewardData.items.length > 0) {
+				data.imgUrl = await this.imgUicons.rewardItemIcon(data.rewardData.items[0].id, data.rewardData.items[0].amount)
+				data.stickerUrl = await this.stickerUicons.rewardItemIcon(data.rewardData.items[0].id, data.rewardData.items[0].amount)
+
+				// data.imgUrl = `${this.config.general.imgUrl}rewards/reward_${data.rewardData.items[0].id}_1.png`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_${data.rewardData.items[0].id}_1.webp`
+			}
+			if (data.dustAmount) {
+				data.imgUrl = await this.imgUicons.rewardStardustIcon(data.rewardData.dustAmount)
+				data.stickerUrl = await this.stickerUicons.rewardStardustIcon(data.rewardData.dustAmount)
+				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_stardust.png`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_stardust.webp`
+			}
+			if (data.rewardData.energyMonsters.length > 0) {
+				data.imgUrl = await this.imgUicons.rewardMegaEnergyIcon(data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
+				data.stickerUrl = await this.stickerUicons.rewardMegaEnergyIcon(data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
+				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.png`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.webp`
+			}
+			if (data.rewardData.candy.length > 0) {
+				data.imgUrl = await this.imgUicons.rewardCandyIcon(data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
+				data.stickerUrl = await this.stickerUicons.rewardCandyIcon(data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
+
+				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.png`
+				// data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.webp`
 			}
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -8,7 +8,7 @@ const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
 const { log } = require('../lib/logger')
-
+const uicons = require('../lib/uicons')
 const questTypeList = require('../util/questTypeList.json')
 // const itemList = require('../util/quests/items')
 const pokemonTypes = ['unset', 'Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark', 'Fairy']
@@ -165,27 +165,38 @@ class Quest extends Controller {
 
 			data.matchedAreas = this.pointInArea([data.latitude, data.longitude])
 			data.matched = data.matchedAreas.map((x) => x.name.toLowerCase())
-			data.imgUrl = data.rewardData.monsters.length > 0
-				? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
-				: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
-			data.stickerUrl = data.rewardData.monsters.length > 0
-				? `${this.config.general.stickerUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.webp`
-				: ''
+			data.imgUrl = 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
+			data.stickerUrl = ''
+
+			if (data.rewardData.monsters.length > 0) {
+				data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
+				// data.imgUrl = data.rewardData.monsters.length > 0
+				// 	? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
+				// 	: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
+				data.stickerUrl = data.rewardData.monsters.length > 0
+					? `${this.config.general.stickerUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.webp`
+					: ''
+			}
 
 			if (data.rewardData.items.length > 0) {
-				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_${data.rewardData.items[0].id}_1.png`
+				data.imgUrl = await uicons.rewardItemIcon(this.config.general.imgUrl, 'png', data.rewardData.items[0].id)
+				// data.imgUrl = `${this.config.general.imgUrl}rewards/reward_${data.rewardData.items[0].id}_1.png`
 				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_${data.rewardData.items[0].id}_1.webp`
 			}
 			if (data.dustAmount) {
-				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_stardust.png`
+				data.imgUrl = await uicons.rewardStardustIcon(this.config.general.imgUrl, 'png', data.rewardData.dustAmount)
+				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_stardust.png`
 				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_stardust.webp`
 			}
 			if (data.rewardData.energyMonsters.length > 0) {
-				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.png`
+				data.imgUrl = await uicons.rewardMegaEnergyIcon(this.config.general.imgUrl, 'png', data.rewardData.energyMonsters[0].pokemonId, data.rewardData.energyMonsters[0].amount)
+				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.png`
 				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_mega_energy_${data.rewardData.energyMonsters[0].pokemonId}.webp`
 			}
 			if (data.rewardData.candy.length > 0) {
-				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.png`
+				data.imgUrl = await uicons.rewardCandyIcon(this.config.general.imgUrl, 'png', data.rewardData.candy[0].pokemonId, data.rewardData.candy[0].amount)
+
+				//				data.imgUrl = `${this.config.general.imgUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.png`
 				data.stickerUrl = `${this.config.general.stickerUrl}rewards/reward_candy_${data.rewardData.candy[0].pokemonId}.webp`
 			}
 

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -192,7 +192,7 @@ class Quest extends Controller {
 
 			if (data.rewardData.monsters.length > 0) {
 				data.imgUrl = await this.imgUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
-				data.stickerUrl = await this.stickerUicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
+				data.stickerUrl = await this.stickerUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
 				// data.imgUrl = data.rewardData.monsters.length > 0
 				// 	? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
 				// 	: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -228,8 +228,9 @@ class Raid extends Controller {
 				data.evolutionname = data.evolutionNameEng // deprecated
 				// should be moved after the fold as is more expensive now
 				data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
+				data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
 				// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.png`
-				data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.webp`
+				// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.webp`
 				data.quickMoveId = data.move_1 ? data.move_1 : ''
 				data.chargeMoveId = data.move_2 ? data.move_2 : ''
 				data.quickMoveNameEng = this.GameData.moves[data.move_1] ? this.GameData.moves[data.move_1].name : ''
@@ -393,8 +394,9 @@ class Raid extends Controller {
 			data.hatchtime = data.hatchTime // deprecated
 			// should be moved after the fold as is more expensive now
 			data.imgUrl = await uicons.eggIcon(this.config.general.imgUrl, 'png', data.level)
+			data.stickerUrl = await uicons.eggIcon(this.config.general.stickerUrl, 'webp', data.level)
 			// data.imgUrl = `${this.config.general.imgUrl}egg${data.level}.png`
-			data.stickerUrl = `${this.config.general.stickerUrl}egg${data.level}.webp`
+			// data.stickerUrl = `${this.config.general.stickerUrl}egg${data.level}.webp`
 
 			if (data.tth.firstDateWasLater || ((data.tth.hours * 3600) + (data.tth.minutes * 60) + data.tth.seconds) < minTth) {
 				this.log.debug(`${logReference}: Egg at ${data.gymName} already disappeared or is about to expire in: ${data.tth.hours}:${data.tth.minutes}:${data.tth.seconds}`)

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -1,6 +1,7 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
+const uicons = require('../lib/uicons')
 
 class Raid extends Controller {
 	async raidWhoCares(data) {
@@ -225,8 +226,9 @@ class Raid extends Controller {
 				data.tth = moment.preciseDiff(Date.now(), data.end * 1000, true)
 				data.formname = data.formNameEng // deprecated
 				data.evolutionname = data.evolutionNameEng // deprecated
-				//				data.gif = pokemonGif(Number(data.pokemon_id)) // deprecated
-				data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.png`
+				// should be moved after the fold as is more expensive now
+				data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
+				// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.png`
 				data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.webp`
 				data.quickMoveId = data.move_1 ? data.move_1 : ''
 				data.chargeMoveId = data.move_2 ? data.move_2 : ''
@@ -389,7 +391,9 @@ class Raid extends Controller {
 			data.tth = moment.preciseDiff(Date.now(), data.start * 1000, true)
 			data.hatchTime = moment(data.start * 1000).tz(geoTz(data.latitude, data.longitude).toString()).format(this.config.locale.time)
 			data.hatchtime = data.hatchTime // deprecated
-			data.imgUrl = `${this.config.general.imgUrl}egg${data.level}.png`
+			// should be moved after the fold as is more expensive now
+			data.imgUrl = await uicons.eggIcon(this.config.general.imgUrl, 'png', data.level)
+			// data.imgUrl = `${this.config.general.imgUrl}egg${data.level}.png`
 			data.stickerUrl = `${this.config.general.stickerUrl}egg${data.level}.webp`
 
 			if (data.tth.firstDateWasLater || ((data.tth.hours * 3600) + (data.tth.minutes * 60) + data.tth.seconds) < minTth) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -1,7 +1,6 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
 const Controller = require('./controller')
-const uicons = require('../lib/uicons')
 
 class Raid extends Controller {
 	async raidWhoCares(data) {
@@ -224,11 +223,6 @@ class Raid extends Controller {
 				data.tth = moment.preciseDiff(Date.now(), data.end * 1000, true)
 				data.formname = data.formNameEng // deprecated
 				data.evolutionname = data.evolutionNameEng // deprecated
-				// should be moved after the fold as is more expensive now
-				data.imgUrl = await uicons.pokemonIcon(this.config.general.imgUrl, 'png', data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
-				data.stickerUrl = await uicons.pokemonIcon(this.config.general.stickerUrl, 'webp', data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
-				// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.png`
-				// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.webp`
 				data.quickMoveId = data.move_1 ? data.move_1 : ''
 				data.chargeMoveId = data.move_2 ? data.move_2 : ''
 				data.quickMoveNameEng = this.GameData.moves[data.move_1] ? this.GameData.moves[data.move_1].name : ''
@@ -262,6 +256,12 @@ class Raid extends Controller {
 
 					return []
 				}
+
+				data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
+				data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
+				// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.png`
+				// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.webp`
+
 				const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 				const jobs = []
 
@@ -396,11 +396,6 @@ class Raid extends Controller {
 			data.tth = moment.preciseDiff(Date.now(), data.start * 1000, true)
 			data.hatchTime = moment(data.start * 1000).tz(geoTz(data.latitude, data.longitude).toString()).format(this.config.locale.time)
 			data.hatchtime = data.hatchTime // deprecated
-			// should be moved after the fold as is more expensive now
-			data.imgUrl = await uicons.eggIcon(this.config.general.imgUrl, 'png', data.level)
-			data.stickerUrl = await uicons.eggIcon(this.config.general.stickerUrl, 'webp', data.level)
-			// data.imgUrl = `${this.config.general.imgUrl}egg${data.level}.png`
-			// data.stickerUrl = `${this.config.general.stickerUrl}egg${data.level}.webp`
 
 			if (data.tth.firstDateWasLater || ((data.tth.hours * 3600) + (data.tth.minutes * 60) + data.tth.seconds) < minTth) {
 				this.log.debug(`${logReference}: Egg at ${data.gymName} already disappeared or is about to expire in: ${data.tth.hours}:${data.tth.minutes}:${data.tth.seconds}`)
@@ -429,6 +424,12 @@ class Raid extends Controller {
 
 				return []
 			}
+
+			data.imgUrl = await this.imgUicons.eggIcon(data.level)
+			data.stickerUrl = await this.stickerUicons.eggIcon(data.level)
+			// data.imgUrl = `${this.config.general.imgUrl}egg${data.level}.png`
+			// data.stickerUrl = `${this.config.general.stickerUrl}egg${data.level}.webp`
+
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []
 

--- a/src/lib/poracleMessage/commands/backup.js
+++ b/src/lib/poracleMessage/commands/backup.js
@@ -38,6 +38,8 @@ exports.run = async (client, msg, args, options) => {
 			invasion: await client.query.selectAllQuery('invasion', { id: target.id, profile_no: currentProfileNo }),
 			weather: await client.query.selectAllQuery('weather', { id: target.id, profile_no: currentProfileNo }),
 			lures: await client.query.selectAllQuery('lures', { id: target.id, profile_no: currentProfileNo }),
+			gym: await client.query.selectAllQuery('gym', { id: target.id, profile_no: currentProfileNo }),
+			nests: await client.query.selectAllQuery('nests', { id: target.id, profile_no: currentProfileNo }),
 		}
 		backup.monsters.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
 		backup.raid.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
@@ -46,6 +48,8 @@ exports.run = async (client, msg, args, options) => {
 		backup.invasion.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
 		backup.weather.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
 		backup.lures.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
+		backup.gym.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
+		backup.nests.map((x) => { x.id = 0; delete x.uid; x.profile_no = 0 })
 
 		fs.writeFileSync(path.join(__dirname, '../../../../backups', `${args[0]}.json`), JSON.stringify(backup, null, '\t'))
 		msg.react(client.translator.translate('✅'))

--- a/src/lib/uicons.js
+++ b/src/lib/uicons.js
@@ -164,7 +164,7 @@ class Uicons {
 	}
 
 	async eggIcon(level, hatched = false, ex = false) {
-		const currentSet = await getAvailableIcons(this.url)
+		const currentSet = await getAvailableIcons(this.log, this.url)
 		if (currentSet) return `${this.url}/raid/egg/${resolveEggIcon(currentSet.raid.egg, this.imageType, level, hatched, ex)}`
 		if (this.fallback) return `${this.url}/egg${level}.${this.imageType}`
 		return null

--- a/src/lib/uicons.js
+++ b/src/lib/uicons.js
@@ -1,0 +1,189 @@
+const axios = require('axios')
+const { Mutex } = require('async-mutex')
+
+const mutex = new Mutex()
+const availablePokemon = {}
+
+function resolvePokemonIcon(availPokemon, imageType, pokemonId, form = 0, evolution = 0, gender = 0, costume = 0,
+	shiny = false) {
+	const evolutionSuffixes = evolution ? [`_e${evolution}`, ''] : ['']
+	const formSuffixes = form ? [`_f${form}`, ''] : ['']
+	const costumeSuffixes = costume ? [`_c${costume}`, ''] : ['']
+	const genderSuffixes = gender ? [`_g${gender}`, ''] : ['']
+	const shinySuffixes = shiny ? ['_s', ''] : ['']
+	for (const evolutionSuffix of evolutionSuffixes) {
+		for (const formSuffix of formSuffixes) {
+			for (const costumeSuffix of costumeSuffixes) {
+				for (const genderSuffix of genderSuffixes) {
+					for (const shinySuffix of shinySuffixes) {
+						const result = `${pokemonId}${evolutionSuffix}${formSuffix}${costumeSuffix}${genderSuffix}${shinySuffix}.${imageType}`
+						if (availPokemon.has(result)) return result
+					}
+				}
+			}
+		}
+	}
+	return `0.${imageType}` // substitute
+}
+
+function resolveGymIcon(availGym, imageType, teamId, trainerCount = 0, inBattle = false, ex = false) {
+	const trainerSuffixes = trainerCount ? [`_t${trainerCount}`, ''] : ['']
+	const inBattleSuffixes = inBattle ? ['_b', ''] : ['']
+	const exSuffixes = ex ? ['_ex', ''] : ['']
+	for (const trainerSuffix of trainerSuffixes) {
+		for (const inBattleSuffix of inBattleSuffixes) {
+			for (const exSuffix of exSuffixes) {
+				const result = `${teamId}${trainerSuffix}${inBattleSuffix}${exSuffix}.${imageType}`
+				if (availGym.has(result)) return result
+			}
+		}
+	}
+	return `0.${imageType}` // substitute
+}
+
+function resolvePokestopIcon(availPokestop, imageType, lureId, invasionActive = false, questActive = false) {
+	const invasionSuffixes = invasionActive ? ['_i', ''] : ['']
+	const questSuffixes = questActive ? ['_q', ''] : ['']
+	for (const invasionSuffix of invasionSuffixes) {
+		for (const questSuffix of questSuffixes) {
+			const result = `${lureId}${invasionSuffix}${questSuffix}.${imageType}`
+			if (availPokestop.has(result)) return result
+		}
+	}
+	return `0.${imageType}` // substitute
+}
+
+function resolveEggIcon(availEgg, imageType, level, hatched = false, ex = false) {
+	const hatchedSuffixes = hatched ? ['_h', ''] : ['']
+	const exSuffixes = ex ? ['_ex', ''] : ['']
+	for (const hatchedSuffix of hatchedSuffixes) {
+		for (const exSuffix of exSuffixes) {
+			const result = `${level}${hatchedSuffix}${exSuffix}.${imageType}`
+			if (availEgg.has(result)) return result
+		}
+	}
+	return `0.${imageType}` // substitute
+}
+
+function resolveInvasionIcon(availInvasion, imageType, gruntType) {
+	const result = `${gruntType}.${imageType}`
+	if (availInvasion.has(result)) return result
+
+	return `0.${imageType}` // substitute
+}
+
+function resolveItemIcon(itemAvail, imageType, id, amount = 0) {
+	if (amount) {
+		const resultAmount = `${id}_a${amount}.${imageType}`
+		if (itemAvail.has(resultAmount)) return resultAmount
+	}
+	const result = `${id}.${imageType}`
+	if (itemAvail.has(result)) return result
+
+	return `0.${imageType}` // substitute
+}
+
+const maxAge = 60 * 60 * 1000
+
+async function getAvailableIcons(baseUrl) {
+	let currentSet
+
+	try {
+		currentSet = availablePokemon[baseUrl]
+		if (currentSet === undefined || Date.now() - currentSet.lastRetrieved > maxAge) {
+			await mutex.runExclusive(async () => {
+				currentSet = availablePokemon[baseUrl]
+				if (currentSet === undefined || Date.now() - currentSet.lastRetrieved > maxAge) {
+					const response = await axios.get(`${baseUrl}/index.json`)
+					const results = response.data
+					currentSet = {
+						raid: {
+							egg: new Set(results.raid ? results.raid.egg : []),
+						},
+						gym: new Set(results.gym),
+						team: new Set(results.team),
+						weather: new Set(results.weather),
+						pokestop: new Set(results.pokestop),
+						reward: {
+							item: new Set(results.reward ? results.reward.item : []),
+							stardust: new Set(results.reward ? results.reward.stardust : []),
+							candy: new Set(results.reward ? results.reward.candy : []),
+							xl_candy: new Set(results.reward ? results.reward.xl_candy : []),
+							mega_resource: new Set(results.reward ? results.reward.mega_resource : []),
+						},
+						invasion: new Set(results.invasion),
+						pokemon: new Set(results.pokemon),
+					}
+					currentSet.lastRetrieved = Date.now()
+					availablePokemon[baseUrl] = currentSet
+				}
+			})
+		}
+	} catch (e) {
+		console.warn(e)
+	}
+	return currentSet
+}
+
+async function pokemonIcon(baseUrl, imageType, pokemonId, form = 0, evolution = 0, female = false, costume = 0, shiny = false) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/pokemon/${resolvePokemonIcon(currentSet.pokemon, imageType, pokemonId, form, evolution, female, costume, shiny)}` : null
+}
+
+async function eggIcon(baseUrl, imageType, level, hatched = false, ex = false) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/raid/egg/${resolveEggIcon(currentSet.raid.egg, imageType, level, hatched, ex)}` : null
+}
+
+async function invasionIcon(baseUrl, imageType, gruntType) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/invasion/${resolveInvasionIcon(currentSet.invasion, imageType, gruntType)}` : null
+}
+
+async function rewardItemIcon(baseUrl, imageType, itemId) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/reward/item/${resolveItemIcon(currentSet.reward.item, imageType, itemId)}` : null
+}
+
+async function rewardStardustIcon(baseUrl, imageType, amount) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/reward/stardust/${resolveItemIcon(currentSet.reward.stardust, imageType, amount)}` : null
+}
+
+async function rewardMegaEnergyIcon(baseUrl, imageType, itemId) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/reward/mega_resource/${resolveItemIcon(currentSet.reward.mega_resource, imageType, itemId)}` : null
+}
+
+async function rewardCandyIcon(baseUrl, imageType, pokemonId, amount) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/reward/candy/${resolveItemIcon(currentSet.reward.candy, imageType, pokemonId, amount)}` : null
+}
+
+async function rewardXlCandyIcon(baseUrl, imageType, pokemonId, amount) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/reward/xl_candy/${resolveItemIcon(currentSet.reward.xl_candy, imageType, pokemonId, amount)}` : null
+}
+
+async function gymIcon(baseUrl, imageType, teamId, trainerCount = 0, inBattle = false, ex = false) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/gym/${resolveGymIcon(currentSet.gym, imageType, teamId, trainerCount, inBattle, ex)}` : null
+}
+
+async function pokestopIcon(baseUrl, imageType, lureId = 0, invasionActive = false, questActive = false) {
+	const currentSet = await getAvailableIcons(baseUrl)
+	return currentSet ? `${baseUrl}/pokestop/${resolvePokestopIcon(currentSet.pokestop, imageType, lureId, invasionActive, questActive)}` : null
+}
+
+module.exports = {
+	pokemonIcon,
+	eggIcon,
+	invasionIcon,
+	rewardItemIcon,
+	rewardStardustIcon,
+	rewardMegaEnergyIcon,
+	rewardCandyIcon,
+	rewardXlCandyIcon,
+	gymIcon,
+	pokestopIcon,
+}

--- a/src/lib/uicons.js
+++ b/src/lib/uicons.js
@@ -85,7 +85,7 @@ function resolveItemIcon(itemAvail, imageType, id, amount = 0) {
 
 const maxAge = 60 * 60 * 1000
 
-async function getAvailableIcons(baseUrl) {
+async function getAvailableIcons(log, baseUrl) {
 	let currentSet
 
 	try {
@@ -120,70 +120,67 @@ async function getAvailableIcons(baseUrl) {
 			})
 		}
 	} catch (e) {
-		console.warn(e)
+		log.warn(`Cannot load UICONS file from ${baseUrl}`, e)
 	}
 	return currentSet
 }
 
-async function pokemonIcon(baseUrl, imageType, pokemonId, form = 0, evolution = 0, female = false, costume = 0, shiny = false) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/pokemon/${resolvePokemonIcon(currentSet.pokemon, imageType, pokemonId, form, evolution, female, costume, shiny)}` : null
+class Uicons {
+	constructor(url, imageType, log) {
+		this.url = url
+		this.imageType = imageType || 'png'
+		this.log = log || console
+	}
+
+	async pokemonIcon(pokemonId, form = 0, evolution = 0, female = false, costume = 0, shiny = false) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/pokemon/${resolvePokemonIcon(currentSet.pokemon, this.imageType, pokemonId, form, evolution, female, costume, shiny)}` : null
+	}
+
+	async eggIcon(level, hatched = false, ex = false) {
+		const currentSet = await getAvailableIcons(this.url)
+		return currentSet ? `${this.url}/raid/egg/${resolveEggIcon(currentSet.raid.egg, this.imageType, level, hatched, ex)}` : null
+	}
+
+	async invasionIcon(gruntType) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/invasion/${resolveInvasionIcon(currentSet.invasion, this.imageType, gruntType)}` : null
+	}
+
+	async rewardItemIcon(itemId) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/reward/item/${resolveItemIcon(currentSet.reward.item, this.imageType, itemId)}` : null
+	}
+
+	async rewardStardustIcon(amount) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/reward/stardust/${resolveItemIcon(currentSet.reward.stardust, this.imageType, amount)}` : null
+	}
+
+	async rewardMegaEnergyIcon(itemId) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/reward/mega_resource/${resolveItemIcon(currentSet.reward.mega_resource, this.imageType, itemId)}` : null
+	}
+
+	async rewardCandyIcon(pokemonId, amount) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/reward/candy/${resolveItemIcon(currentSet.reward.candy, this.imageType, pokemonId, amount)}` : null
+	}
+
+	async rewardXlCandyIcon(pokemonId, amount) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/reward/xl_candy/${resolveItemIcon(currentSet.reward.xl_candy, this.imageType, pokemonId, amount)}` : null
+	}
+
+	async gymIcon(teamId, trainerCount = 0, inBattle = false, ex = false) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/gym/${resolveGymIcon(currentSet.gym, this.imageType, teamId, trainerCount, inBattle, ex)}` : null
+	}
+
+	async pokestopIcon(lureId = 0, invasionActive = false, questActive = false) {
+		const currentSet = await getAvailableIcons(this.log, this.url)
+		return currentSet ? `${this.url}/pokestop/${resolvePokestopIcon(currentSet.pokestop, this.imageType, lureId, invasionActive, questActive)}` : null
+	}
 }
 
-async function eggIcon(baseUrl, imageType, level, hatched = false, ex = false) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/raid/egg/${resolveEggIcon(currentSet.raid.egg, imageType, level, hatched, ex)}` : null
-}
-
-async function invasionIcon(baseUrl, imageType, gruntType) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/invasion/${resolveInvasionIcon(currentSet.invasion, imageType, gruntType)}` : null
-}
-
-async function rewardItemIcon(baseUrl, imageType, itemId) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/reward/item/${resolveItemIcon(currentSet.reward.item, imageType, itemId)}` : null
-}
-
-async function rewardStardustIcon(baseUrl, imageType, amount) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/reward/stardust/${resolveItemIcon(currentSet.reward.stardust, imageType, amount)}` : null
-}
-
-async function rewardMegaEnergyIcon(baseUrl, imageType, itemId) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/reward/mega_resource/${resolveItemIcon(currentSet.reward.mega_resource, imageType, itemId)}` : null
-}
-
-async function rewardCandyIcon(baseUrl, imageType, pokemonId, amount) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/reward/candy/${resolveItemIcon(currentSet.reward.candy, imageType, pokemonId, amount)}` : null
-}
-
-async function rewardXlCandyIcon(baseUrl, imageType, pokemonId, amount) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/reward/xl_candy/${resolveItemIcon(currentSet.reward.xl_candy, imageType, pokemonId, amount)}` : null
-}
-
-async function gymIcon(baseUrl, imageType, teamId, trainerCount = 0, inBattle = false, ex = false) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/gym/${resolveGymIcon(currentSet.gym, imageType, teamId, trainerCount, inBattle, ex)}` : null
-}
-
-async function pokestopIcon(baseUrl, imageType, lureId = 0, invasionActive = false, questActive = false) {
-	const currentSet = await getAvailableIcons(baseUrl)
-	return currentSet ? `${baseUrl}/pokestop/${resolvePokestopIcon(currentSet.pokestop, imageType, lureId, invasionActive, questActive)}` : null
-}
-
-module.exports = {
-	pokemonIcon,
-	eggIcon,
-	invasionIcon,
-	rewardItemIcon,
-	rewardStardustIcon,
-	rewardMegaEnergyIcon,
-	rewardCandyIcon,
-	rewardXlCandyIcon,
-	gymIcon,
-	pokestopIcon,
-}
+module.exports = Uicons


### PR DESCRIPTION
UICONS support
Your imgUrl must be changed to one which supports uicons. I used:

```
     "imgUrl": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS",
     "stickerUrl": "https://raw.githubusercontent.com/bbdoc/tgUICONS/main",
```
for my testing

imgUrl now works for lures, gyms, and invasions - when it didn't properly before.

For reference, here is how to recreate some old image lookups if you want to use an old style repository

monsters: `https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/pmsf/pokemon_icon_{{pad0 pokemonId}}_{{#if formId}}{{formId}}{{else}}00{{/if}}.png`
