### PR TITLE
First class shiny support

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -33,7 +33,8 @@
       },
       "stickers": {
       },
-        "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
+      "requestShinyImages": false,
+      "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
     // disabledCommands - array of commands which will be disabled from use
       "disabledCommands": [],
     // disableXXX - disables individual hook processing for particular scanner webhook types.  disablePokestop disables

--- a/src/app.js
+++ b/src/app.js
@@ -26,6 +26,7 @@ const telegramController = require('./lib/telegram/middleware/controller')
 const DiscordReconciliation = require('./lib/discord/discordReconciliation')
 const TelegramReconciliation = require('./lib/telegram/telegramReconciliation')
 const PogoEventParser = require('./lib/pogoEventParser')
+const ShinyPossible = require('./lib/shinyLoader')
 
 const { Config } = require('./lib/configFetcher')
 
@@ -67,6 +68,7 @@ const Query = require('./controllers/query')
 
 const query = new Query(logs.controller, knex, config, geofence)
 const pogoEventParser = new PogoEventParser(logs.log)
+const shinyPossible = new ShinyPossible(logs.log)
 
 const gymCache = pcache.load('gymCache', path.join(__dirname, '../.cache'))
 
@@ -214,6 +216,30 @@ async function processPogoEvents() {
 	}
 
 	setTimeout(processPogoEvents, 6 * 60 * 60 * 1000) // 6 hours
+}
+
+async function processPossibleShiny() {
+	let file
+	log.info('ShinyPossible: Fetching new shiny file')
+
+	try {
+		file = await shinyPossible.download()
+	} catch (err) {
+		log.error('ShinyPossible: Cannot shiny file', err)
+		setTimeout(processPossibleShiny, 15 * 60 * 1000) // 15 mins
+		return
+	}
+
+	for (const relayWorker of workers) {
+		relayWorker.commandPort.postMessage(
+			{
+				type: 'shinyBroadcast',
+				data: file,
+			},
+		)
+	}
+
+	setTimeout(processPossibleShiny, 6 * 60 * 60 * 1000) // 6 hours
 }
 
 let ohbem
@@ -821,6 +847,7 @@ async function run() {
 	}
 
 	setTimeout(processPogoEvents, 30000)
+	setTimeout(processPossibleShiny, 30000)
 
 	chokidar.watch([
 		path.join(__dirname, '../config/dts.json'),

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -16,7 +16,7 @@ const urlShortener = require('../lib/urlShortener')
 const EmojiLookup = require('../lib/emojiLookup')
 
 class Controller extends EventEmitter {
-	constructor(log, db, config, dts, geofence, GameData, discordCache, translatorFactory, mustache, weatherData, statsData, eventParser) {
+	constructor(log, db, config, dts, geofence, GameData, discordCache, translatorFactory, mustache, weatherData, statsData, eventProviders) {
 		super()
 		this.db = db
 		this.cp = cp
@@ -32,7 +32,8 @@ class Controller extends EventEmitter {
 		this.earthRadius = 6371 * 1000 // m
 		this.weatherData = weatherData
 		this.statsData = statsData
-		this.eventParser = eventParser
+		this.eventParser = eventProviders && eventProviders.pogoEvents
+		this.shinyPossible = eventProviders && eventProviders.shinyPossible
 		//		this.controllerData = weatherCacheData || {}
 		this.tileserverPregen = new TileserverPregen(this.config, this.log)
 		this.emojiLookup = new EmojiLookup(GameData.utilData.emojis)

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -253,6 +253,7 @@ class Monster extends Controller {
 			data.pvpPokemonId = data.pokemon_id
 			data.pvpFormId = data.form
 			data.pvpEvolutionData = {}
+			data.shinyPossible = this.shinyPossible.isShinyPossible(data.pokemonId, data.formId)
 
 			let ohbemms = 0
 
@@ -407,8 +408,8 @@ class Monster extends Controller {
 				return []
 			}
 
-			data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form, 0, data.gender, data.costume, false)
-			data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form, 0, data.gender, data.costume, false)
+			data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form, 0, data.gender, data.costume, data.shinyPossible && this.config.general.requestShinyImages)
+			data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form, 0, data.gender, data.costume, data.shinyPossible && this.config.general.requestShinyImages)
 			// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.png`
 			// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}.webp`
 
@@ -510,6 +511,7 @@ class Monster extends Controller {
 					name: translator.translate(data.genderDataEng.name),
 					emoji: translator.translate(this.emojiLookup.lookup(data.genderDataEng.emoji, platform)),
 				}
+				data.shinyPossibleEmoji = data.shinyPossible ? translator.translate(this.emojiLookup.lookup('shiny', platform)) : ''
 				data.rarityName = translator.translate(data.rarityNameEng)
 				data.quickMoveName = data.weight && this.GameData.moves[data.quickMoveId] ? translator.translate(this.GameData.moves[data.quickMoveId].name) : ''
 				data.quickMoveEmoji = this.GameData.moves[data.quickMoveId] && this.GameData.utilData.types[this.GameData.moves[data.quickMoveId].type] ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.types[this.GameData.moves[data.quickMoveId].type].emoji, platform)) : ''

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -327,6 +327,9 @@ class Quest extends Controller {
 				data.energyMonstersNamesEng = data.rewardData.energyMonsters.map((item) => `${item.amount} ${item.nameEng} Mega Energy`).join(', ')
 
 				for (const monster of data.rewardData.candy) {
+					let [platform] = cares.type.split(':')
+					if (platform === 'webhook') platform = 'discord'
+
 					let monsterName
 
 					const mon = Object.values(this.GameData.monsters).find((m) => m.id === monster.pokemonId && !m.form.id)
@@ -375,9 +378,6 @@ class Quest extends Controller {
 					now: new Date(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
-
-				let [platform] = cares.type.split(':')
-				if (platform === 'webhook') platform = 'discord'
 
 				const templateType = 'quest'
 				const mustache = this.getDts(logReference, templateType, platform, cares.template, language)

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -154,6 +154,8 @@ class Quest extends Controller {
 			this.log.debug(`${logReference} Quest: data.questString: ${data.questStringEng}, data.rewardData: ${JSON.stringify(data.rewardData)}`)
 			data.dustAmount = data.rewardData.dustAmount
 			data.isShiny = data.rewardData.monsters.length > 0 ? data.rewardData.monsters[0].shiny : 0
+			data.shinyPossible = data.rewardData.monsters.length > 0 ? this.shinyPossible.isShinyPossible(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId) : false
+
 			data.itemAmount = data.rewardData.itemAmount
 			//			data.monsters = data.rewardData.monsters
 			//			data.monsterData = data.rewardData.monsterData
@@ -192,8 +194,8 @@ class Quest extends Controller {
 			data.stickerUrl = ''
 
 			if (data.rewardData.monsters.length > 0) {
-				data.imgUrl = await this.imgUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
-				data.stickerUrl = await this.stickerUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId)
+				data.imgUrl = await this.imgUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId, 0, 0, 0, data.isShiny || (data.shinyPossible && this.config.general.requestShinyImages))
+				data.stickerUrl = await this.stickerUicons.pokemonIcon(data.rewardData.monsters[0].pokemonId, data.rewardData.monsters[0].formId, 0, 0, 0, data.isShiny || (data.shinyPossible && this.config.general.requestShinyImages))
 				// data.imgUrl = data.rewardData.monsters.length > 0
 				// 	? `${this.config.general.imgUrl}pokemon_icon_${data.rewardData.monsters[0].pokemonId.toString().padStart(3, '0')}_${data.rewardData.monsters[0].formId.toString().padStart(2, '0')}.png`
 				// 	: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/production/jonmrich/assets/20150203194453red_pin.png'
@@ -356,6 +358,8 @@ class Quest extends Controller {
 					data.energyMonstersNamesEng,
 					data.candyMonstersNamesEng,
 				].filter((x) => x).join(', ')
+
+				data.shinyPossibleEmoji = data.shinyPossible ? translator.translate(this.emojiLookup.lookup('shiny', platform)) : ''
 
 				const view = {
 					...geoResult,

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -266,6 +266,8 @@ class Quest extends Controller {
 
 				const language = cares.language || this.config.general.locale
 				const translator = this.translatorFactory.Translator(language)
+				let [platform] = cares.type.split(':')
+				if (platform === 'webhook') platform = 'discord'
 
 				data.questString = translator.translate(data.questStringEng)
 
@@ -327,9 +329,6 @@ class Quest extends Controller {
 				data.energyMonstersNamesEng = data.rewardData.energyMonsters.map((item) => `${item.amount} ${item.nameEng} Mega Energy`).join(', ')
 
 				for (const monster of data.rewardData.candy) {
-					let [platform] = cares.type.split(':')
-					if (platform === 'webhook') platform = 'discord'
-
 					let monsterName
 
 					const mon = Object.values(this.GameData.monsters).find((m) => m.id === monster.pokemonId && !m.form.id)

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -304,6 +304,7 @@ class Raid extends Controller {
 					data.boostWeatherEmoji = data.boosted ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
 					data.gameWeatherName = data.weather ? translator.translate(data.gameWeatherNameEng) : ''
 					data.gameWeatherEmoji = data.weather ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
+					data.shinyPossibleEmoji = data.shinyPossible ? translator.translate(this.emojiLookup.lookup('shiny', platform)) : ''
 
 					data.quickMove = data.quickMoveName // deprecated
 					data.chargeMove = data.chargeMoveName // deprecated

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -228,6 +228,7 @@ class Raid extends Controller {
 				data.chargeMoveId = data.move_2 ? data.move_2 : ''
 				data.quickMoveNameEng = this.GameData.moves[data.move_1] ? this.GameData.moves[data.move_1].name : ''
 				data.chargeMoveNameEng = this.GameData.moves[data.move_2] ? this.GameData.moves[data.move_2].name : ''
+				data.shinyPossible = this.shinyPossible.isShinyPossible(data.pokemonId, data.formId)
 
 				data.ex = !!(data.ex_raid_eligible || data.is_ex_raid_eligible)
 				if (data.tth.firstDateWasLater || ((data.tth.hours * 3600) + (data.tth.minutes * 60) + data.tth.seconds) < minTth) {
@@ -258,8 +259,8 @@ class Raid extends Controller {
 					return []
 				}
 
-				data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
-				data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form, data.evolution, data.gender, data.costume, false)
+				data.imgUrl = await this.imgUicons.pokemonIcon(data.pokemon_id, data.form, data.evolution, data.gender, data.costume, data.shinyPossible && this.config.general.requestShinyImages)
+				data.stickerUrl = await this.stickerUicons.pokemonIcon(data.pokemon_id, data.form, data.evolution, data.gender, data.costume, data.shinyPossible && this.config.general.requestShinyImages)
 				// data.imgUrl = `${this.config.general.imgUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.png`
 				// data.stickerUrl = `${this.config.general.stickerUrl}pokemon_icon_${data.pokemon_id.toString().padStart(3, '0')}_${data.form ? data.form.toString() : '00'}${data.evolution > 0 ? `_${data.evolution.toString()}` : ''}.webp`
 

--- a/src/lib/handlebars.js
+++ b/src/lib/handlebars.js
@@ -188,5 +188,20 @@ module.exports = () => {
 		return f.map[value]
 	})
 
+	handlebars.registerHelper('map2', (name, value, value2, options) => {
+		const r = require('./customMap')
+
+		let f = r.find((x) => (x.name === name && x.language === options.data.language))
+		if (!f) {
+			f = r.find((x) => (x.name === name))
+		}
+
+		if (options.fn) {
+			return options.fn(f.map[value] || f.map[value2])
+		}
+
+		return f.map[value] || f.map[value2]
+	})
+
 	return handlebars
 }

--- a/src/lib/shinyLoader.js
+++ b/src/lib/shinyLoader.js
@@ -1,0 +1,67 @@
+const axios = require('axios')
+
+/**
+ * Class for handling jms412's shiny list
+ *
+ */
+class ShinyPossible {
+	constructor(log) {
+		this.log = log
+	}
+
+	/**
+	 * Download latest shiny list
+	 * @returns {Promise<any>}
+	 */
+	// eslint-disable-next-line class-methods-use-this
+	async download() {
+		const timeoutMs = 10000
+
+		const source = axios.CancelToken.source()
+		const timeout = setTimeout(() => {
+			source.cancel(`Timeout waiting for response - ${timeoutMs}ms`)
+			// Timeout Logic
+		}, timeoutMs)
+
+		const url = 'https://raw.githubusercontent.com/jms412/PkmnShinyMap/main/shinyPossible.json'
+		const result = await axios({
+			method: 'get',
+			url,
+			validateStatus: ((status) => status < 500),
+			cancelToken: source.token,
+		})
+
+		clearTimeout(timeout)
+		return result.data
+	}
+
+	/**
+	 * Set parser to use given shiny list
+	 * @param events
+	 */
+	loadMap(shinyPossibleMap) {
+		this.shinyPossibleMap = shinyPossibleMap
+	}
+
+	/**
+	 *
+	 * @param pokemonId
+	 * @param formId
+	 * @returns {{reason: string, name, time}}
+	 */
+	isShinyPossible(pokemonId, formId) {
+		if (!this.shinyPossibleMap) return false
+
+		try {
+			if (!this.shinyPossibleMap.map) return false
+			if (formId && `${pokemonId}_${formId}` in this.shinyPossibleMap.map) return true
+			if (pokemonId in this.shinyPossibleMap.map) return true
+
+			return false
+		} catch (err) {
+			this.log.error('ShinyPossible: Error parsing shiny file', err)
+		}
+	}
+}
+
+module.exports = ShinyPossible

--- a/src/lib/uicons.js
+++ b/src/lib/uicons.js
@@ -163,9 +163,9 @@ class Uicons {
 		this.log = log || console
 	}
 
-	async pokemonIcon(pokemonId, form = 0, evolution = 0, female = false, costume = 0, shiny = false) {
+	async pokemonIcon(pokemonId, form = 0, evolution = 0, gender = 0, costume = 0, shiny = false) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/pokemon/${resolvePokemonIcon(currentSet.pokemon, this.imageType, pokemonId, form, evolution, female, costume, shiny)}`
+		if (currentSet) return `${this.url}/pokemon/${resolvePokemonIcon(currentSet.pokemon, this.imageType, pokemonId, form, evolution, gender, costume, shiny)}`
 		if (this.fallback) return `${this.url}/pokemon_icon_${pokemonId.toString().padStart(3, '0')}_${form ? form.toString() : '00'}${evolution > 0 ? `_${evolution.toString()}` : ''}.${this.imageType}`
 		return null
 	}

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -828,6 +828,7 @@
 		"team-uncontested": "\u26AA",
 		"team-mystic": "\uD83D\uDD35",
 		"team-valor": "\uD83D\uDD34",
-		"team-instinct": "\uD83D\uDFE1"
+		"team-instinct": "\uD83D\uDFE1",
+		"shiny": "✨"
 	}
 }


### PR DESCRIPTION
Poracle downloads jms412's shiny possible map, and sets {{shinyPossible}} (to be used in #if statements) and {{shinyPossibleEmoji}} (which defaults to the typical sparklies but can be overridden in emoji.json)

In addition, the new config requestShinyImages will make poracle request the shiny version of an a pokemon from your UICONS provider if shiny is possible.

Support in monsters, raids and quests