### PR TITLE
Adds ISO formatted time to dts

### DIFF
--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -213,6 +213,7 @@ class Gym extends Controller {
 					tthm: data.tth.minutes,
 					tths: data.tth.seconds,
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
 

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -670,6 +670,7 @@ class Monster extends Controller {
 					tthm: data.tth.minutes,
 					tths: data.tth.seconds,
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 					pvpUserRanking: cares.pvp_ranking_worst === 4096 ? 0 : cares.pvp_ranking_worst,
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 					pvpDisplayMaxRank: this.config.pvp.pvpDisplayMaxRank,

--- a/src/controllers/nest.js
+++ b/src/controllers/nest.js
@@ -212,6 +212,7 @@ class Nest extends Controller {
 					tthm: data.tth.minutes,
 					tths: data.tth.seconds,
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
 

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -285,6 +285,7 @@ class Invasion extends Controller {
 					tths: data.tth.seconds,
 					confirmedTime: data.disappear_time_verified,
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 					genderData: data.genderDataEng ? {
 						name: translator.translate(data.genderDataEng.name),
 						emoji: translator.translate(this.emojiLookup.lookup(data.genderDataEng.emoji, platform)),

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -186,6 +186,7 @@ class Lure extends Controller {
 					tthm: data.tth.minutes,
 					tths: data.tth.seconds,
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
 

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -375,6 +375,7 @@ class Quest extends Controller {
 					tths: data.tth.seconds,
 					confirmedTime: data.disappear_time_verified,
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
 

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -349,6 +349,7 @@ class Raid extends Controller {
 						tths: data.tth.seconds,
 						confirmedTime: data.disappear_time_verified,
 						now: new Date(),
+						nowISO: new Date().toISOString(),
 						genderData: { name: translator.translate(data.genderDataEng.name), emoji: translator.translate(this.emojiLookup.lookup(data.genderDataEng.emoji, platform)) },
 						areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 					}
@@ -476,6 +477,7 @@ class Raid extends Controller {
 					tths: data.tth.seconds,
 					confirmedTime: data.disappear_time_verified,
 					now: new Date(),
+                                        nowISO: new Date().toISOString(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
 

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -477,7 +477,7 @@ class Raid extends Controller {
 					tths: data.tth.seconds,
 					confirmedTime: data.disappear_time_verified,
 					now: new Date(),
-                                        nowISO: new Date().toISOString(),
+					nowISO: new Date().toISOString(),
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 				}
 

--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -413,6 +413,7 @@ class Weather extends Controller {
 					id: data.s2_cell_id,
 					areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name.replace(/'/gi, '')).join(', '),
 					now: new Date(),
+					nowISO: new Date().toISOString(),
 				}
 
 				const templateType = 'weatherchange'


### PR DESCRIPTION

## Description
In addition to the {{now}} handlebar that can be used in dts, this adds {{nowISO}} which is the same thing as {{now}} except in ISO format

## Motivation and Context
While using {{now}} works in the footer of messages directly from the bot, to add the timestamp in the footer of webhooks you have to use the ISO formatted time.

## How Has This Been Tested?
Been running this change on my system for over a week. Webhook footer timestamps work using {{nowISO}}

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.