### PR TITLE
Update tile defaults to use imgUrl / poracle configured repository

### DIFF
--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -376,6 +376,11 @@ class Weather extends Controller {
 					const activePokemons = cares.caredPokemons.filter((pokemon) => pokemon.alteringWeathers.includes(data.condition))
 
 					data.activePokemons = activePokemons.slice(0, this.config.weather.showAlteredPokemonMaxCount) || null
+					if (data.activePokemons) {
+						for (const mon of data.activePokemons) {
+							mon.imgUrl = await this.imgUicons.pokemonIcon(mon.pokemon_id, mon.form)
+						}
+					}
 				}
 				if (pregenerateTile && this.config.geocoding.staticMapType.weather && this.config.weather.showAlteredPokemon && this.config.weather.showAlteredPokemonStaticMap) {
 					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, this.config.geocoding.staticMapType.weather)

--- a/src/lib/poracleMessage/commands/info.js
+++ b/src/lib/poracleMessage/commands/info.js
@@ -3,6 +3,7 @@ const geoTz = require('geo-tz')
 const EmojiLookup = require('../../emojiLookup')
 const helpCommand = require('./help')
 const weatherTileGenerator = require('../../weatherTileGenerator')
+const Uicons = require('../../uicons')
 
 exports.run = async (client, msg, args, options) => {
 	try {
@@ -124,9 +125,12 @@ exports.run = async (client, msg, args, options) => {
 				}
 
 				const weatherId = weatherInfo[currentHourTimestamp]
-				const staticMap = client.config.geocoding.staticProvider === 'tileservercache'
-					? await weatherTileGenerator.generateWeatherTile(client.query.tileserverPregen, weatherCellId, weatherId)
-					: null
+				let staticMap = null
+				if (client.config.geocoding.staticProvider === 'tileservercache') {
+					const imgUicons = new Uicons(client.config.general.imgUrl, 'png', client.log)
+
+					staticMap = await weatherTileGenerator.generateWeatherTile(client.query.tileserverPregen, weatherCellId, weatherId, imgUicons)
+				}
 
 				// Build forecast information
 

--- a/src/lib/weatherTileGenerator.js
+++ b/src/lib/weatherTileGenerator.js
@@ -6,10 +6,14 @@ function getWeatherCellId(lat, lon) {
 	return S2.keyToId(weatherCellKey)
 }
 
-async function generateWeatherTile(tileserverPregen, cellId, weatherId) {
+async function generateWeatherTile(tileserverPregen, cellId, weatherId, imgUicons) {
 	const data = {}
 
 	data.condition = weatherId
+	if (imgUicons) {
+		data.imgUrl = await imgUicons.weatherIcon(data.condition)
+	}
+
 	const s2cell = new S2ts.S2Cell(new S2ts.S2CellId(cellId))
 	const s2cellCenter = S2ts.S2LatLng.fromPoint(s2cell.getCenter())
 	data.latitude = s2cellCenter.latRadians * 180 / Math.PI

--- a/tileservercache_templates/poracle-gym.json
+++ b/tileservercache_templates/poracle-gym.json
@@ -8,7 +8,7 @@
   "scale": 1,
   "markers": [
     {
-      "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/gyms/gym_#(teamId).png",
+      "url": "#(imgUrl)",
       "latitude": #(latitude),
       "longitude": #(longitude),
       "width": 50,

--- a/tileservercache_templates/poracle-monster.json
+++ b/tileservercache_templates/poracle-monster.json
@@ -8,8 +8,7 @@
     "scale": 1,
     "markers": [
         {
-            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
-            "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
+            "url": "#(imgUrl)",
             "latitude": #(latitude),
             "longitude": #(longitude),
             "width": 50,

--- a/tileservercache_templates/poracle-multi-monster.json
+++ b/tileservercache_templates/poracle-multi-monster.json
@@ -15,8 +15,7 @@
                         "scale": 2,
                         "markers": [
                             {
-                                "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
-                                "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
+                                "url": "#(imgUrl)",
                                 "latitude": #(latitude),
                                 "longitude": #(longitude),
                                 "width": 20,
@@ -47,8 +46,7 @@
                         "scale": 1,
                         "markers": [
                             {
-                                "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
-                                "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
+                                "url": "#(imgUrl)",
                                 "latitude": #(latitude),
                                 "longitude": #(longitude),
                                 "width": 60,

--- a/tileservercache_templates/poracle-nest.json
+++ b/tileservercache_templates/poracle-nest.json
@@ -27,8 +27,7 @@
 
   "markers": [
   {
-    "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
-    "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
+    "url": "#(imgUrl)",
     "latitude": #(latitude),
     "longitude": #(longitude),
     "width": 30,

--- a/tileservercache_templates/poracle-pokestop.json
+++ b/tileservercache_templates/poracle-pokestop.json
@@ -8,7 +8,7 @@
     "scale": 1,
     "markers": [
         {
-            "url": "#if(lureTypeId != nil):https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/RDM_OS_128/pokestop/#(lureTypeId-500).png#elseif(gruntTypeId != nil):https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/RDM_OS_128/pokestop/i0.png#else:https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/RDM_OS_128/pokestop/0.png#endif",
+            "url": "#(imgUrl)",
             "latitude": #(latitude),
             "longitude": #(longitude),
             "width": 50,

--- a/tileservercache_templates/poracle-raid.json
+++ b/tileservercache_templates/poracle-raid.json
@@ -8,12 +8,7 @@
     "scale": 1,
     "markers": [
         {
-            #if(pokemon_id != nil && pokemon_id != 0):
-            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif#if(evolution > 0):_#pad(evolution,1)#endif.png",
-            "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pokemon_id,3)_00.png",
-            #else:
-            "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/egg#(level).png",
-            #endif
+            "url": "#(imgUrl)",
             "latitude": #(latitude),
             "longitude": #(longitude),
             "width": 50,

--- a/tileservercache_templates/poracle-weather.json
+++ b/tileservercache_templates/poracle-weather.json
@@ -10,7 +10,7 @@
     #if(activePokemons != nil):
      #for(pok in activePokemons):
      {
-         "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_#pad(pok.pokemon_id,3)_#if(form != nil):#pad(form, 2)#else:00#endif.png",
+         "url": "#(pok.imgUrl)",
          "latitude": #(pok.latitude),
          "longitude": #(pok.longitude),
          "width": 20,
@@ -19,8 +19,7 @@
      #endfor
      #endif
     {
-      "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/ICONS_STANDARD/weather/#(condition).png",
-      "fallback_url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/pokemon_icon_025_00.png",
+      "url": "#(imgUrl)",
       "height": 40,
       "width": 40,
       "x_offset": 0,


### PR DESCRIPTION
The sample tiles had their own tile lookups, this converts them to use the poracle calculated tile (from uicons or not)
