### PR TITLE
Fixed enable/disable command bugs 

### DIFF
--- a/src/lib/poracleMessage/commands/disable.js
+++ b/src/lib/poracleMessage/commands/disable.js
@@ -22,7 +22,7 @@ exports.run = async (client, msg, args, options) => {
 		for (const id of targets) {
 			client.log.info(`Disable ${id}`)
 
-			await client.query.updateQuery('humans', { admin_disable: 1, disabled_date: null }, { id })
+			await client.query.updateQuery('humans', { admin_disable: 1, disabled_date: null }, { id: id })
 		}
 		await msg.react('✅')
 	} catch (err) {

--- a/src/lib/poracleMessage/commands/disable.js
+++ b/src/lib/poracleMessage/commands/disable.js
@@ -22,7 +22,7 @@ exports.run = async (client, msg, args, options) => {
 		for (const id of targets) {
 			client.log.info(`Disable ${id}`)
 
-			await client.query.updateQuery('humans', { admin_disable: 1, disabled_date: null }, { id: id })
+			await client.query.updateQuery('humans', { admin_disable: 1, disabled_date: null }, { id })
 		}
 		await msg.react('✅')
 	} catch (err) {

--- a/src/lib/poracleMessage/commands/enable.js
+++ b/src/lib/poracleMessage/commands/enable.js
@@ -22,7 +22,7 @@ exports.run = async (client, msg, args, options) => {
 		for (const id of targets) {
 			client.log.info(`Enable ${id}`)
 
-			await client.query.updateQuery('humans', { admin_disable: 0, disabled_date: null }, { id: id })
+			await client.query.updateQuery('humans', { admin_disable: 0, disabled_date: null }, { id })
 		}
 		await msg.react('✅')
 	} catch (err) {

--- a/src/lib/poracleMessage/commands/enable.js
+++ b/src/lib/poracleMessage/commands/enable.js
@@ -17,12 +17,12 @@ exports.run = async (client, msg, args, options) => {
 		// Make list of ids
 		const mentions = msg.getMentions()
 		const targets = mentions.map((x) => x.id)
-		targets.push(args.filter((x) => parseInt(x, 10)))
+		targets.push(...(args.filter((x) => parseInt(x, 10))))
 
 		for (const id of targets) {
 			client.log.info(`Enable ${id}`)
 
-			await client.query.updateQuery('humans', { admin_disable: 0, disabled_date: null }, { id })
+			await client.query.updateQuery('humans', { admin_disable: 0, disabled_date: null }, { id: id })
 		}
 		await msg.react('✅')
 	} catch (err) {


### PR DESCRIPTION
There were errors execute the update query when executing either the enable or disable commands. The 'id' values weren't getting passed in. 

## Description
Included the 'id' value in their respective poracleMessage commands. Also fixed enumeration of mentions in the enable command. 

## Motivation and Context
Needed commands to work. 

## How Has This Been Tested?
Allow rate limiter function to stop/disable the user. Attempt to perform enable. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.