### PR TITLE
Add littleLeagueCanEvolve setting

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -169,8 +169,9 @@
   //
   "pvp": {
       "dataSource": "webhook",                      // webhook - from hooks, internal - internal calculator
-      "levelCaps": [50],                            // level caps to be included in internal rank calculations - alternative could be [50, 51]
-      "includeMegaEvolution": false,                // whether to include mega evolutions in rank calculations
+      "levelCaps": [50],                            // internal: level caps to be included in internal rank calculations - alternative could be [50, 51]
+      "includeMegaEvolution": false,                // internal: whether to include mega evolutions in rank calculations
+      "littleLeagueCanEvolve": false,               // internal: whether little league mons that are evolved are included
       "pvpEvolutionDirectTracking": false,          // pvpEvolutionDirectTracking - whether users can track pvp evolutions directly (eg vaporean would match an eevee)
     // pvpDisplay* - these are variables that will be passed into DTS to allow you to perform
     //   a filtering calculation

--- a/src/app.js
+++ b/src/app.js
@@ -246,7 +246,10 @@ async function initialiseOhbem() {
 			// all of the following options are optional and these (except for pokemonData) are the default values
 			// read the documentation for more information
 			leagues: {
-				little: 500,
+				little: {
+					little: !config.pvp.littleLeagueCanEvolve,
+					cap: 500,
+				},
 				great: 1500,
 				ultra: 2500,
 				//	master: null,

--- a/src/controllerWorker.js
+++ b/src/controllerWorker.js
@@ -298,5 +298,4 @@ if (!isMainThread) {
 
 	monsterController.on('userCares', (data) => notifyWeatherController('userCares', data))
 	setInterval(currentStatus, 60000)
-	setImmediate(async () => monsterController.initialiseObem())
 }

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -1,6 +1,5 @@
 const geoTz = require('geo-tz')
 const moment = require('moment-timezone')
-const Ohbem = require('ohbem')
 const Controller = require('./controller')
 require('moment-precise-range-plugin')
 
@@ -10,30 +9,6 @@ class Monster extends Controller {
 		const nonBoostingWeathers = [1, 2, 3, 4, 5, 6, 7].filter((weather) => !boostingWeathers.includes(weather))
 		if (boostStatus > 0) return nonBoostingWeathers
 		return boostingWeathers
-	}
-
-	async initialiseObem() {
-		// This per worker method will likely be removed
-
-		if (this.config.pvp.dataSource === 'internal2') {
-			const pokemonData = await Ohbem.fetchPokemonData()
-
-			this.ohbem = new Ohbem({
-				// all of the following options are optional and these (except for pokemonData) are the default values
-				// read the documentation for more information
-				leagues: {
-					little: 500,
-					great: 1500,
-					ultra: 2500,
-					master: null,
-				},
-				levelCaps: this.config.pvp.levelCaps,
-				// The following field is required to use queryPvPRank
-				// You can skip populating it if you only want to use other helper methods
-				pokemonData,
-				cachingStrategy: Ohbem.cachingStrategies.balanced,
-			})
-		}
 	}
 
 	async monsterWhoCares(data) {
@@ -250,20 +225,8 @@ class Monster extends Controller {
 			data.pvpEvolutionData = {}
 			data.shinyPossible = this.shinyPossible.isShinyPossible(data.pokemonId, data.formId)
 
-			let ohbemms = 0
-
 			if (this.config.logger.enableLogs.pvp && data.iv >= 0) {
 				this.log.verbose(`${data.encounter_id}: PVP From hook: "great":${JSON.stringify(data.pvp_rankings_great_league)} "ultra":${JSON.stringify(data.pvp_rankings_ultra_league)}`)
-			}
-
-			if (this.ohbem && data.iv >= 0) {
-				const ohbemstart = process.hrtime()
-
-				const ohbemCalc = this.ohbem.queryPvPRank(+data.pokemonId, +data.form || 0, +data.costume, +data.gender, +data.atk, +data.def, +data.sta, +data.level)
-				const ohbemend = process.hrtime(ohbemstart)
-				ohbemms = ohbemend[1] / 1000000
-
-				data.ohbem_pvp = ohbemCalc
 			}
 
 			if (data.ohbem_pvp) {
@@ -273,7 +236,7 @@ class Monster extends Controller {
 					this.log.verbose(`${data.encounter_id}: PVP From ohbem: ${JSON.stringify(pvpData)}`)
 				}
 
-				if (this.config.pvp.dataSource === 'internal' || this.config.pvp.dataSource === 'internal2') {
+				if (this.config.pvp.dataSource === 'internal') {
 					if (pvpData.great) {
 						data.pvp_rankings_great_league = pvpData.great.filter((x) => this.config.pvp.includeMegaEvolution || !x.evolution)
 					} else delete data.pvp_rankings_great_league
@@ -376,9 +339,9 @@ class Monster extends Controller {
 			let hrend = process.hrtime(hrstart)
 			const hrendms = hrend[1] / 1000000
 			if (whoCares.length) {
-				this.log.info(`${data.encounter_id}: ${monster.name}{${encountered ? `${data.cp}/${data.iv}` : '?'}} appeared at [${data.latitude.toFixed(3)},${data.longitude.toFixed(3)}] areas (${data.matched}) and ${whoCares.length} humans cared. (${hrendms}${this.ohbem ? `/${ohbemms}` : ''} ms)`)
+				this.log.info(`${data.encounter_id}: ${monster.name}{${encountered ? `${data.cp}/${data.iv}` : '?'}} appeared at [${data.latitude.toFixed(3)},${data.longitude.toFixed(3)}] areas (${data.matched}) and ${whoCares.length} humans cared. (${hrendms} ms)`)
 			} else {
-				this.log.verbose(`${data.encounter_id}: ${monster.name}{${encountered ? `${data.cp}/${data.iv}` : '?'}} appeared at [${data.latitude.toFixed(3)},${data.longitude.toFixed(3)}] areas (${data.matched}) and ${whoCares.length} humans cared. (${hrendms}${this.ohbem ? `/${ohbemms}` : ''} ms)`)
+				this.log.verbose(`${data.encounter_id}: ${monster.name}{${encountered ? `${data.cp}/${data.iv}` : '?'}} appeared at [${data.latitude.toFixed(3)},${data.longitude.toFixed(3)}] areas (${data.matched}) and ${whoCares.length} humans cared. (${hrendms} ms)`)
 			}
 
 			if (!whoCares.length) return []


### PR DESCRIPTION
Add littleLeagueCanEvolve setting in default.json - swapping this allows little league tracking to include evolved pokemon (for little jungle cup)

Removed alternative ohbem execution code from pre-release performance testing which we haven't needed in production