### PR TITLE
Additional timing stats

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -104,6 +104,7 @@
         "telegram": true,                 // turn on telegram log (for outbound messages to telegram users, groups and channels)
         "pvp": false                      // whether to log pvp info/calculations (at verbose level)
       },
+      "timingStats": false,               // whether to increase log level of key timing stats to 'verbose' (from debug)
       "dailyLogLimit": 7,                 // the number of days to keep the daily logs (everything aside from webhooks)
       "webhookLogLimit": 12               // the number of hours to keep the webhook logs, if enabled
   },

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -639,7 +639,7 @@ class Monster extends Controller {
 			}
 			hrend = process.hrtime(hrstart)
 			const hrendprocessing = hrend[1] / 1000000
-			this.log.debug(`${data.encounter_id}: ${monster.name} appeared and ${whoCares.length} humans cared [end]. (${hrendms} ms sql ${hrendprocessing} ms processing dts)`)
+			this.log.verbose(`${data.encounter_id}: ${monster.name} appeared and ${whoCares.length} humans cared [end]. (${hrendms} ms sql + ${hrendprocessing} ms processing dts)`)
 
 			return jobs
 		} catch (e) {

--- a/src/lib/discord/discordWorker.js
+++ b/src/lib/discord/discordWorker.js
@@ -1,6 +1,7 @@
 const { Client, DiscordAPIError } = require('discord.js')
 const fsp = require('fs').promises
 const NodeCache = require('node-cache')
+const { performance } = require('perf_hooks')
 const FairPromiseQueue = require('../FairPromiseQueue')
 
 const noop = () => { }
@@ -133,7 +134,11 @@ class Worker {
 				data.message.embed.files = [{ attachment: url, name: 'map.png' }]
 			}
 
+			const startTime = performance.now()
 			const msg = await user.send(data.message.content || '', data.message)
+			const endTime = performance.now();
+			(this.config.logger.timingStats ? this.logs.discord.verbose : this.logs.discord.debug)(`${logReference}: #${this.id} -> ${data.name} ${data.target} USER (${endTime - startTime} ms)`)
+
 			if (data.clean) {
 				msg.delete({ timeout: msgDeletionMs, reason: 'Removing old stuff.' }).catch(noop)
 				this.discordMessageTimeouts.set(msg.id, { type: 'user', id: data.target }, Math.floor(msgDeletionMs / 1000) + 1)
@@ -162,7 +167,11 @@ class Worker {
 				data.message.embed.files = [{ attachment: url, name: 'map.png' }]
 			}
 
+			const startTime = performance.now()
 			const msg = await channel.send(data.message.content || '', data.message)
+			const endTime = performance.now();
+			(this.config.logger.timingStats ? this.logs.discord.verbose : this.logs.discord.debug)(`${logReference}: #${this.id} -> ${data.name} ${data.target} CHANNEL (${endTime - startTime} ms)`)
+
 			if (data.clean) {
 				msg.delete({ timeout: msgDeletionMs, reason: 'Removing old stuff.' }).catch(() => { })
 				this.discordMessageTimeouts.set(msg.id, { type: 'channel', id: data.target }, Math.floor(msgDeletionMs / 1000) + 1)

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -42,8 +42,8 @@ class TileserverPregen {
 				this.log.warn(`${logReference}: Failed to Pregenerate ${templateType}StaticMap. Got invalid response from tileserver - ${result.data}`)
 				return null
 			}
-			const tileResult = result.data.startsWith('http') ? result.data : `${this.config.geocoding.staticProviderURL}/${mapType}/pregenerated/${result.data}`
-			this.log.debug(`${logReference}: Tile generated ${tileResult} (${hrendms} ms)`)
+			const tileResult = result.data.startsWith('http') ? result.data : `${this.config.geocoding.staticProviderURL}/${mapType}/pregenerated/${result.data}`;
+			(this.config.logger.timingStats ? this.log.verbose : this.log.debug)(`${logReference}: Tile generated ${tileResult} (${hrendms} ms)`)
 
 			return tileResult
 		} catch (error) {

--- a/src/util/generateData.js
+++ b/src/util/generateData.js
@@ -12,11 +12,11 @@ const fetch = async (url) => {
 		}
 		return await data.json()
 	} catch (e) {
-		console.error(e, `Unable to fetch ${url}`)
+		log.warn(e, `Unable to fetch ${url}`)
 	}
 }
 
-let update = async function update() {
+const update = async function update() {
 	// Write monsters/moves/items/questTypes
 	try {
 		log.info('Fetching latest Game Master...')
@@ -78,8 +78,8 @@ let update = async function update() {
 	}
 }
 
-module.exports.update = update;
+module.exports.update = update
 
 if (require.main === module) {
-	update().then(() => { console.log("OK") } );
+	update().then(() => { log.info('OK') })
 }


### PR DESCRIPTION
Ever felt that poracle gave you insufficient log information about its performance?
I doubt it. But @dkmur loves this stuff, and so do I!

Additional timing information is now available at debug level; and this can be brought up to verbose level by the simple toggling of a config item if you love _all the stats_