### PR TITLE
Choose best rank for direct evolution scanning

### DIFF
--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -256,13 +256,16 @@ class Monster extends Controller {
 				let bestCP = 0
 				if (leagueData) {
 					for (const stats of leagueData) {
+						let newBest = false
 						if (stats.rank && stats.rank < bestRank) {
 							bestRank = stats.rank
 							bestCP = stats.cp || 0
+							newBest = true
 						} else if (stats.rank && stats.cp && stats.rank === bestRank && stats.cp > bestCP) {
 							bestCP = stats.cp
+							newBest = true
 						}
-						if (this.config.pvp.pvpEvolutionDirectTracking && stats.rank && stats.cp && stats.pokemon !== data.pokemon_id && stats.rank <= this.config.pvp.pvpFilterMaxRank && stats.cp >= minCp) {
+						if (newBest && !stats.evolution && this.config.pvp.pvpEvolutionDirectTracking && stats.rank && stats.cp && stats.pokemon !== data.pokemon_id && stats.rank <= this.config.pvp.pvpFilterMaxRank && stats.cp >= minCp) {
 							const leagueStats = {}
 							leagueStats[league] = {
 								rank: stats.rank,


### PR DESCRIPTION
If PVP direct evolution tracking, and multiple level caps were being calculated by ohbem (or sent from chuck) the last value for each league was being used in favour of the best value.
Now the best ranked stats are used for the direct evolution scan
