### PR TITLE
Populate tile server tiles with pokestops and gyms

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -441,25 +441,20 @@
       "staticProviderURL": "",
       "tileserverSettings": {
         "default": {
-          "type": "staticMap",
+          "type": "staticMap",          // can be staticMap or multiStaticMap - default is unlike to be changed
           "width": 500,
           "height": 250,
           "zoom": 15,
           "pregenerate": true,
           "includeStops": false
         }
+        // add further types to 'override' - type can be monster, raid, pokestop, quest, weather, location, nest, gym
+        // override values can be any of the above fields
+//      ,  "monster": {
+//          "type": "staticMap",
+//          "includeStops": true
+//        }
       },
-    // staticMapType - can be either staticMap, multiStaticMap or empty to disable static map creation for this hook type
-//      "staticMapType": {
-//        "pokemon": "staticMap",
-//        "raid": "staticMap",
-//        "pokestop": "staticMap",
-//        "quest": "staticMap",
-//        "weather": "staticMap",
-//        "location": "staticMap",
-//        "nest": "staticMap",
-//        "gym": "staticMap"
-//      },
     // geocodingKey - google keys for geolocation - can be more than one in this array and poracle will cycle
       "geocodingKey":[""],
     // staticKey - google or mapquest keys for provision of tiles - can be array and poracle will cycle, and parameters to use when requesting tiles

--- a/config/default.json
+++ b/config/default.json
@@ -439,17 +439,27 @@
     //   uses templates (examples provided in tileservercache_templates folder)
       "staticProvider": "none",
       "staticProviderURL": "",
-    // staticMapType - can be either staticMap, multiStaticMap or empty to disable static map creation for this hook type
-      "staticMapType": {
-        "pokemon": "staticMap",
-        "raid": "staticMap",
-        "pokestop": "staticMap",
-        "quest": "staticMap",
-        "weather": "staticMap",
-        "location": "staticMap",
-        "nest": "staticMap",
-        "gym": "staticMap"
+      "tileserverSettings": {
+        "default": {
+          "type": "staticMap",
+          "width": 500,
+          "height": 250,
+          "zoom": 15,
+          "pregenerate": true,
+          "includeStops": false
+        }
       },
+    // staticMapType - can be either staticMap, multiStaticMap or empty to disable static map creation for this hook type
+//      "staticMapType": {
+//        "pokemon": "staticMap",
+//        "raid": "staticMap",
+//        "pokestop": "staticMap",
+//        "quest": "staticMap",
+//        "weather": "staticMap",
+//        "location": "staticMap",
+//        "nest": "staticMap",
+//        "gym": "staticMap"
+//      },
     // geocodingKey - google keys for geolocation - can be more than one in this array and poracle will cycle
       "geocodingKey":[""],
     // staticKey - google or mapquest keys for provision of tiles - can be array and poracle will cycle, and parameters to use when requesting tiles

--- a/config/default.json
+++ b/config/default.json
@@ -34,6 +34,7 @@
       "stickers": {
       },
       "requestShinyImages": false,
+      "populatePokestopName": false,            // [RDM] lookup nearby pokestop names in scanner db for nearby mons
       "locale": "en",                           // default locale for Poracle - eg en, fr, de, it, ru
     // disabledCommands - array of commands which will be disabled from use
       "disabledCommands": [],

--- a/src/controllerWorker.js
+++ b/src/controllerWorker.js
@@ -8,6 +8,7 @@ const PogoEventParser = require('./lib/pogoEventParser')
 const ShinyPossible = require('./lib/shinyLoader')
 const logs = require('./lib/logger')
 const GameData = require('./lib/GameData')
+const scannerFactory = require('./lib/scanner/scannerFactory')
 
 const { log } = logs
 
@@ -18,7 +19,7 @@ const { workerId } = workerData
 logs.setWorkerId(workerId)
 
 const {
-	config, knex, dts, geofence, translatorFactory,
+	config, knex, scannerKnex, dts, geofence, translatorFactory,
 } = Config(false)
 
 const PromiseQueue = require('./lib/PromiseQueue')
@@ -43,19 +44,20 @@ const controllerWeatherManager = new ControllerWeatherManager(config, log)
 const statsData = new StatsData(config, log)
 const pogoEventParser = new PogoEventParser(log)
 const shinyPossible = new ShinyPossible(log)
+const scannerQuery = scannerFactory.createScanner(scannerKnex, config.database.scannerType)
 
 const eventParsers = {
 	shinyPossible,
 	pogoEvents: pogoEventParser,
 }
 
-const monsterController = new MonsterController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
-const raidController = new RaidController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
-const questController = new QuestController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
-const pokestopController = new PokestopController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
-const nestController = new NestController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
-const pokestopLureController = new PokestopLureController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
-const gymController = new GymController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const monsterController = new MonsterController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const raidController = new RaidController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const questController = new QuestController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const pokestopController = new PokestopController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const nestController = new NestController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const pokestopLureController = new PokestopLureController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
+const gymController = new GymController(logs.controller, knex, scannerQuery, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache, controllerWeatherManager, statsData, eventParsers)
 
 const hookQueue = []
 let queuePort

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -229,30 +229,9 @@ class Controller extends EventEmitter {
 	}
 
 	async getStaticMapUrl(logReference, data, maptype, keys, pregenKeys) {
-		const tileTemplate = maptype
-		const configTemplate = maptype === 'monster' ? 'pokemon' : maptype
 		switch (this.config.geocoding.staticProvider.toLowerCase()) {
 			case 'tileservercache': {
-				const tileServerOptions = {}
-				Object.assign(tileServerOptions, {
-					type: 'staticMap',
-					includeStops: false,
-					width: 500,
-					height: 250,
-					zoom: 15,
-					pregenerate: true,
-				}, this.config.geocoding.tileserverSettings ? this.config.geocoding.tileserverSettings.default : null)
-
-				if (this.config.geocoding.staticMapType && this.config.geocoding.staticMapType[configTemplate]) {
-					Object.assign(tileServerOptions, {
-						type: this.config.geocoding.staticMapType[configTemplate].startsWith('*') ? this.config.geocoding.staticMapType[configTemplate].substring(1) : this.config.geocoding.staticMapType[configTemplate],
-						pregenerate: !this.config.geocoding.staticMapType[configTemplate].startsWith('*'),
-					})
-				}
-
-				if (this.config.geocoding.tileserverSettings && this.config.geocoding.tileserverSettings[tileTemplate]) {
-					Object.assign(tileServerOptions, this.config.geocoding.tileserverSettings[tileTemplate])
-				}
+				const tileServerOptions = this.tileserverPregen.getConfigForTileType(maptype)
 
 				if (tileServerOptions.includeStops && tileServerOptions.pregenerate && this.scannerQuery) {
 					const limits = this.tileserverPregen.limits(data.latitude, data.longitude, tileServerOptions.width, tileServerOptions.height, tileServerOptions.zoom)
@@ -276,12 +255,12 @@ class Controller extends EventEmitter {
 
 				if (tileServerOptions.type && tileServerOptions.type !== 'none') {
 					if (!tileServerOptions.pregenerate) {
-						data.staticMap = await this.tileserverPregen.getTileURL(logReference, tileTemplate,
+						data.staticMap = await this.tileserverPregen.getTileURL(logReference, maptype,
 							Object.fromEntries(Object.entries(data)
 								.filter(([field]) => keys.includes(field))),
 							tileServerOptions.type)
 					} else {
-						data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, tileTemplate,
+						data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, maptype,
 							pregenKeys ? Object.fromEntries(Object.entries(data).filter(([field]) => ['nearbyStops', 'uiconPokestopUrl'].includes(field) || pregenKeys.includes(field))) : data, tileServerOptions.type)
 					}
 				}

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -261,7 +261,7 @@ class Controller extends EventEmitter {
 						for (const stop of data.nearbyStops) {
 							switch (stop.type) {
 								case 'gym': {
-									stop.imgUrl = await this.imgUicons.gymIcon(stop.teamId, stop.slots, false, false)
+									stop.imgUrl = await this.imgUicons.gymIcon(stop.teamId, 6 - stop.slots, false, false)
 									break
 								}
 								case 'pokestop': {

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -228,7 +228,7 @@ class Controller extends EventEmitter {
 		return message
 	}
 
-	async getStaticMapUrl(logReference, data, maptype, keys, excludeKeys) {
+	async getStaticMapUrl(logReference, data, maptype, keys, pregenKeys) {
 		const tileTemplate = maptype
 		const configTemplate = maptype === 'monster' ? 'pokemon' : maptype
 		switch (this.config.geocoding.staticProvider.toLowerCase()) {
@@ -282,7 +282,7 @@ class Controller extends EventEmitter {
 							tileServerOptions.type)
 					} else {
 						data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, tileTemplate,
-							excludeKeys ? Object.fromEntries(Object.entries(data).filter(([field]) => !excludeKeys.includes(field))) : data, tileServerOptions.type)
+							pregenKeys ? Object.fromEntries(Object.entries(data).filter(([field]) => ['nearbyStops', 'uiconPokestopUrl'].includes(field) || pregenKeys.includes(field))) : data, tileServerOptions.type)
 					}
 				}
 

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -243,7 +243,7 @@ class Controller extends EventEmitter {
 					pregenerate: true,
 				}, this.config.geocoding.tileserverSettings ? this.config.geocoding.tileserverSettings.default : null)
 
-				if (this.config.geocoding.staticMapType[configTemplate]) {
+				if (this.config.geocoding.staticMapType && this.config.geocoding.staticMapType[configTemplate]) {
 					Object.assign(tileServerOptions, {
 						type: this.config.geocoding.staticMapType[configTemplate].startsWith('*') ? this.config.geocoding.staticMapType[configTemplate].substring(1) : this.config.geocoding.staticMapType[configTemplate],
 						pregenerate: !this.config.geocoding.staticMapType[configTemplate].startsWith('*'),

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -257,6 +257,21 @@ class Controller extends EventEmitter {
 				if (tileServerOptions.includeStops && tileServerOptions.pregenerate && this.scannerQuery) {
 					const limits = this.tileserverPregen.limits(data.latitude, data.longitude, tileServerOptions.width, tileServerOptions.height, tileServerOptions.zoom)
 					data.nearbyStops = await this.scannerQuery.getStopData(limits[0][0], limits[0][1], limits[1][0], limits[1][1])
+					if (data.nearbyStops) {
+						for (const stop of data.nearbyStops) {
+							switch (stop.type) {
+								case 'gym': {
+									stop.imgUrl = await this.imgUicons.gymIcon(stop.teamId, stop.slots, false, false)
+									break
+								}
+								case 'pokestop': {
+									stop.imgUrl = await this.imgUicons.pokestopIcon(0)
+									break
+								}
+								default:
+							}
+						}
+					}
 				}
 
 				if (tileServerOptions.type && tileServerOptions.type !== 'none') {

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -228,7 +228,7 @@ class Controller extends EventEmitter {
 		return message
 	}
 
-	async getStaticMapUrl(logReference, data, maptype, keys) {
+	async getStaticMapUrl(logReference, data, maptype, keys, excludeKeys) {
 		const tileTemplate = maptype
 		const configTemplate = maptype === 'monster' ? 'pokemon' : maptype
 		switch (this.config.geocoding.staticProvider.toLowerCase()) {
@@ -258,6 +258,7 @@ class Controller extends EventEmitter {
 					const limits = this.tileserverPregen.limits(data.latitude, data.longitude, tileServerOptions.width, tileServerOptions.height, tileServerOptions.zoom)
 					data.nearbyStops = await this.scannerQuery.getStopData(limits[0][0], limits[0][1], limits[1][0], limits[1][1])
 					if (data.nearbyStops) {
+						data.uiconPokestopUrl = await this.imgUicons.pokestopIcon(0)
 						for (const stop of data.nearbyStops) {
 							switch (stop.type) {
 								case 'gym': {
@@ -265,7 +266,6 @@ class Controller extends EventEmitter {
 									break
 								}
 								case 'pokestop': {
-									stop.imgUrl = await this.imgUicons.pokestopIcon(0)
 									break
 								}
 								default:
@@ -281,7 +281,8 @@ class Controller extends EventEmitter {
 								.filter(([field]) => keys.includes(field))),
 							tileServerOptions.type)
 					} else {
-						data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, tileTemplate, data, tileServerOptions.type)
+						data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, tileTemplate,
+							excludeKeys ? Object.fromEntries(Object.entries(data).filter(([field]) => !excludeKeys.includes(field))) : data, tileServerOptions.type)
 					}
 				}
 

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -122,6 +122,8 @@ class Gym extends Controller {
 			data.gymColor = this.GameData.utilData.teams[data.teamId].color
 			data.slotsAvailable = data.slots_available
 			data.oldSlotsAvailable = data.old_slots_available
+			data.trainerCount = 6 - data.slotsAvailable
+			data.oldTrainerCount = 6 - data.oldSlotsAvailable
 			data.ex = !!(data.ex_raid_eligible || data.is_ex_raid_eligible)
 			data.color = data.gymColor
 			data.inBattle = data.is_in_battle !== undefined ? data.is_in_battle : data.in_battle
@@ -147,8 +149,8 @@ class Gym extends Controller {
 				return []
 			}
 
-			data.imgUrl = await this.imgUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
-			data.stickerUrl = await this.stickerUicons.gymIcon(data.teamId, data.slotsAvailable, false, data.ex)
+			data.imgUrl = await this.imgUicons.gymIcon(data.teamId, 6 - data.slotsAvailable, data.inBattle, data.ex)
+			data.stickerUrl = await this.stickerUicons.gymIcon(data.teamId, 6 - data.slotsAvailable, data.inBattle, data.ex)
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -392,7 +392,7 @@ class Monster extends Controller {
 					const jobs = []
 
 					await this.getStaticMapUrl(logReference, data, 'monster', ['pokemon_id', 'latitude', 'longitude', 'form', 'costume', 'imgUrl'],
-						['ohbem_pvp', 'pvpEvolutionData', 'pvp_ranking_ultra_league', 'pvp_ranking_great_league', 'pvp_ranking_little_league', 'pvpGreat', 'pvpUltra', 'pvpLittle'])
+						['pokemon_id', 'display_pokemon_id', 'latitude', 'longitude', 'verified', 'costume', 'form', 'pokemonId', 'generation', 'weather', 'confirmedTime', 'shinyPossible', 'imgUrl'])
 					data.staticmap = data.staticMap // deprecated
 
 					// get Weather Forecast information

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -391,7 +391,8 @@ class Monster extends Controller {
 					})
 					const jobs = []
 
-					await this.getStaticMapUrl(logReference, data, 'monster', ['pokemon_id', 'latitude', 'longitude', 'form', 'costume', 'imgUrl'])
+					await this.getStaticMapUrl(logReference, data, 'monster', ['pokemon_id', 'latitude', 'longitude', 'form', 'costume', 'imgUrl'],
+						['ohbem_pvp', 'pvpEvolutionData', 'pvp_ranking_ultra_league', 'pvp_ranking_great_league', 'pvp_ranking_little_league', 'pvpGreat', 'pvpUltra', 'pvpLittle'])
 					data.staticmap = data.staticMap // deprecated
 
 					// get Weather Forecast information

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -436,6 +436,11 @@ class Monster extends Controller {
 						data.futureEventTrigger = event.reason
 					}
 
+					// Lookup pokestop name if needed
+					if (this.config.general.populatePokestopName && !data.pokestopName && data.pokestop_id && this.scannerQuery) {
+						data.pokestopName = this.escapeJsonString(await this.scannerQuery.getPokestopName(data.pokestop_id))
+					}
+
 					for (const cares of whoCares) {
 						this.log.debug(`${logReference}: Creating monster alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template}`, cares)
 

--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -323,8 +323,12 @@ class Weather extends Controller {
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 
-			if (pregenerateTile && this.config.geocoding.staticMapType.weather && !this.config.weather.showAlteredPokemonStaticMap) {
-				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, this.config.geocoding.staticMapType.weather)
+			if (pregenerateTile && !this.config.weather.showAlteredPokemonStaticMap) {
+				const tileServerOptions = this.tileserverPregen.getConfigForTileType('weather')
+
+				if (tileServerOptions.type !== 'none') {
+					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, tileServerOptions.type)
+				}
 			}
 
 			data.oldWeatherId = (previousWeather > -1) ? previousWeather : ''
@@ -382,8 +386,12 @@ class Weather extends Controller {
 						}
 					}
 				}
-				if (pregenerateTile && this.config.geocoding.staticMapType.weather && this.config.weather.showAlteredPokemon && this.config.weather.showAlteredPokemonStaticMap) {
-					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, this.config.geocoding.staticMapType.weather)
+				if (pregenerateTile && this.config.weather.showAlteredPokemon && this.config.weather.showAlteredPokemonStaticMap) {
+					const tileServerOptions = this.tileserverPregen.getConfigForTileType('weather')
+
+					if (tileServerOptions.type !== 'none') {
+						data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, tileServerOptions.type)
+					}
 				}
 				data.staticmap = data.staticMap // deprecated
 				if (cares.caresUntil) weatherTth = moment.preciseDiff(now, cares.caresUntil * 1000, true)

--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -12,8 +12,8 @@ const weatherKeyCache = pcache.load('weatherKeyCache', path.join(__dirname, '../
 const weatherCache = pcache.load('weatherCache', path.join(__dirname, '../../.cache'))
 
 class Weather extends Controller {
-	constructor(log, db, config, dts, geofence, GameData, discordCache, translatorFactory, mustache) {
-		super(log, db, config, dts, geofence, GameData, discordCache, translatorFactory, mustache, null, null, null)
+	constructor(log, db, scannerQuery, config, dts, geofence, GameData, discordCache, translatorFactory, mustache) {
+		super(log, db, scannerQuery, config, dts, geofence, GameData, discordCache, translatorFactory, mustache, null, null, null)
 		this.controllerData = weatherCache.getKey('weatherCacheData') || {}
 		this.caresData = weatherCache.getKey('caredPokemon') || {}
 

--- a/src/lib/configFetcher.js
+++ b/src/lib/configFetcher.js
@@ -50,11 +50,16 @@ function getKnex(conf) {
 
 function getScannerKnex(conf) {
 	if (conf.database.scannerType === 'mad' || conf.database.scannerType === 'rdm') {
-		return Knex({
-			client: 'mysql2',
-			connection: conf.database.scanner,
-			pool: { min: 0, max: conf.tuning.maxDatabaseConnections },
-		})
+		return !Array.isArray(conf.database.scanner)
+			? [Knex({
+				client: 'mysql2',
+				connection: conf.database.scanner,
+				pool: { min: 0, max: conf.tuning.maxDatabaseConnections },
+			})] : conf.database.scanner.map((scanner) => Knex({
+				client: 'mysql2',
+				connection: scanner,
+				pool: { min: 0, max: conf.tuning.maxDatabaseConnections },
+			}))
 	}
 
 	return null

--- a/src/lib/poracleMessage/commands/area.js
+++ b/src/lib/poracleMessage/commands/area.js
@@ -178,7 +178,7 @@ exports.run = async (client, msg, args, options) => {
 				break
 			}
 			case 'overview': {
-				if (client.config.geocoding.staticMapType.location && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
+				if (client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
 					const staticMap = await geofenceTileGenerator.generateGeofenceOverviewTile(
 						client.geofence,
 						client.query.tileserverPregen,
@@ -193,8 +193,9 @@ exports.run = async (client, msg, args, options) => {
 				break
 			}
 			case 'show': {
-				if (client.config.geocoding.staticMapType.location && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
-					for (const area of args) {
+				if (client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
+					const areas = args.length > 2 ? args : JSON.parse(human.area)
+					for (const area of areas) {
 						let staticMap
 
 						if (area.match(client.re.dRe)) {

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -84,18 +84,26 @@ exports.run = async (client, msg, args, options) => {
 		const maplink = `https://www.google.com/maps/search/?api=1&query=${lat},${lon}`
 		message = `👋, ${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}:\n${maplink}`
 
-		if (platform === 'discord' && client.config.geocoding.staticMapType.location && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
-			staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', { latitude: lat, longitude: lon }, client.config.geocoding.staticMapType.location)
-			message = {
-				embed: {
-					color: 0x00ff00,
-					title: translator.translate('New location'),
-					description: `${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}`,
-					image: {
-						url: staticMap,
+		if (platform === 'discord' && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
+			const tileServerOptions = client.query.tileserverPregen.getConfigForTileType('location')
+			if (tileServerOptions.type !== 'none') {
+				// Could also use logic to not pregenerate
+				staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', {
+					latitude: lat,
+					longitude: lon,
+				}, tileServerOptions.type)
+
+				message = {
+					embed: {
+						color: 0x00ff00,
+						title: translator.translate('New location'),
+						description: `${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}`,
+						image: {
+							url: staticMap,
+						},
+						url: maplink,
 					},
-					url: maplink,
-				},
+				}
 			}
 		}
 

--- a/src/lib/scanner/madScanner.js
+++ b/src/lib/scanner/madScanner.js
@@ -22,6 +22,27 @@ class MadScanner {
 			throw { source: 'getPokestopName', error: err }
 		}
 	}
+
+	async getStopData(aLat, aLon, bLat, bLon) {
+		const minLat = Math.min(aLat, bLat)
+		const minLon = Math.min(aLon, bLon)
+		const maxLat = Math.max(aLat, bLat)
+		const maxLon = Math.max(aLon, bLon)
+
+		try {
+			const pokestopRows = await this.db.select('latitude', 'longitude').from('pokestop').whereBetween('latitude', [minLat, maxLat]).whereBetween('longitude', [minLon, maxLon])
+			const gymRows = await this.db.select('latitude', 'longitude', 'team_id', 'slots_available').from('gym').whereBetween('latitude', [minLat, maxLat]).whereBetween('longitude', [minLon, maxLon])
+
+			return [
+				...pokestopRows.map((x) => ({ latitude: x.latitude, longitude: x.longitude, type: 'pokestop' })),
+				...gymRows.map((x) => ({
+					latitude: x.latitude, longitude: x.longitude, type: 'gym', teamId: x.team_id, slots: x.slots_available,
+				})),
+			]
+		} catch (err) {
+			throw { source: 'getStopData', error: err }
+		}
+	}
 }
 
 module.exports = MadScanner

--- a/src/lib/scanner/madScanner.js
+++ b/src/lib/scanner/madScanner.js
@@ -50,7 +50,7 @@ class MadScanner {
 				stopDetails.push(...pokestopRows.map((x) => ({
 					latitude: x.latitude,
 					longitude: x.longitude,
-					type: 'pokestop',
+					type: 'stop',
 				})))
 
 				stopDetails.push(...gymRows.map((x) => ({

--- a/src/lib/scanner/rdmScanner.js
+++ b/src/lib/scanner/rdmScanner.js
@@ -22,6 +22,27 @@ class RdmScanner {
 			throw { source: 'getPokestopName', error: err }
 		}
 	}
+
+	async getStopData(aLat, aLon, bLat, bLon) {
+		const minLat = Math.min(aLat, bLat)
+		const minLon = Math.min(aLon, bLon)
+		const maxLat = Math.max(aLat, bLat)
+		const maxLon = Math.max(aLon, bLon)
+
+		try {
+			const pokestopRows = await this.db.select('lat', 'lon').from('pokestop').whereBetween('lat', [minLat, maxLat]).whereBetween('lon', [minLon, maxLon])
+			const gymRows = await this.db.select('lat', 'lon', 'team_id', 'availble_slots').from('gym').whereBetween('lat', [minLat, maxLat]).whereBetween('lon', [minLon, maxLon])
+
+			return [
+				...pokestopRows.map((x) => ({ latitude: x.lat, longitude: x.lon, type: 'pokestop' })),
+				...gymRows.map((x) => ({
+					latitude: x.lat, longitude: x.lon, type: 'gym', teamId: x.team_id, slots: x.availble_slots,
+				})),
+			]
+		} catch (err) {
+			throw { source: 'getStopData', error: err }
+		}
+	}
 }
 
 module.exports = RdmScanner

--- a/src/lib/scanner/rdmScanner.js
+++ b/src/lib/scanner/rdmScanner.js
@@ -56,7 +56,7 @@ class RdmScanner {
 				stopDetails.push(...pokestopRows.map((x) => ({
 					latitude: x.lat,
 					longitude: x.lon,
-					type: 'pokestop',
+					type: 'stop',
 				})))
 
 				stopDetails.push(...gymRows.map((x) => ({

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -166,6 +166,29 @@ class TileserverPregen {
 			longitude,
 		}
 	}
+
+	// eslint-disable-next-line class-methods-use-this
+	limits(latCenter, lonCenter, width, height, zoom) {
+		// copied from https://help.openstreetmap.org/questions/75611/transform-xy-pixel-values-into-lat-and-long
+		const C = (256 / (2 * Math.PI)) * 2 ** zoom
+
+		const xcenter = C * (lonCenter * Math.PI / 180.0 + Math.PI)
+		const ycenter = C * (Math.PI - Math.log(Math.tan((Math.PI / 4) + latCenter * Math.PI / 360.0)))
+
+		const points = []
+		for (const point of [[0, 0], [width, height]]) {
+			const xpoint = xcenter - (width / 2 - point[0])
+			const ypoint = ycenter - (height / 2 - point[1])
+
+			const M = (xpoint / C) - Math.PI
+			const N = -(ypoint / C) + Math.PI
+
+			const finLon = M * 180.0 / Math.PI
+			const finLat = (Math.atan(Math.E ** N) - (Math.PI / 4)) * 2 * 180.0 / Math.PI
+			points.push([finLat, finLon])
+		}
+		return points
+	}
 }
 
 module.exports = TileserverPregen

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -7,6 +7,34 @@ class TileserverPregen {
 		this.config = config
 	}
 
+	getConfigForTileType(maptype) {
+		const tileTemplate = maptype
+		const configTemplate = maptype === 'monster' ? 'pokemon' : maptype
+
+		const tileServerOptions = {}
+		Object.assign(tileServerOptions, {
+			type: 'staticMap',
+			includeStops: false,
+			width: 500,
+			height: 250,
+			zoom: 15,
+			pregenerate: true,
+		}, this.config.geocoding.tileserverSettings ? this.config.geocoding.tileserverSettings.default : null)
+
+		if (this.config.geocoding.staticMapType && this.config.geocoding.staticMapType[configTemplate]) {
+			Object.assign(tileServerOptions, {
+				type: this.config.geocoding.staticMapType[configTemplate].startsWith('*') ? this.config.geocoding.staticMapType[configTemplate].substring(1) : this.config.geocoding.staticMapType[configTemplate],
+				pregenerate: !this.config.geocoding.staticMapType[configTemplate].startsWith('*'),
+			})
+		}
+
+		if (this.config.geocoding.tileserverSettings && this.config.geocoding.tileserverSettings[tileTemplate]) {
+			Object.assign(tileServerOptions, this.config.geocoding.tileserverSettings[tileTemplate])
+		}
+
+		return tileServerOptions
+	}
+
 	async getPregeneratedTileURL(logReference, type, data, staticMapType) {
 		let mapType = 'staticmap'
 		let templateType = ''

--- a/src/weatherWorker.js
+++ b/src/weatherWorker.js
@@ -19,7 +19,7 @@ const {
 const WeatherController = require('./controllers/weather')
 
 const rateLimitedUserCache = new NodeCache({ stdTTL: config.discord.limitSec })
-const weatherController = new WeatherController(logs.controller, knex, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache)
+const weatherController = new WeatherController(logs.controller, knex, null, config, dts, geofence, GameData, rateLimitedUserCache, translatorFactory, mustache)
 
 const hookQueue = []
 const workerId = 'WEATHER'

--- a/tileservercache_templates/poracle-gym.json
+++ b/tileservercache_templates/poracle-gym.json
@@ -7,6 +7,18 @@
   "height": 250,
   "scale": 1,
   "markers": [
+     #if(nearbyStops != nil):
+        #for(stop in nearbyStops):
+        {
+            "url": "#(stop.imgUrl)",
+            "latitude": #(stop.latitude),
+            "longitude": #(stop.longitude),
+            "width": 20,
+            "height": 20,
+            "y_offset": -10
+        },
+        #endfor
+    #endif
     {
       "url": "#(imgUrl)",
       "latitude": #(latitude),

--- a/tileservercache_templates/poracle-gym.json
+++ b/tileservercache_templates/poracle-gym.json
@@ -10,7 +10,7 @@
      #if(nearbyStops != nil):
         #for(stop in nearbyStops):
         {
-            "url": "#(stop.imgUrl)",
+            "url": "#if(stop.imgUrl):#(stop.imgUrl)#else:#(uiconPokestopUrl)#endif",
             "latitude": #(stop.latitude),
             "longitude": #(stop.longitude),
             "width": 20,

--- a/tileservercache_templates/poracle-monster.json
+++ b/tileservercache_templates/poracle-monster.json
@@ -7,6 +7,18 @@
     "height": 250,
     "scale": 1,
     "markers": [
+    #if(nearbyStops != nil):
+        #for(stop in nearbyStops):
+        {
+            "url": #if(stop.teamId != nil):"https://raw.githubusercontent.com/ccev/stopwatcher-icons/master/tileserver-2/#(stop.teamId).png"#else:"https://raw.githubusercontent.com/ccev/stopwatcher-icons/master/tileserver-2/stop.png"#endif,
+            "latitude": #(stop.latitude),
+            "longitude": #(stop.longitude),
+            "width": 20,
+            "height": 20,
+            "y_offset": -10
+        },
+        #endfor
+    #endif
         {
             "url": "#(imgUrl)",
             "latitude": #(latitude),

--- a/tileservercache_templates/poracle-monster.json
+++ b/tileservercache_templates/poracle-monster.json
@@ -10,7 +10,7 @@
     #if(nearbyStops != nil):
         #for(stop in nearbyStops):
         {
-            "url": "#(stop.imgUrl)",
+            "url": "#if(stop.imgUrl):#(stop.imgUrl)#else:#(uiconPokestopUrl)#endif",
             "latitude": #(stop.latitude),
             "longitude": #(stop.longitude),
             "width": 20,

--- a/tileservercache_templates/poracle-monster.json
+++ b/tileservercache_templates/poracle-monster.json
@@ -10,7 +10,7 @@
     #if(nearbyStops != nil):
         #for(stop in nearbyStops):
         {
-            "url": #if(stop.teamId != nil):"https://raw.githubusercontent.com/ccev/stopwatcher-icons/master/tileserver-2/#(stop.teamId).png"#else:"https://raw.githubusercontent.com/ccev/stopwatcher-icons/master/tileserver-2/stop.png"#endif,
+            "url": "#(stop.imgUrl)",
             "latitude": #(stop.latitude),
             "longitude": #(stop.longitude),
             "width": 20,

--- a/tileservercache_templates/poracle-multi-monster.json
+++ b/tileservercache_templates/poracle-multi-monster.json
@@ -14,6 +14,18 @@
                         "height": 250,
                         "scale": 2,
                         "markers": [
+                            #if(nearbyStops != nil):
+                                #for(stop in nearbyStops):
+                                {
+                                    "url": "#(stop.imgUrl)",
+                                    "latitude": #(stop.latitude),
+                                    "longitude": #(stop.longitude),
+                                    "width": 20,
+                                    "height": 20,
+                                    "y_offset": -10
+                                },
+                                #endfor
+                            #endif
                             {
                                 "url": "#(imgUrl)",
                                 "latitude": #(latitude),

--- a/tileservercache_templates/poracle-multi-monster.json
+++ b/tileservercache_templates/poracle-multi-monster.json
@@ -17,7 +17,7 @@
                             #if(nearbyStops != nil):
                                 #for(stop in nearbyStops):
                                 {
-                                    "url": "#(stop.imgUrl)",
+                                    "url": "#if(stop.imgUrl):#(stop.imgUrl)#else:#(uiconPokestopUrl)#endif",
                                     "latitude": #(stop.latitude),
                                     "longitude": #(stop.longitude),
                                     "width": 20,

--- a/tileservercache_templates/poracle-pokestop.json
+++ b/tileservercache_templates/poracle-pokestop.json
@@ -10,7 +10,7 @@
     #if(nearbyStops != nil):
         #for(stop in nearbyStops):
         {
-            "url": "#(stop.imgUrl)",
+            "url": "#if(stop.imgUrl):#(stop.imgUrl)#else:#(uiconPokestopUrl)#endif",
             "latitude": #(stop.latitude),
             "longitude": #(stop.longitude),
             "width": 20,

--- a/tileservercache_templates/poracle-pokestop.json
+++ b/tileservercache_templates/poracle-pokestop.json
@@ -7,6 +7,18 @@
     "height": 250,
     "scale": 1,
     "markers": [
+    #if(nearbyStops != nil):
+        #for(stop in nearbyStops):
+        {
+            "url": "#(stop.imgUrl)",
+            "latitude": #(stop.latitude),
+            "longitude": #(stop.longitude),
+            "width": 20,
+            "height": 20,
+            "y_offset": -10
+        },
+        #endfor
+    #endif
         {
             "url": "#(imgUrl)",
             "latitude": #(latitude),

--- a/tileservercache_templates/poracle-quest.json
+++ b/tileservercache_templates/poracle-quest.json
@@ -10,7 +10,7 @@
     #if(nearbyStops != nil):
         #for(stop in nearbyStops):
         {
-            "url": "#(stop.imgUrl)",
+            "url": "#if(stop.imgUrl):#(stop.imgUrl)#else:#(uiconPokestopUrl)#endif",
             "latitude": #(stop.latitude),
             "longitude": #(stop.longitude),
             "width": 20,

--- a/tileservercache_templates/poracle-quest.json
+++ b/tileservercache_templates/poracle-quest.json
@@ -7,6 +7,18 @@
     "height": 250,
     "scale": 1,
     "markers": [
+    #if(nearbyStops != nil):
+        #for(stop in nearbyStops):
+        {
+            "url": "#(stop.imgUrl)",
+            "latitude": #(stop.latitude),
+            "longitude": #(stop.longitude),
+            "width": 20,
+            "height": 20,
+            "y_offset": -10
+        },
+        #endfor
+    #endif
         {
             "url": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/PMSF_icons_large/misc/pokestop.png",
             "latitude": #(latitude),

--- a/tileservercache_templates/poracle-raid.json
+++ b/tileservercache_templates/poracle-raid.json
@@ -10,7 +10,7 @@
     #if(nearbyStops != nil):
         #for(stop in nearbyStops):
         {
-            "url": "#(stop.imgUrl)",
+            "url": "#if(stop.imgUrl):#(stop.imgUrl)#else:#(uiconPokestopUrl)#endif",
             "latitude": #(stop.latitude),
             "longitude": #(stop.longitude),
             "width": 20,

--- a/tileservercache_templates/poracle-raid.json
+++ b/tileservercache_templates/poracle-raid.json
@@ -7,6 +7,18 @@
     "height": 250,
     "scale": 1,
     "markers": [
+    #if(nearbyStops != nil):
+        #for(stop in nearbyStops):
+        {
+            "url": "#(stop.imgUrl)",
+            "latitude": #(stop.latitude),
+            "longitude": #(stop.longitude),
+            "width": 20,
+            "height": 20,
+            "y_offset": -10
+        },
+        #endfor
+    #endif
         {
             "url": "#(imgUrl)",
             "latitude": #(latitude),


### PR DESCRIPTION
Many users of Poracle choose to use Malte's excellent 'middleman', which amongst other things provides a way for tiles to be populated with nearby pokestop and gym information.

With malte stepping back from active maintenance of this project, and with Poracle now having a connection to the scanner database it seemed like the right time to bring this capability 'in-house'

![image](https://user-images.githubusercontent.com/1204736/141485592-6af11c32-a96a-45a3-81a9-b53ca6a73e08.png)

This implementation borrows heavily from Malte's code.

Configuation:
1. Include a connection to your scanner, as per standard config
2. The way that tile configuration is defined has changed.  There is a default, and you now can specify a number of different options about tile generation per controller.

```
      "tileserverSettings": {
        "default": {
          "type": "staticMap",          // can be staticMap or multiStaticMap - default is unlike to be changed
          "width": 500,
          "height": 250,
          "zoom": 15,
          "pregenerate": true,
          "includeStops": false
        }
        // add further types to 'override' - type can be monster, raid, pokestop, quest, weather, location, nest, gym - overrides can be any of the above fields
//      ,  "monster": {
//          "type": "staticMap",
//          "includeStops": true
//        }
      },
```

Note including the stops is only compatible with pregeneration.  The width, height and zoom are used to calculate
Only the poracle-monster.json template has so far been updated, but the others could be updated in exactly the same way.
Note that the multimap template has a different height, width and zoom so that will need putting in the configuration file
