### PR TITLE
Add disabledHooks to apiConfig

### DIFF
--- a/src/routes/apiConfig.js
+++ b/src/routes/apiConfig.js
@@ -32,7 +32,8 @@ module.exports = async (fastify, options, next) => {
 			},
 			maxDistance: fastify.config.tracking.maxDistance,
 			everythingFlagPermissions: fastify.config.tracking.everythingFlagPermissions,
-			disabledHooks: ["Pokemon", "Raid", "Pokestop", "Invasion", "Lure", "Quest", "Weather", "Nest", "Gym"].filter((hookType) => fastify.config.general[`disable${hookType}`]).map((hookType) => hookType.toLowerCase()),
+			disabledHooks: ["Pokemon", "Raid", "Pokestop", "Invasion", "Lure", "Quest", "Weather", "Nest", "Gym"]
+				.filter((hookType) => fastify.config.general[`disable${hookType}`]).map((hookType) => hookType.toLowerCase()),
 		}
 	})
 

--- a/src/routes/apiConfig.js
+++ b/src/routes/apiConfig.js
@@ -32,7 +32,9 @@ module.exports = async (fastify, options, next) => {
 			},
 			maxDistance: fastify.config.tracking.maxDistance,
 			everythingFlagPermissions: fastify.config.tracking.everythingFlagPermissions,
-
+			disabledHooks: ["Pokemon", "Raid", "Pokestop", "Invasion", "Lure", "Quest", "Weather", "Nest", "Gym"].flatMap((hookType) => (
+				(Object.keys(fastify.config.general).includes(`disable${hookType}`) && fastify.config.general[`disable${hookType}`]) ? hookType.toLowerCase() : []
+			))
 		}
 	})
 

--- a/src/routes/apiConfig.js
+++ b/src/routes/apiConfig.js
@@ -32,9 +32,7 @@ module.exports = async (fastify, options, next) => {
 			},
 			maxDistance: fastify.config.tracking.maxDistance,
 			everythingFlagPermissions: fastify.config.tracking.everythingFlagPermissions,
-			disabledHooks: ["Pokemon", "Raid", "Pokestop", "Invasion", "Lure", "Quest", "Weather", "Nest", "Gym"].flatMap((hookType) => (
-				(Object.keys(fastify.config.general).includes(`disable${hookType}`) && fastify.config.general[`disable${hookType}`]) ? hookType.toLowerCase() : []
-			))
+			disabledHooks: ["Pokemon", "Raid", "Pokestop", "Invasion", "Lure", "Quest", "Weather", "Nest", "Gym"].filter((hookType) => fastify.config.general[`disable${hookType}`]).map((hookType) => hookType.toLowerCase()),
 		}
 	})
 


### PR DESCRIPTION
Fetches `config > general > disablePokemon / disableRaid / disablePokestop ...` to return in apiConfig call an array `disabledHooks = [ 'weather', 'nest' ]` of hooks that are set to `disableXXXXX = true`