### PR TITLE
Partials support

### DIFF
--- a/config/defaults/partials.json
+++ b/config/defaults/partials.json
@@ -1,0 +1,3 @@
+{
+  "remaining_time": "{{#if tthh}}{{tthh}}h{{#or tthm tths}} {{/or}}{{/if}}{{#if tthm}}{{tthm}}m{{#if tths}}{{/if}}{{/if}}{{#if tths}}{{tths}}s{{/if}}"
+}

--- a/config/defaults/partials.json
+++ b/config/defaults/partials.json
@@ -1,3 +1,3 @@
 {
-  "remaining_time": "{{#if tthh}}{{tthh}}h{{#or tthm tths}} {{/or}}{{/if}}{{#if tthm}}{{tthm}}m{{#if tths}}{{/if}}{{/if}}{{#if tths}}{{tths}}s{{/if}}"
+  "remainingTime": "{{#if tthh}}{{tthh}}h{{#or tthm tths}} {{/or}}{{/if}}{{#if tthm}}{{tthm}}m{{#if tths}}{{/if}}{{/if}}{{#if tths}}{{tths}}s{{/if}}"
 }

--- a/src/lib/configFileCreator.js
+++ b/src/lib/configFileCreator.js
@@ -18,4 +18,8 @@ module.exports = () => {
 		const defaultGeofConfig = fs.readFileSync(path.join(__dirname, '../../config/defaults/pokemonAlias.json'), 'utf8')
 		fs.writeFileSync(path.join(__dirname, '../../config/pokemonAlias.json'), defaultGeofConfig)
 	}
+	if (!fs.existsSync(path.join(__dirname, '../../config/partials.json'))) {
+		const defaultDtsConfig = fs.readFileSync(path.join(__dirname, '../../config/defaults/partials.json'), 'utf8')
+		fs.writeFileSync(path.join(__dirname, '../../config/partials.json'), defaultDtsConfig)
+	}
 }

--- a/src/lib/handlebars.js
+++ b/src/lib/handlebars.js
@@ -1,6 +1,7 @@
 const handlebars = require('handlebars')
 const config = require('config')
 const moreHandlebars = require('./more-handlebars')
+const partials = require('./partials')
 const {
 	moves, monsters, utilData: {
 		cpMultipliers, types, powerUpCost, emojis,
@@ -31,6 +32,7 @@ function translatorAlt() {
 
 module.exports = () => {
 	moreHandlebars.registerHelpers(handlebars)
+	partials.registerPartials(handlebars)
 
 	handlebars.registerHelper('numberFormat', (value, decimals) => {
 		if (!['string', 'number'].includes(typeof decimals)) decimals = 2 // We may have the handlebars options in the parameter

--- a/src/lib/partials.js
+++ b/src/lib/partials.js
@@ -1,0 +1,10 @@
+function registerPartials(handlebars) {
+	const partials = require('../../config/partials.json')
+
+	// eslint-disable-next-line guard-for-in
+	for (const key in partials) {
+		handlebars.registerPartial(key, partials[key])
+	}
+}
+
+exports.registerPartials = registerPartials

--- a/src/lib/partials.js
+++ b/src/lib/partials.js
@@ -1,9 +1,18 @@
-function registerPartials(handlebars) {
-	const partials = require('../../config/partials.json')
+const stripJsonComments = require('strip-json-comments')
+const fs = require('fs')
+const path = require('path')
 
-	// eslint-disable-next-line guard-for-in
-	for (const key in partials) {
-		handlebars.registerPartial(key, partials[key])
+function registerPartials(handlebars) {
+	let partials
+	try {
+		const partialText = stripJsonComments(fs.readFileSync(path.join(__dirname, '../../config/partials.json'), 'utf8'))
+		partials = JSON.parse(partialText)
+	} catch (err) {
+		throw new Error(`partials.json - ${err.message}`)
+	}
+
+	for (const [key, partial] of Object.entries(partials)) {
+		handlebars.registerPartial(key, partial)
 	}
 }
 


### PR DESCRIPTION
Cherry picked from @Tabbomat fork, partials
New partial.json allows you to define re-usable components for your dts

an example:

```json
{
  "remainingTime": "{{#if tthh}}{{tthh}}h{{#or tthm tths}} {{/or}}{{/if}}{{#if tthm}}{{tthm}}m{{#if tths}}{{/if}}{{/if}}{{#if tths}}{{tths}}s{{/if}}"
}
```

These can be reused in a dts like this: `{{> remainingTime}}`
