### PR TITLE
Telegram: Add venue support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "hastebin-gen": "^2.0.5",
     "import-fresh": "^3.3.0",
     "knex": "^1.0.1",
-    "lru-cache": "^6.0.0",
     "moment-precise-range-plugin": "^1.3.0",
     "moment-timezone": "^0.5.34",
     "mysql2": "^2.3.3",

--- a/src/lib/telegram/Telegram.js
+++ b/src/lib/telegram/Telegram.js
@@ -268,7 +268,7 @@ class Telegram extends EventEmitter {
 								// eslint-disable-next-line no-shadow
 								const msg = await this.retrySender(
 									senderId,
-									async () => this.bot.telegram.sendVenue(data.target, data.lat, data.lon, data.message.venue.title ?? '', data.message.venue.address ?? '', { disable_notification: true }),
+									async () => this.bot.telegram.sendVenue(data.target, data.lat, data.lon, data.message.venue.title ?? '', data.message.venue.address ?? '', { disable_notification: !sendOrder.includes('text') }),
 								)
 								messageIds.push(msg.message_id)
 							} catch (err) {

--- a/src/lib/telegram/Telegram.js
+++ b/src/lib/telegram/Telegram.js
@@ -205,7 +205,7 @@ class Telegram extends EventEmitter {
 
 			const senderId = `${logReference}: ${data.name} ${data.target}`
 
-			const sendOrderDefault = ['sticker', 'photo', 'text', 'location']
+			const sendOrderDefault = ['sticker', 'photo', 'text', 'location', 'venue']
 			const sendOrderDefaultSet = new Set(sendOrderDefault)
 			let sendOrder = data.message.send_order || sendOrderDefault
 			// lowercase, filter unique and check for valid entries
@@ -258,6 +258,24 @@ class Telegram extends EventEmitter {
 							}),
 						)
 						messageIds.push(msg.message_id)
+						break
+					}
+					case 'venue': {
+						if (data.message.venue) {
+							this.logs.telegram.debug(`${logReference}: #${this.id} -> ${data.name} ${data.target} Venue ${data.lat} ${data.lat} Title ${data.message.venue.title ?? ''} Address: ${data.message.venue.address ?? ''}`)
+
+							try {
+								// eslint-disable-next-line no-shadow
+								const msg = await this.retrySender(
+									senderId,
+									async () => this.bot.telegram.sendVenue(data.target, data.lat, data.lon, data.message.venue.title ?? '', data.message.venue.address ?? '', { disable_notification: true }),
+								)
+								messageIds.push(msg.message_id)
+							} catch (err) {
+								this.logs.telegram.error(`${logReference}: #${this.id} -> ${data.name} ${data.target}  Failed to send Telegram venue ${data.lat} ${data.lat} Title ${data.message.venue.title ?? ''} Address: ${data.message.venue.address ?? ''}`, err)
+							}
+						}
+
 						break
 					}
 					case 'location': {


### PR DESCRIPTION
Add ability to send a 'venue' instead of a 'location'

DTS example:

```
  {
    "id": 2,
    "type": "monster",
    "default": true,
    "platform": "telegram",
    "template": {
      "venue": {
        "title": "{{name}} {{round iv}}%",
        "address": "cp:{{cp}} L:{{level}} {{atk}}/{{def}}/{{sta}} {{boostemoji}}\nEnd: {{time}}, Time left: {{tthm}}m {{tths}}s"
      },
      "send_order": ["venue"]
    }
  },
```

![image](https://user-images.githubusercontent.com/1204736/153042706-c91d99d9-2326-4453-80ad-3094f9a624b5.png)
