### PR TITLE
Fix min_weight and max_weight on monsters controller

### DIFF
--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -131,8 +131,8 @@ class Monster extends Controller {
 		max_atk>=${data.atk} and
 		max_def>=${data.def} and
 		max_sta>=${data.sta} and
-		min_weight<=${data.weight * 1000} and
-		max_weight>=${data.weight * 1000} and
+		min_weight<=${data.weight} and
+		max_weight>=${data.weight} and
 		rarity<=${data.rarityGroup} and
 		max_rarity>=${data.rarityGroup} and
 		(${pvpQueryString})


### PR DESCRIPTION
## Description
data.weight was populated with values like 4.22, 5.60, 0.94 or 8.39
So when filtering for min_weight everything would go through the filter and when filtering for max_weight nothing would pass it. 
min_weight<=${data.weight * 1000} -> min_weight<=2.42 * 1000} -> min_weight<=2420}
It should be min_weight<=2.42}

## Motivation and Context
I couldn't filter by weight and users asked for the big carp and small rat medals.

## How Has This Been Tested?
This works for my setup in stock RDM, it could be different in MAD. I would appreciate if someone could check it as I don't have access to MAD anymore.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.