### PR TITLE
Filter PVP section of track results by user's track

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -190,6 +190,7 @@
       "includeMegaEvolution": false,                // internal: whether to include mega evolutions in rank calculations
       "littleLeagueCanEvolve": false,               // internal: whether little league mons that are evolved are included
       "pvpEvolutionDirectTracking": false,          // pvpEvolutionDirectTracking - whether users can track pvp evolutions directly (eg vaporean would match an eevee)
+      "filterByTrack": false,                       // whether new style PVP listings are auto-filtered by user's track requirements
     // pvpDisplay* - these are variables that will be passed into DTS to allow you to perform
     //   a filtering calculation
       "pvpDisplayMaxRank": 10,

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -702,6 +702,7 @@ class Monster extends Controller {
 										displayRank.fullName = displayRank.name.concat(displayRank.form ? ' ' : '', displayRank.form)
 									}
 
+									displayRank.matchesUserTrack = false
 									if (cares.filters.length) {
 										displayRank.passesFilter = false
 										for (const filter of cares.filters) {
@@ -709,7 +710,7 @@ class Monster extends Controller {
 											&& (filter.pvp_ranking_cap === 0 || filter.pvp_ranking_cap === displayRank.cap || displayRank.capped)
 											&& (filter.pvp_ranking_worst >= displayRank.rank)) {
 												displayRank.passesFilter = true
-												break
+												displayRank.matchesUserTrack = true
 											}
 										}
 									} else {

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -25,7 +25,7 @@ class Monster extends Controller {
 
 		const pvpQueryLimit = this.config.pvp.pvpQueryMaxRank || this.config.pvp.pvpFilterMaxRank || 100
 
-		let result = []
+		const result = []
 
 		// Basic Pokemon
 		result.push(...await this.performQuery(this.buildQuery('Basic', data, strictareastring, areastring, { pokemon_id: data.pokemon_id, form: data.form, includeEverything: true }, 0)))
@@ -83,13 +83,13 @@ class Monster extends Controller {
 		}
 
 		// remove any duplicates
-		const alertIds = []
-		result = result.filter((alert) => {
-			if (!alertIds.includes(alert.id)) {
-				alertIds.push(alert.id)
-				return alert
-			}
-		})
+		// const alertIds = []
+		// result = result.filter((alert) => {
+		// 	if (!alertIds.includes(alert.id)) {
+		// 		alertIds.push(alert.id)
+		// 		return alert
+		// 	}
+		// })
 		return result
 	}
 
@@ -113,7 +113,7 @@ class Monster extends Controller {
 		}
 
 		let query = `
-		select humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, monsters.template, monsters.distance, monsters.clean, monsters.ping, monsters.pvp_ranking_worst from monsters
+		select humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, monsters.template, monsters.distance, monsters.clean, monsters.ping, monsters.pokemon_id, monsters.pvp_ranking_cap, monsters.pvp_ranking_league, monsters.pvp_ranking_worst from monsters
 		join humans on (humans.id = monsters.id and humans.current_profile_no = monsters.profile_no)
 		where humans.enabled = true and humans.admin_disable = false and (humans.blocked_alerts IS NULL OR humans.blocked_alerts NOT LIKE '%monster%') and
 		(${pokemonQueryString}) and
@@ -431,6 +431,26 @@ class Monster extends Controller {
 						return []
 					}
 
+					const consolidatedAlerts = []
+					for (const alert of whoCares) {
+						let existingAlert = consolidatedAlerts.find((x) => x.id === alert.id)
+						if (!existingAlert) {
+							existingAlert = {
+								...alert,
+								filters: [],
+							}
+							consolidatedAlerts.push(existingAlert)
+						}
+
+						if (alert.pvp_ranking_worst < 4096) {
+							existingAlert.filters.push({
+								pvp_ranking_league: alert.pvp_ranking_league,
+								pvp_ranking_worst: alert.pvp_ranking_worst,
+								pvp_ranking_cap: alert.pvp_ranking_cap,
+							})
+						}
+					}
+
 					if (data.display_pokemon_id && data.display_pokemon_id !== data.pokemon_id) {
 						data.display_form ??= 0
 						const displayMonster = this.GameData.monsters[`${data.display_pokemon_id}_${data.display_form}`] || this.GameData.monsters[`${data.display_pokemon_id}_0`]
@@ -511,7 +531,7 @@ class Monster extends Controller {
 						data.pokestopName = this.escapeJsonString(await this.scannerQuery.getPokestopName(data.pokestop_id))
 					}
 
-					for (const cares of whoCares) {
+					for (const cares of consolidatedAlerts) {
 						this.log.debug(`${logReference}: Creating monster alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template}`, cares)
 
 						const rateLimitTtr = this.getRateLimitTimeToRelease(cares.id)
@@ -620,7 +640,7 @@ class Monster extends Controller {
 						data.emojiString = e.join('')
 						data.typeEmoji = data.emojiString
 
-						const createPvpDisplay = (leagueData, maxRank, minCp) => {
+						const createPvpDisplay = (leagueCap, leagueData, maxRank, minCp) => {
 							const displayList = []
 							for (const rank of leagueData) {
 								if (rank.rank <= maxRank
@@ -681,15 +701,31 @@ class Monster extends Controller {
 										displayRank.fullNameEng = displayRank.nameEng.concat(displayRank.formEng ? ' ' : '', displayRank.formEng)
 										displayRank.fullName = displayRank.name.concat(displayRank.form ? ' ' : '', displayRank.form)
 									}
-									displayList.push(displayRank)
+
+									if (cares.filters.length) {
+										displayRank.passesFilter = false
+										for (const filter of cares.filters) {
+											if ((filter.pvp_ranking_league === leagueCap || filter.pvp_ranking_league === 0)
+											&& (filter.pvp_ranking_cap === 0 || filter.pvp_ranking_cap === displayRank.cap || displayRank.capped)
+											&& (filter.pvp_ranking_worst >= displayRank.rank)) {
+												displayRank.passesFilter = true
+												break
+											}
+										}
+									} else {
+										displayRank.passesFilter = true
+									}
+									if (!this.config.pvp.filterByTrack || displayRank.passesFilter) {
+										displayList.push(displayRank)
+									}
 								}
 							}
 							return displayList.length ? displayList : null
 						}
 
-						data.pvpGreat = data.pvp_rankings_great_league ? createPvpDisplay(data.pvp_rankings_great_league, this.config.pvp.pvpDisplayMaxRank, this.config.pvp.pvpDisplayGreatMinCP) : null
-						data.pvpUltra = data.pvp_rankings_ultra_league ? createPvpDisplay(data.pvp_rankings_ultra_league, this.config.pvp.pvpDisplayMaxRank, this.config.pvp.pvpDisplayUltraMinCP) : null
-						data.pvpLittle = data.pvp_rankings_little_league ? createPvpDisplay(data.pvp_rankings_little_league, this.config.pvp.pvpDisplayMaxRank, this.config.pvp.pvpDisplayLittleMinCP) : null
+						data.pvpGreat = data.pvp_rankings_great_league ? createPvpDisplay(1500, data.pvp_rankings_great_league, this.config.pvp.pvpDisplayMaxRank, this.config.pvp.pvpDisplayGreatMinCP) : null
+						data.pvpUltra = data.pvp_rankings_ultra_league ? createPvpDisplay(2500, data.pvp_rankings_ultra_league, this.config.pvp.pvpDisplayMaxRank, this.config.pvp.pvpDisplayUltraMinCP) : null
+						data.pvpLittle = data.pvp_rankings_little_league ? createPvpDisplay(500, data.pvp_rankings_little_league, this.config.pvp.pvpDisplayMaxRank, this.config.pvp.pvpDisplayLittleMinCP) : null
 						data.pvpAvailable = data.pvpGreat !== null || data.pvpUltra !== null || data.pvpLittle !== null
 
 						data.distance = cares.longitude ? this.getDistance({
@@ -754,7 +790,7 @@ class Monster extends Controller {
 					}
 					hrend = process.hrtime(hrstart)
 					const hrendprocessing = hrend[1] / 1000000
-					this.log.verbose(`${data.encounter_id}: ${monster.name} appeared and ${whoCares.length} humans cared [end]. (${hrendms} ms sql + ${hrendprocessing} ms processing dts)`)
+					this.log.verbose(`${data.encounter_id}: ${monster.name} appeared and ${whoCares.length}/${consolidatedAlerts.length} humans cared [end]. (${hrendms} ms sql + ${hrendprocessing} ms processing dts)`)
 
 					this.emit('postMessage', jobs)
 				} catch (e) {

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -788,6 +788,7 @@ class Monster extends Controller {
 						data.pvpLittleBest = calculateBestInfo(data.pvpLittle)
 
 						data.pvpAvailable = data.pvpGreat !== null || data.pvpUltra !== null || data.pvpLittle !== null
+						data.userHasPvpTracks = !!cares.filters.length
 
 						data.distance = cares.longitude ? this.getDistance({
 							lat: cares.latitude,

--- a/src/lib/discord/discordWebhookWorker.js
+++ b/src/lib/discord/discordWebhookWorker.js
@@ -84,7 +84,7 @@ class DiscordWebhookWorker {
 			}
 		} while (retry === true && retryCount < 10)
 
-		if (retryCount === 10 && retry) {
+		if (retry) {
 			this.logs.discord.warn(`${senderId} WEBHOOK given up sending after retries`)
 		}
 		return res


### PR DESCRIPTION
Poracle collects together the user's matching tracks for this alert, and if there are any PVP matches will set a filter parameter on the display entry to indicate whether it should be displayed.

As an example:
```
{{#each pvpLittle}}{{this.fullName}} #{{this.rank}} @{{this.cp}}CP (Lvl. {{this.levelWithCap}}) {{#if this.passesFilter}}PASS{{else}}FAIL{{/if}}\n
{{/each}}
```
In this case the filter result is displayed (which is a great test).
There is also a 'this.matchesUserTrack' which is true if this entry matches a user track, and false if it is not. This would be good for displaying a tick mark for example, but not filtering on.  The passesFilter will be 'true' for all items if there are no pvp track, whereas matchesUserTrack would be false in this case.

In addition there is a new local.json parameter:

```
      "filterByTrack": false,                       // whether new style PVP listings are auto-filtered by user's track requirements
```

This causes poracle to auto filter the pvpLittle, pvpGreat, pvpUltra lists according to the 'passesFilter'

Additionally, you can tell if the user has any pvp tracks to exclude the whole pvp section (the default filter will not remove anything if there are no PVP tracks at all)

{{#if userHasPvpTracks}}....{{/if}}

