### PR TITLE
Support for Mega Legendary raids

### DIFF
--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -171,6 +171,8 @@ class Raid extends Controller {
 			data.gameWeatherId = data.weather
 			data.gameWeatherNameEng = data.weather ? this.GameData.utilData.weather[data.gameWeatherId].name : ''
 
+			data.levelNameEng = this.GameData.utilData.raidLevels[data.level]
+
 			if (this.config.general.ignoreLongRaids
 				&& (data.end - data.start) > 47 * 60) {
 				this.log.verbose(`${this.logReference}: Raid/Egg on ${data.gymName} will be longer than 47 minutes - ignored`)
@@ -294,6 +296,7 @@ class Raid extends Controller {
 								data.fullName = data.name.concat(data.formNormalised ? ' ' : '', data.formNormalised)
 							}
 
+							data.levelName = translator.translateFormat(data.levelNameEng)
 							data.megaName = data.evolution ? translator.translateFormat(this.GameData.utilData.megaName[data.evolution], data.name) : data.name
 							data.teamNameEng = this.GameData.utilData.teams[data.team_id].name
 							data.teamName = translator.translate(data.teamNameEng)
@@ -526,6 +529,7 @@ class Raid extends Controller {
 						data.teamEmoji = data.team_id !== undefined ? this.emojiLookup.lookup(this.GameData.utilData.teams[data.team_id].emoji, platform) : ''
 						data.gameWeatherName = data.weather ? translator.translate(data.gameWeatherNameEng) : ''
 						data.gameWeatherEmoji = data.weather ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
+						data.levelName = translator.translateFormat(data.levelNameEng)
 
 						const view = {
 							...geoResult,

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -102,7 +102,7 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'valor' || element === 'red') team = 2
 			else if (element === 'mystic' || element === 'blue') team = 1
 			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') [1, 3, 5, 6].forEach((x) => levelSet.add(x))
+			else if (element === 'everything') [1, 3, 5, 6, 7].forEach((x) => levelSet.add(x))
 			else if (element === 'clean') clean = true
 		}
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -844,6 +844,15 @@
 		"562_2344": "8",
 		"618_2345": "8"
 	},
+	"raidLevels": {
+		"1": "Level 1",
+		"2": "Level 2",
+		"3": "Level 3",
+		"4": "Level 4",
+		"5": "Level 5",
+		"6": "Mega",
+		"7": "Mega Legendary"
+	},
 	"emojis": {
 		"lure-normal": "\ud83d\udccd",
 		"lure-glacial": "\u2744",


### PR DESCRIPTION
1. Add level7 to !raid everything
2. Add {{levelName}} and {{levelNameEng}} to raid and egg dts.  This will show Level 1, Level 3, Level 5, Mega and Mega Legendary for levels 1,3,5,6, and 7 respectively

I will keep this PR open until I have seen a level7 raid and roll anything else needed for support into here.