### PR TITLE
Support tracking of evolutions

### DIFF
--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -221,7 +221,7 @@ exports.run = async (client, msg, args, options) => {
 							count++
 							if (count > 20) return
 							if (mon.evolutions) {
-								for(const evolution of mon.evolutions) {
+								for (const evolution of mon.evolutions) {
 									monsterList.add(evolution.evoId)
 									const evoMonster = client.GameData.monsters[`${evolution.evoId}_${evolution.id}`]
 									evoAdd(evoMonster)
@@ -230,8 +230,7 @@ exports.run = async (client, msg, args, options) => {
 						}
 						evoAdd(monster)
 					}
-				}
-				else if (typeArray.includes(element)) typeList.push(element)
+				} else if (typeArray.includes(element)) typeList.push(element)
 				else {
 					await msg.react('🙅')
 					return msg.reply(translator.translateFormat('I do not understand this option: {0}', element))

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -205,8 +205,32 @@ exports.run = async (client, msg, args, options) => {
 					}
 				}
 			} else {
-				const monster = Object.values(client.GameData.monsters).find((mon) => (element === mon.name.toLowerCase()) || element === mon.id.toString())
-				if (monster) monsterList.add(monster.id)
+				let monsterMatch = element
+				let addEvolutions = false
+				if (monsterMatch.endsWith('+')) {
+					monsterMatch = monsterMatch.slice(0, -1)
+					addEvolutions = true
+				}
+				const monster = Object.values(client.GameData.monsters).find((mon) => (monsterMatch === mon.name.toLowerCase()) || element === mon.id.toString())
+				if (monster) {
+					monsterList.add(monster.id)
+					if (addEvolutions) {
+						let count = 0
+						// eslint-disable-next-line no-loop-func
+						const evoAdd = (mon) => {
+							count++
+							if (count > 20) return
+							if (mon.evolutions) {
+								for(const evolution of mon.evolutions) {
+									monsterList.add(evolution.evoId)
+									const evoMonster = client.GameData.monsters[`${evolution.evoId}_${evolution.id}`]
+									evoAdd(evoMonster)
+								}
+							}
+						}
+						evoAdd(monster)
+					}
+				}
 				else if (typeArray.includes(element)) typeList.push(element)
 				else {
 					await msg.react('🙅')


### PR DESCRIPTION
Would you like to track all evolutions of a particular pokemon?

Well now you can. Just add + after the monster name.

![image](https://user-images.githubusercontent.com/1204736/171822075-a1ec0f25-bf0a-47f1-bff6-26983b54c43f.png)
