### PR TITLE
Fix quest cache

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,7 @@ const fastify = require('fastify')({
 	bodyLimit: 52428800,
 	maxParamLength: 256,
 })
+const stringify = require('fast-json-stable-stringify');
 const { Telegraf } = require('telegraf')
 const Ohbem = require('ohbem')
 const path = require('path')
@@ -652,7 +653,7 @@ async function processOne(hook) {
 				}
 				if (!hook.message.poracleTest) {
 					fastify.webhooks.info(`quest ${JSON.stringify(hook.message)}`)
-					const cacheKey = `${hook.message.pokestop_id}_${JSON.stringify(hook.message.rewards)}`
+					const cacheKey = `${hook.message.pokestop_id}_${stringify(hook.message.rewards)}`
 
 					if (fastify.cache.get(cacheKey)) {
 						fastify.controllerLog.debug(`${hook.message.pokestop_id}: Quest was sent again too soon, ignoring`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix Cache problem for quests. Now Poracle use pokestop id and rewards for create cache key, but the same reward can came in diffrent order:
`[{"info":{"form_id":861,"pokemon_id":443,"shiny":false,"costume_id":0,"gender_id":0},"type":7}]

[{"type":7,"info":{"costume_id":0,"gender_id":0,"pokemon_id":443,"shiny":false,"form_id":861}}]`

json.stringify save it as is, fast-json-stable-stringify save is with order, so now cache will be works. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Change solve problem with cache quest webhook properly. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing on my setup. I don't sure if lib is already in node modules, but should be. 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.