### PR TITLE
Lowering default minCP for PvP

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -194,14 +194,14 @@
     // pvpDisplay* - these are variables that will be passed into DTS to allow you to perform
     //   a filtering calculation
       "pvpDisplayMaxRank": 10,
-      "pvpDisplayGreatMinCP": 1450,
-      "pvpDisplayUltraMinCP": 2450,
+      "pvpDisplayGreatMinCP": 1400,
+      "pvpDisplayUltraMinCP": 2350,
       "pvpDisplayLittleMinCP": 450,
     // pvpFilter* - these filters are used as minimums on the track command to help users get
     //   PVP tracking right and to eliminate unexpectedly large tracks
       "pvpFilterMaxRank": 10,
-      "pvpFilterGreatMinCP": 1450,
-      "pvpFilterUltraMinCP": 2450,
+      "pvpFilterGreatMinCP": 1400,
+      "pvpFilterUltraMinCP": 2350,
       "pvpFilterLittleMinCP": 450
   },
   //


### PR DESCRIPTION
Current Ultra won't cover cases like rank1 Stunfisk Galarian with CP 2445 at level 50, Togedemaru with CP 2442 or Skarmory with CP 2383. 

Current Great won't cover cases like rank1 Chansey with CP 1418.