### PR TITLE
fix autocreate mixing permissions between roles

### DIFF
--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -95,10 +95,10 @@ exports.run = async (client, msg, [args]) => {
 
 			// add role permissions
 			let roleId
-			const allowed = []
 			if (channelDefinition.roles) {
 				const roleOverwrites = []
 				for (const role of channelDefinition.roles) {
+					const allowed = []
 					roleId = await guild.roles.cache.get(format(role.id, args))
 					if (role.view) allowed.push('VIEW_CHANNEL')
 					if (role.viewHistory) allowed.push('READ_MESSAGE_HISTORY')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using the autocreate command, and putting multiple roles with different permissions in the channel definition, I noticed that the permissions were mixed between the different roles. For instance:
```json
          "roles": [
            {
              "id": "AAA",
              "view": true,
              "viewHistory": true,
              "send": true,
              "react": true
            },
            {
              "id": "BBB",
              "view": false,
              "viewHistory": false,
              "send": false,
              "react": false
            },
          ]
```
With this definition, when creating the channel, the role `BBB` will have the same permissions as the role `AAA`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The fix is quite easy. I just made it so that the permissions array (called `allowed` here) is reset between each role creation. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
