### PR TITLE
change {{{googleMapUrl}}} link url

### DIFF
--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -88,7 +88,7 @@ class Gym extends Controller {
 
 			Object.assign(data, this.config.general.dtsDictionary)
 			data.gymId = data.id || data.gym_id
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -235,7 +235,7 @@ class Monster extends Controller {
 			if (!data.weather) data.weather = 0
 			Object.assign(data, this.config.general.dtsDictionary)
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {
 				data.rdmUrl = `${this.config.general.rdmURL}${!this.config.general.rdmURL.endsWith('/') ? '/' : ''}@pokemon/${data.encounter_id}`

--- a/src/controllers/nest.js
+++ b/src/controllers/nest.js
@@ -75,7 +75,7 @@ class Nest extends Controller {
 			data.latitude = data.lat
 
 			Object.assign(data, this.config.general.dtsDictionary)
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -72,7 +72,7 @@ class Invasion extends Controller {
 			const logReference = data.pokestop_id
 
 			Object.assign(data, this.config.general.dtsDictionary)
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -74,7 +74,7 @@ class Lure extends Controller {
 			const logReference = data.pokestop_id
 
 			Object.assign(data, this.config.general.dtsDictionary)
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -105,7 +105,7 @@ class Quest extends Controller {
 			const logReference = data.pokestop_id
 
 			Object.assign(data, this.config.general.dtsDictionary)
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -138,7 +138,7 @@ class Raid extends Controller {
 			const logReference = data.gym_id
 
 			Object.assign(data, this.config.general.dtsDictionary)
-			data.googleMapUrl = `https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude}`
+			data.googleMapUrl = `https://maps.google.com/maps?q=${data.latitude},${data.longitude}`
 			data.appleMapUrl = `https://maps.apple.com/maps?daddr=${data.latitude},${data.longitude}`
 			data.wazeMapUrl = `https://www.waze.com/ul?ll=${data.latitude},${data.longitude}&navigate=yes&zoom=17`
 			if (this.config.general.rdmURL) {

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -93,7 +93,7 @@ exports.run = async (client, msg, args, options) => {
 		if (remove) {
 			message = translator.translateFormat('I have removed {0}\'s  location', target.name)
 		} else {
-			const maplink = `https://www.google.com/maps/search/?api=1&query=${lat},${lon}`
+			const maplink = `https://maps.google.com/maps?q=${lat},${lon}`
 			message = `👋, ${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}:\n${maplink}`
 
 			if (platform === 'discord' && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -235,7 +235,7 @@ exports.run = async (client, msg, args, options) => {
 
 		const blocked = human.blocked_alerts ? JSON.parse(human.blocked_alerts) : []
 
-		const maplink = `https://www.google.com/maps/search/?api=1&query=${human.latitude},${human.longitude}`
+		const maplink = `https://maps.google.com/maps?q=${human.latitude},${human.longitude}`
 		if (args.includes('area')) {
 			return msg.reply(currentAreaText(translator, client.geofence, JSON.parse(human.area)))
 		}

--- a/test/tests/sqlite/commands/location.js
+++ b/test/tests/sqlite/commands/location.js
@@ -40,7 +40,7 @@ describe('!location command tests', () => {
 		assert.equal(result.latitude, 59.4372155)
 		assert.equal(result.longitude, 24.7453688)
 		assert.equal(client.lastReact, '✅')
-		assert.equal(client.lastMessage, ':wave:, I set registeredUserInTallinns location to : \nhttps://www.google.com/maps/search/?api=1&query=59.4372155,24.7453688')
+		assert.equal(client.lastMessage, ':wave:, I set registeredUserInTallinns location to : \nhttps://maps.google.com/maps?q=59.4372155,24.7453688')
 		assert.equal(discordMessaveValidator(client.lastMessage, 'bot'), true)
 	})
 
@@ -59,7 +59,7 @@ describe('!location command tests', () => {
 		assert.equal(result.latitude, 59.4372155)
 		assert.equal(result.longitude, 24.7453688)
 		assert.equal(client.lastReact, '✅')
-		assert.equal(client.lastMessage, ':wave:, I set adminSetLocationInThisChannels location to : \nhttps://www.google.com/maps/search/?api=1&query=59.4372155,24.7453688')
+		assert.equal(client.lastMessage, ':wave:, I set adminSetLocationInThisChannels location to : \nhttps://maps.google.com/maps?q=59.4372155,24.7453688')
 		assert.equal(discordMessaveValidator(client.lastMessage, 'bot'), true)
 	})
 
@@ -69,7 +69,7 @@ describe('!location command tests', () => {
 		assert.equal(result.latitude, 59.4372155)
 		assert.equal(result.longitude, 24.7453688)
 		assert.equal(client.lastReact, '✅')
-		assert.equal(client.lastMessage, ':wave:, I set registeredwebhooks location to : \nhttps://www.google.com/maps/search/?api=1&query=59.4372155,24.7453688')
+		assert.equal(client.lastMessage, ':wave:, I set registeredwebhooks location to : \nhttps://maps.google.com/maps?q=59.4372155,24.7453688')
 		assert.equal(discordMessaveValidator(client.lastMessage, 'bot'), true)
 	})
 


### PR DESCRIPTION
## Description
This submission changes {{{googleMapUrl}}} links from https://www.google.com/maps/search/?api=1&query=${data.latitude},${data.longitude} to https://maps.google.com/maps?q=${data.latitude},${data.longitude}

## Motivation and Context
This fixes the bug on iPhone where the urls do not resolve when the "Web browser" setting in Discord app is set to Chrome.

## How Has This Been Tested?
Verified that the "google" links work correctly from Discord on iOS.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.