### PR TITLE
fix autocreate channels deny

### DIFF
--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -75,8 +75,13 @@ exports.run = async (client, msg, [args]) => {
 
 		let categoryId
 		if (template.definition.category) {
-			const category = await guild.channels.create(format(template.definition.category, args), { type: 'GUILD_CATEGORY' })
-			categoryId = category.id
+			const exists = await guild.channels.cache.find(type => type.type === 'GUILD_CATEGORY' && type.name === template.definition.category)
+			if (exists) {
+				categoryId = exists.id
+			} else {
+				const category = await guild.channels.create(format(template.definition.category, args), { type: 'GUILD_CATEGORY' })
+				categoryId = category.id
+			}
 		}
 
 		for (const channelDefinition of template.definition.channels) {
@@ -103,22 +108,22 @@ exports.run = async (client, msg, [args]) => {
 					roleId = await guild.roles.cache.get(format(role.id, args))
 					if (role.view) { 
 						allowed.push('VIEW_CHANNEL')
-					} else { 
+					} else if (role.view === false) { 
 						deny.push('VIEW_CHANNEL')
 					}
 					if (role.viewHistory) {
 						allowed.push('READ_MESSAGE_HISTORY')
-					} else { 
+					} else if (role.viewHistory === false) { 
 						deny.push('READ_MESSAGE_HISTORY')
 					}
 					if (role.send) {
 						allowed.push('SEND_MESSAGES')
-					} else {
+					} else if (role.send === false) {
 						deny.push('SEND_MESSAGES')
 					}
 					if (role.react) {
 						allowed.push('ADD_REACTIONS')
-					} else {
+					} else if (role.react === false) {
 						deny.push('ADD_REACTIONS') 
 					}
 					roleOverwrites.push({ id: roleId, allow: allowed, deny: deny })

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -119,7 +119,7 @@ exports.run = async (client, msg, [args]) => {
 					if (role.react) {
 						allowed.push('ADD_REACTIONS')
 					} else {
-						deny.push('ADD_REACTIONS')
+						deny.push('ADD_REACTIONS') 
 					}
 					roleOverwrites.push({ id: roleId, allow: allowed, deny: deny })
 				}

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -75,7 +75,7 @@ exports.run = async (client, msg, [args]) => {
 
 		let categoryId
 		if (template.definition.category) {
-			const exists = await guild.channels.cache.find(type => type.type === 'GUILD_CATEGORY' && type.name === template.definition.category)
+			const exists = await guild.channels.cache.find(channel => channel.type === 'GUILD_CATEGORY' && channel.name === template.definition.category)
 			if (exists) {
 				categoryId = exists.id
 			} else {

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -99,12 +99,29 @@ exports.run = async (client, msg, [args]) => {
 				const roleOverwrites = []
 				for (const role of channelDefinition.roles) {
 					const allowed = []
+					const deny = []
 					roleId = await guild.roles.cache.get(format(role.id, args))
-					if (role.view) allowed.push('VIEW_CHANNEL')
-					if (role.viewHistory) allowed.push('READ_MESSAGE_HISTORY')
-					if (role.send) allowed.push('SEND_MESSAGES')
-					if (role.react) allowed.push('ADD_REACTIONS')
-					roleOverwrites.push({ id: roleId, allow: allowed })
+					if (role.view) { 
+						allowed.push('VIEW_CHANNEL')
+					} else { 
+						deny.push('VIEW_CHANNEL')
+					}
+					if (role.viewHistory) {
+						allowed.push('READ_MESSAGE_HISTORY')
+					} else { 
+						deny.push('READ_MESSAGE_HISTORY')
+					}
+					if (role.send) {
+						allowed.push('SEND_MESSAGES')
+					} else {
+						deny.push('SEND_MESSAGES')
+					}
+					if (role.react) {
+						allowed.push('ADD_REACTIONS')
+					} else {
+						deny.push('ADD_REACTIONS')
+					}
+					roleOverwrites.push({ id: roleId, allow: allowed, deny: deny })
 				}
 				channelOptions.permissionOverwrites = roleOverwrites
 			}

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -75,13 +75,8 @@ exports.run = async (client, msg, [args]) => {
 
 		let categoryId
 		if (template.definition.category) {
-			const exists = await guild.channels.cache.find(channel => channel.type === 'GUILD_CATEGORY' && channel.name === template.definition.category)
-			if (exists) {
-				categoryId = exists.id
-			} else {
-				const category = await guild.channels.create(format(template.definition.category, args), { type: 'GUILD_CATEGORY' })
-				categoryId = category.id
-			}
+			const category = await guild.channels.create(format(template.definition.category, args), { type: 'GUILD_CATEGORY' })
+			categoryId = category.id
 		}
 
 		for (const channelDefinition of template.definition.channels) {
@@ -124,7 +119,7 @@ exports.run = async (client, msg, [args]) => {
 					if (role.react) {
 						allowed.push('ADD_REACTIONS')
 					} else if (role.react === false) {
-						deny.push('ADD_REACTIONS') 
+						deny.push('ADD_REACTIONS')
 					}
 					roleOverwrites.push({ id: roleId, allow: allowed, deny: deny })
 				}


### PR DESCRIPTION
Poracle's autocreate command did not respect the `false` values for permissions.

This change should make it possible to deny view for everyone role

tested and works as intended :)