### PR TITLE
Allow Styles To Be Used in Config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -449,7 +449,7 @@
       "providerURL": "",
       "forwardOnly": false, // When true, disable reverse geocoding lookup
       "cacheDetail": 3,     // number of decimal places of lon/lat to use while caching geocoding (default 3 - or use 4 for 100x more detail)
-      "dayStyle": "", 
+      "dayStyle": "", // Names of styles you want to use for different times of day using tileservercache
       "dawnStyle": "",
       "duskStyle": "",
       "nightStyle": "",

--- a/config/default.json
+++ b/config/default.json
@@ -450,7 +450,7 @@
       "forwardOnly": false, // When true, disable reverse geocoding lookup
       "cacheDetail": 3,     // number of decimal places of lon/lat to use while caching geocoding (default 3 - or use 4 for 100x more detail)
       "dayStyle": "", // Names of styles you want to use for different times of day using tileservercache
-      "dawnStyle": "",
+      "dawnStyle": "", // Use style: "#(style)" in templates to utilize this config option
       "duskStyle": "",
       "nightStyle": "",
       "intersectionUsers": [], //list of geonames usernames to use for getting street intersections

--- a/config/default.json
+++ b/config/default.json
@@ -449,6 +449,10 @@
       "providerURL": "",
       "forwardOnly": false, // When true, disable reverse geocoding lookup
       "cacheDetail": 3,     // number of decimal places of lon/lat to use while caching geocoding (default 3 - or use 4 for 100x more detail)
+      "dayStyle": "", 
+      "dawnStyle": "",
+      "duskStyle": "",
+      "nightStyle": "",
     // staticProvider - this is your provider of map tiles; can be tileservercache
     //   (swift tile server - https://github.com/123FLO321/SwiftTileserverCache)
     //   or google,osm,mapbox - staticKey provides an array of keys to use

--- a/src/controllers/common/nightTime.js
+++ b/src/controllers/common/nightTime.js
@@ -17,21 +17,17 @@ function setNightTime(data, checkTime, config) {
 	data.dawnTime = checkTime.isBetween(sunriseTime, dawnEndTime)
 	data.duskTime = checkTime.isBetween(duskStartTime, sunsetTime)
 
-	const defaultStyle = "klokantech-basic"
+	const defaultStyle = 'klokantech-basic'
 
-	if (data.dawnTime){
+	if (data.dawnTime) {
 		data.style = config.geocoding.dawnStyle || defaultStyle
-	}
-	else if (data.duskTime){
+	} else if (data.duskTime) {
 		data.style = config.geocoding.duskStyle || defaultStyle
-	}
-	else if (data.nightTime){
+	} else if (data.nightTime) {
 		data.style = config.geocoding.nightStyle || defaultStyle
-	}
-	else {
+	} else {
 		data.style = config.geocoding.dayStyle || defaultStyle
 	}
-
 }
 
 module.exports = { setNightTime }

--- a/src/controllers/common/nightTime.js
+++ b/src/controllers/common/nightTime.js
@@ -5,7 +5,7 @@ const SunCalc = require('suncalc')
 
 /* Night time clculations */
 
-function setNightTime(data, checkTime) {
+function setNightTime(data, checkTime, config) {
 	const times = SunCalc.getTimes(checkTime.toDate(), data.latitude, data.longitude)
 	const sunsetTime = moment(times.sunset)
 	const sunriseTime = moment(times.sunrise)
@@ -16,6 +16,22 @@ function setNightTime(data, checkTime) {
 	data.nightTime = !checkTime.isBetween(sunriseTime, sunsetTime)
 	data.dawnTime = checkTime.isBetween(sunriseTime, dawnEndTime)
 	data.duskTime = checkTime.isBetween(duskStartTime, sunsetTime)
+
+	const defaultStyle = "klokantech-basic"
+
+	if (data.dawnTime){
+		data.style = config.geocoding.dawnStyle || defaultStyle
+	}
+	else if (data.duskTime){
+		data.style = config.geocoding.duskStyle || defaultStyle
+	}
+	else if (data.nightTime){
+		data.style = config.geocoding.nightStyle || defaultStyle
+	}
+	else {
+		data.style = config.geocoding.dayStyle || defaultStyle
+	}
+
 }
 
 module.exports = { setNightTime }

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -178,7 +178,6 @@ class Gym extends Controller {
 
 					require('./common/nightTime').setNightTime(data, conqueredTime, this.config)
 
-
 					await this.getStaticMapUrl(logReference, data, 'gym', ['teamId', 'latitude', 'longitude', 'imgUrl', 'style'])
 					data.staticmap = data.staticMap // deprecated
 

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -178,7 +178,22 @@ class Gym extends Controller {
 
 					require('./common/nightTime').setNightTime(data, conqueredTime)
 
-					await this.getStaticMapUrl(logReference, data, 'gym', ['teamId', 'latitude', 'longitude', 'imgUrl'])
+					data.style = "klokantech-basic";
+
+					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
+						data.style = this.config.geocoding.dawnStyle;
+					}
+					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
+						data.style = this.config.geocoding.duskStyle;
+					}
+					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
+						data.style = this.config.geocoding.nightStyle;
+					}
+					else {
+						data.style = this.config.geocoding.dayStyle;
+					}
+
+					await this.getStaticMapUrl(logReference, data, 'gym', ['teamId', 'latitude', 'longitude', 'imgUrl', 'style'])
 					data.staticmap = data.staticMap // deprecated
 
 					for (const cares of whoCares) {

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -177,10 +177,10 @@ class Gym extends Controller {
 					const jobs = []
 
 					require('./common/nightTime').setNightTime(data, conqueredTime, this.config)
-          
+
 					await this.getStaticMapUrl(logReference, data, 'gym', ['teamId', 'latitude', 'longitude', 'imgUrl', 'style'])
 					data.intersection = await this.obtainIntersection(data)
-          
+
 					data.staticmap = data.staticMap // deprecated
 
 					for (const cares of whoCares) {

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -176,22 +176,8 @@ class Gym extends Controller {
 					const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 					const jobs = []
 
-					require('./common/nightTime').setNightTime(data, conqueredTime)
+					require('./common/nightTime').setNightTime(data, conqueredTime, this.config)
 
-					data.style = "klokantech-basic";
-
-					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
-						data.style = this.config.geocoding.dawnStyle;
-					}
-					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
-						data.style = this.config.geocoding.duskStyle;
-					}
-					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
-						data.style = this.config.geocoding.nightStyle;
-					}
-					else {
-						data.style = this.config.geocoding.dayStyle;
-					}
 
 					await this.getStaticMapUrl(logReference, data, 'gym', ['teamId', 'latitude', 'longitude', 'imgUrl', 'style'])
 					data.staticmap = data.staticMap // deprecated

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -507,22 +507,7 @@ class Monster extends Controller {
 					})
 					const jobs = []
 
-					require('./common/nightTime').setNightTime(data, disappearTime)
-
-					data.style = "klokantech-basic";
-
-					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
-						data.style = this.config.geocoding.dawnStyle;
-					}
-					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
-						data.style = this.config.geocoding.duskStyle;
-					}
-					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
-						data.style = this.config.geocoding.nightStyle;
-					}
-					else {
-						data.style = this.config.geocoding.dayStyle;
-					}
+					require('./common/nightTime').setNightTime(data, disappearTime, this.config)
 
 					if (data.seen_type) {
 						switch (data.seen_type) {

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -509,6 +509,21 @@ class Monster extends Controller {
 
 					require('./common/nightTime').setNightTime(data, disappearTime)
 
+					data.style = "klokantech-basic";
+
+					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
+						data.style = this.config.geocoding.dawnStyle;
+					}
+					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
+						data.style = this.config.geocoding.duskStyle;
+					}
+					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
+						data.style = this.config.geocoding.nightStyle;
+					}
+					else {
+						data.style = this.config.geocoding.dayStyle;
+					}
+
 					if (data.seen_type) {
 						switch (data.seen_type) {
 							case 'nearby_stop': {
@@ -551,8 +566,8 @@ class Monster extends Controller {
 						logReference,
 						data,
 						'monster',
-						['pokemon_id', 'latitude', 'longitude', 'form', 'costume', 'imgUrl', 'imgUrlAlt'],
-						['pokemon_id', 'display_pokemon_id', 'latitude', 'longitude', 'verified', 'costume', 'form', 'pokemonId', 'generation', 'weather', 'confirmedTime', 'shinyPossible', 'seenType', 'seen_type', 'cell_coords', 'imgUrl', 'imgUrlAlt', 'nightTime', 'duskTime', 'dawnTime'],
+						['pokemon_id', 'latitude', 'longitude', 'form', 'costume', 'imgUrl', 'imgUrlAlt', 'style'],
+						['pokemon_id', 'display_pokemon_id', 'latitude', 'longitude', 'verified', 'costume', 'form', 'pokemonId', 'generation', 'weather', 'confirmedTime', 'shinyPossible', 'seenType', 'seen_type', 'cell_coords', 'imgUrl', 'imgUrlAlt', 'nightTime', 'duskTime', 'dawnTime', 'style'],
 					)
 					data.staticmap = data.staticMap // deprecated
 

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -191,11 +191,26 @@ class Invasion extends Controller {
 
 					require('./common/nightTime').setNightTime(data, disappearTime)
 
+					data.style = "klokantech-basic";
+
+					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
+						data.style = this.config.geocoding.dawnStyle;
+					}
+					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
+						data.style = this.config.geocoding.duskStyle;
+					}
+					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
+						data.style = this.config.geocoding.nightStyle;
+					}
+					else {
+						data.style = this.config.geocoding.dayStyle;
+					}
+
 					// Get current cell weather from cache
 					const weatherCellId = this.weatherData.getWeatherCellId(data.latitude, data.longitude)
 					const currentCellWeather = this.weatherData.getCurrentWeatherInCell(weatherCellId)
 
-					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'gruntTypeId', 'displayTypeId'])
+					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'gruntTypeId', 'displayTypeId', 'style'])
 					data.staticmap = data.staticMap // deprecated
 
 					for (const cares of whoCares) {

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -189,22 +189,7 @@ class Invasion extends Controller {
 					const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 					const jobs = []
 
-					require('./common/nightTime').setNightTime(data, disappearTime)
-
-					data.style = "klokantech-basic";
-
-					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
-						data.style = this.config.geocoding.dawnStyle;
-					}
-					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
-						data.style = this.config.geocoding.duskStyle;
-					}
-					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
-						data.style = this.config.geocoding.nightStyle;
-					}
-					else {
-						data.style = this.config.geocoding.dayStyle;
-					}
+					require('./common/nightTime').setNightTime(data, disappearTime, this.config)
 
 					// Get current cell weather from cache
 					const weatherCellId = this.weatherData.getWeatherCellId(data.latitude, data.longitude)

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -260,7 +260,7 @@ class Invasion extends Controller {
 											const firstReward = +fr.id
 											const firstRewardForm = +fr.form
 											const firstRewardMonster = Object.values(this.GameData.monsters).find((mon) => mon.id === firstReward && mon.form.id === firstRewardForm)
-											gruntRewardsformNormalised = firstRewardMonster.form.name === 'Normal' ? '' : (translator.translate(firstRewardMonster.form.name)+' ')
+											gruntRewardsformNormalised = firstRewardMonster.form.name === 'Normal' ? '' : (`${translator.translate(firstRewardMonster.form.name)} `)
 											gruntRewards += gruntRewardsformNormalised + firstRewardMonster ? translator.translate(firstRewardMonster.name) : ''
 											gruntRewardsList.first.monsters.push({
 												id: firstReward,
@@ -280,7 +280,7 @@ class Invasion extends Controller {
 											const secondReward = +sr.id
 											const secondRewardForm = +sr.form
 											const secondRewardMonster = Object.values(this.GameData.monsters).find((mon) => mon.id === secondReward && mon.form.id === secondRewardForm)
-											gruntRewardsformNormalised = secondRewardMonster.form.name === 'Normal' ? '' : (translator.translate(secondRewardMonster.form.name)+' ')
+											gruntRewardsformNormalised = secondRewardMonster.form.name === 'Normal' ? '' : (`${translator.translate(secondRewardMonster.form.name)} `)
 											gruntRewards += gruntRewardsformNormalised + secondRewardMonster ? translator.translate(secondRewardMonster.name) : ''
 											gruntRewardsList.second.monsters.push({
 												id: secondReward,
@@ -301,7 +301,7 @@ class Invasion extends Controller {
 											const reward = +tr.id
 											const rewardForm = +tr.form
 											const rewardMonster = Object.values(this.GameData.monsters).find((mon) => mon.id === reward && mon.form.id === rewardForm)
-											gruntRewardsformNormalised = rewardMonster.form.name === 'Normal' ? '' : (translator.translate(rewardMonster.form.name)+' ')
+											gruntRewardsformNormalised = rewardMonster.form.name === 'Normal' ? '' : (`${translator.translate(rewardMonster.form.name)} `)
 											gruntRewards += gruntRewardsformNormalised + rewardMonster ? translator.translate(rewardMonster.name) : ''
 											gruntRewardsList.first.monsters.push({
 												id: reward,

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -155,7 +155,22 @@ class Lure extends Controller {
 
 					require('./common/nightTime').setNightTime(data, disappearTime)
 
-					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'lureTypeId'])
+					data.style = "klokantech-basic";
+
+					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
+						data.style = this.config.geocoding.dawnStyle;
+					}
+					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
+						data.style = this.config.geocoding.duskStyle;
+					}
+					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
+						data.style = this.config.geocoding.nightStyle;
+					}
+					else {
+						data.style = this.config.geocoding.dayStyle;
+					}
+
+					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'lureTypeId', 'style'])
 					data.staticmap = data.staticMap // deprecated
 
 					for (const cares of whoCares) {

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -153,22 +153,7 @@ class Lure extends Controller {
 					})
 					const jobs = []
 
-					require('./common/nightTime').setNightTime(data, disappearTime)
-
-					data.style = "klokantech-basic";
-
-					if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
-						data.style = this.config.geocoding.dawnStyle;
-					}
-					else if (data.duskTime && this.config.geocoding.duskStyle != ''){
-						data.style = this.config.geocoding.duskStyle;
-					}
-					else if (data.nightTime && this.config.geocoding.nightStyle != ''){
-						data.style = this.config.geocoding.nightStyle;
-					}
-					else {
-						data.style = this.config.geocoding.dayStyle;
-					}
+					require('./common/nightTime').setNightTime(data, disappearTime, this.config)
 
 					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'lureTypeId', 'style'])
 					data.staticmap = data.staticMap // deprecated

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -157,7 +157,7 @@ class Lure extends Controller {
 
 					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'lureTypeId', 'style'])
 					data.intersection = await this.obtainIntersection(data)
-          
+
 					data.staticmap = data.staticMap // deprecated
 
 					for (const cares of whoCares) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -512,7 +512,7 @@ class Raid extends Controller {
 					const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 					const jobs = []
 
-					require('./common/nightTime').setNightTime(data, hatchTime)
+					require('./common/nightTime').setNightTime(data, hatchTime, this.config)
 
 					await this.getStaticMapUrl(logReference, data, 'raid', ['latitude', 'longitude', 'level', 'imgUrl'])
 					data.staticmap = data.staticMap // deprecated

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -260,22 +260,7 @@ class Raid extends Controller {
 						})
 						const jobs = []
 
-						require('./common/nightTime').setNightTime(data, disappearTime)
-
-						data.style = "klokantech-basic";
-
-						if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
-							data.style = this.config.geocoding.dawnStyle;
-						}
-						else if (data.duskTime && this.config.geocoding.duskStyle != ''){
-							data.style = this.config.geocoding.duskStyle;
-						}
-						else if (data.nightTime && this.config.geocoding.nightStyle != ''){
-							data.style = this.config.geocoding.nightStyle;
-						}
-						else {
-							data.style = this.config.geocoding.dayStyle;
-						}
+						require('./common/nightTime').setNightTime(data, disappearTime, this.config)
 
 						await this.getStaticMapUrl(logReference, data, 'raid', ['pokemon_id', 'latitude', 'longitude', 'form', 'level', 'imgUrl', 'style'])
 						data.staticmap = data.staticMap // deprecated

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -262,7 +262,22 @@ class Raid extends Controller {
 
 						require('./common/nightTime').setNightTime(data, disappearTime)
 
-						await this.getStaticMapUrl(logReference, data, 'raid', ['pokemon_id', 'latitude', 'longitude', 'form', 'level', 'imgUrl'])
+						data.style = "klokantech-basic";
+
+						if (data.dawnTime && this.config.geocoding.dawnStyle != ''){
+							data.style = this.config.geocoding.dawnStyle;
+						}
+						else if (data.duskTime && this.config.geocoding.duskStyle != ''){
+							data.style = this.config.geocoding.duskStyle;
+						}
+						else if (data.nightTime && this.config.geocoding.nightStyle != ''){
+							data.style = this.config.geocoding.nightStyle;
+						}
+						else {
+							data.style = this.config.geocoding.dayStyle;
+						}
+
+						await this.getStaticMapUrl(logReference, data, 'raid', ['pokemon_id', 'latitude', 'longitude', 'form', 'level', 'imgUrl', 'style'])
 						data.staticmap = data.staticMap // deprecated
 						data.types = monster.types.map((type) => type.id)
 

--- a/src/lib/poracleMessage/commands/info.js
+++ b/src/lib/poracleMessage/commands/info.js
@@ -244,6 +244,8 @@ exports.run = async (client, msg, args, options) => {
 						const strengths = {}
 						const weaknesses = {}
 
+						message = message.concat(`\n**Pokédex ID:** ${mon.id}\n`);
+
 						for (const type of types) {
 							strengths[type] = []
 							typeInfo[type].strengths.forEach((x) => {

--- a/src/lib/poracleMessage/commands/info.js
+++ b/src/lib/poracleMessage/commands/info.js
@@ -244,7 +244,7 @@ exports.run = async (client, msg, args, options) => {
 						const strengths = {}
 						const weaknesses = {}
 
-						message = message.concat(`\n**Pokédex ID:** ${mon.id}\n`);
+						message = message.concat(`\n**Pokédex ID:** ${mon.id}\n`)
 
 						for (const type of types) {
 							strengths[type] = []


### PR DESCRIPTION
## Description
Made change so that you can put time of day styles in config rather than through tileserver, this way you can just put "#(style)" in your template rather than praying you get the if else string right in your template.

## Motivation and Context
Makes it so you only have to change your config when you want to change styles, rather than changing every template to use new styles when they come out. 

## How Has This Been Tested?
Can be tested by adding the appriopriate styles names to the config in the geocoding section and changing templates to have 
"style": "#(style)"

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.