### PR TITLE
Get Street Intersections from Geonames

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -449,6 +449,7 @@
       "providerURL": "",
       "forwardOnly": false, // When true, disable reverse geocoding lookup
       "cacheDetail": 3,     // number of decimal places of lon/lat to use while caching geocoding (default 3 - or use 4 for 100x more detail)
+      "intersectionUsers": [""],
     // staticProvider - this is your provider of map tiles; can be tileservercache
     //   (swift tile server - https://github.com/123FLO321/SwiftTileserverCache)
     //   or google,osm,mapbox - staticKey provides an array of keys to use

--- a/src/controllers/gym.js
+++ b/src/controllers/gym.js
@@ -178,6 +178,8 @@ class Gym extends Controller {
 
 					require('./common/nightTime').setNightTime(data, conqueredTime)
 
+					data.intersection = await this.getIntersection(data.latitude, data.longitude);
+
 					await this.getStaticMapUrl(logReference, data, 'gym', ['teamId', 'latitude', 'longitude', 'imgUrl'])
 					data.staticmap = data.staticMap // deprecated
 

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -509,6 +509,8 @@ class Monster extends Controller {
 
 					require('./common/nightTime').setNightTime(data, disappearTime)
 
+					data.intersection = await this.getIntersection(data.latitude, data.longitude);
+
 					if (data.seen_type) {
 						switch (data.seen_type) {
 							case 'nearby_stop': {

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -191,6 +191,8 @@ class Invasion extends Controller {
 
 					require('./common/nightTime').setNightTime(data, disappearTime)
 
+					data.intersection = await this.getIntersection(data.latitude, data.longitude);
+
 					// Get current cell weather from cache
 					const weatherCellId = this.weatherData.getWeatherCellId(data.latitude, data.longitude)
 					const currentCellWeather = this.weatherData.getCurrentWeatherInCell(weatherCellId)

--- a/src/controllers/pokestop_lure.js
+++ b/src/controllers/pokestop_lure.js
@@ -155,6 +155,8 @@ class Lure extends Controller {
 
 					require('./common/nightTime').setNightTime(data, disappearTime)
 
+					data.intersection = await this.getIntersection(data.latitude, data.longitude);
+
 					await this.getStaticMapUrl(logReference, data, 'pokestop', ['latitude', 'longitude', 'imgUrl', 'lureTypeId'])
 					data.staticmap = data.staticMap // deprecated
 

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -117,6 +117,7 @@ class Quest extends Controller {
 			if (this.config.general.rocketMadURL) {
 				data.rocketMadUrl = `${this.config.general.rocketMadURL}${!this.config.general.rocketMadURL.endsWith('/') ? '/' : ''}?lat=${data.latitude}&lon=${data.longitude}&zoom=18.0`
 			}
+			data.intersection = await this.getIntersection(data.latitude, data.longitude);
 			data.disappearTime = moment.tz(new Date(), this.config.locale.time, geoTz.find(data.latitude, data.longitude)[0].toString()).endOf('day')
 			data.applemap = data.appleMapUrl // deprecated
 			data.mapurl = data.googleMapUrl // deprecated

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -262,6 +262,8 @@ class Raid extends Controller {
 
 						require('./common/nightTime').setNightTime(data, disappearTime)
 
+						data.intersection = await this.getIntersection(data.latitude, data.longitude);
+
 						await this.getStaticMapUrl(logReference, data, 'raid', ['pokemon_id', 'latitude', 'longitude', 'form', 'level', 'imgUrl'])
 						data.staticmap = data.staticMap // deprecated
 						data.types = monster.types.map((type) => type.id)


### PR DESCRIPTION
## Description
Added the ability to get street intersections from Geonames, pretty sure none of the other geocoding providers currently offer this and this is probably one of the more useful ways a user can quickly determine if they want to get something or not.

## Motivation and Context
People know street intersections very well, so this helps them to know if it's worth it or not to go after a mon at quick glance. 

## How Has This Been Tested?
Use {{intersection}} in DTS in order to get intersection of streets. Make sure to use multiple users for geonames if you will hit rate limit of 20k per day

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
Config option added to use multiple users for Geonames to not reach rate limit. 