### PR TITLE
Overhaul the Autocreate command

### DIFF
--- a/config/defaults/channelTemplate.json
+++ b/config/defaults/channelTemplate.json
@@ -2,17 +2,59 @@
   {
     "name":"newSection",
     "definition":{
-      "category":"{0} Pokemon",
+      "category":{
+        "categoryName":"{0} Pokemon",
+        "roles":[
+          {
+            "name":"{0}",
+            "view": true,
+            "viewHistory": true,
+            "send": false,
+            "react": true,
+            "pingEveryone": false,
+            "embedLinks": false,
+            "attachFiles": false,
+            "externalEmoji": false,
+            "externalStickers": false,
+            "createPublicThreads": false,
+            "createPrivateThreads": false,
+            "sendThreads": false,
+            "slash": false
+          },
+          {
+            "name":"@everyone",
+            "view": false
+          }
+        ]
+      },
       "channels":[
         {
-          "channelName":"{0}-iv100",
-/*
+          "channelName":"{0}-chatroom",
           "roles":[
             {
-              "id":"11111111111111111", "view": true, "viewHistory": true, "send": true, "react": true
+              "name":"{0}",
+              "view": true,
+              "viewHistory": true,
+              "send": true,
+              "react": true,
+              "externalEmoji": true
+            },
+            {
+              "name":"{1}",
+              "view": true,
+              "viewHistory": true,
+              "send": false,
+              "react": true
+            },
+            {
+              "name":"@everyone",
+              "view": false
             }
           ],
-*/
+          "topic": "Chat for {0} users"
+        },
+        {
+          "channelName":"{0}-iv100",
           "topic": "Hundos for {0}",
           "controlType":"bot",
           "commands":[

--- a/config/defaults/channelTemplate.json
+++ b/config/defaults/channelTemplate.json
@@ -8,18 +8,38 @@
           {
             "name":"{0}",
             "view": true,
+            // Text
             "viewHistory": true,
             "send": false,
             "react": true,
             "pingEveryone": false,
             "embedLinks": false,
             "attachFiles": false,
+            "sendTTS": false,
             "externalEmoji": false,
             "externalStickers": false,
             "createPublicThreads": false,
             "createPrivateThreads": false,
             "sendThreads": false,
-            "slash": false
+            "slashCommands": false,
+            // Voice
+            "connect": false,
+            "speak": false,
+            "autoMic": false,
+            "stream": false,
+            "vcActivities": false,
+            "prioritySpeaker": false,
+            // Admin
+            "createInvite": false,
+            "channels": false,
+            "messages": false,
+            "roles": false,
+            "webhooks": false,
+            "threads": false,
+            "events": false,
+            "mute": false,
+            "deafen": false,
+            "move": false
           },
           {
             "name":"@everyone",
@@ -30,6 +50,8 @@
       "channels":[
         {
           "channelName":"{0}-chatroom",
+          "channelType":"text",
+          "topic": "Chat for {0} users",
           "roles":[
             {
               "name":"{0}",
@@ -50,11 +72,16 @@
               "name":"@everyone",
               "view": false
             }
-          ],
-          "topic": "Chat for {0} users"
+          ]
+        },
+        {
+          "channelName":"{0}-voicechat",
+          "channelType":"voice",
+          "topic": "Voice for {0}"
         },
         {
           "channelName":"{0}-iv100",
+          "channelType":"text",
           "topic": "Hundos for {0}",
           "controlType":"bot",
           "commands":[
@@ -64,6 +91,7 @@
         },
         {
           "channelName":"{0}-UltraRares",
+          "channelType":"text",
           "controlType":"webhook",
           "commands":[
             "area add {0}",
@@ -72,6 +100,7 @@
         },
         {
           "channelName":"{0}-Raids",
+          "channelType":"text",
           "controlType":"webhook",
           "commands":[
             "area add {0}",

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -137,6 +137,11 @@ exports.run = async (client, msg, [args]) => {
 					} else if (role.attachFiles === false) {
 						deny.push('ATTACH_FILES')
 					}
+					if (role.sendTTS) {
+						allowed.push('SEND_TTS_MESSAGES')
+					} else if (role.sendTTS === false) {
+						deny.push('SEND_TTS_MESSAGES')
+					}
 					if (role.externalEmoji) {
 						allowed.push('USE_EXTERNAL_EMOJIS')
 					} else if (role.externalEmoji === false) {
@@ -162,10 +167,95 @@ exports.run = async (client, msg, [args]) => {
 					} else if (role.sendThreads === false) {
 						deny.push('SEND_MESSAGES_IN_THREADS')
 					}
-          if (role.slash) {
+          if (role.slashCommands) {
 						allowed.push('USE_APPLICATION_COMMANDS')
-					} else if (role.slash === false) {
+					} else if (role.slashCommands === false) {
 						deny.push('USE_APPLICATION_COMMANDS')
+					}
+          if (role.connect) {
+						allowed.push('CONNECT')
+					} else if (role.connect === false) {
+						deny.push('CONNECT')
+					}
+          if (role.speak) {
+						allowed.push('SPEAK')
+					} else if (role.speak === false) {
+						deny.push('SPEAK')
+					}
+          if (role.autoMic) {
+						allowed.push('USE_VAD')
+					} else if (role.autoMic === false) {
+						deny.push('USE_VAD')
+					}
+          if (role.stream) {
+						allowed.push('STREAM')
+					} else if (role.stream === false) {
+						deny.push('STREAM')
+					}
+/*           if (role.soundboard) {
+						allowed.push('USE_SOUNDBOARD')
+					} else if (role.soundboard === false) {
+						deny.push('USE_SOUNDBOARD')
+					} */ //future use, v9 API
+          if (role.vcActivities) {
+						allowed.push('START_EMBEDDED_ACTIVITIES')
+					} else if (role.vcActivities === false) {
+						deny.push('START_EMBEDDED_ACTIVITIES')
+					}
+          if (role.prioritySpeaker) {
+						allowed.push('PRIORITY_SPEAKER')
+					} else if (role.prioritySpeaker === false) {
+						deny.push('PRIORITY_SPEAKER')
+					}
+          if (role.createInvite) {
+						allowed.push('CREATE_INSTANT_INVITE')
+					} else if (role.createInvite === false) {
+						deny.push('CREATE_INSTANT_INVITE')
+					}
+          if (role.channels) {
+						allowed.push('MANAGE_CHANNELS')
+					} else if (role.channels === false) {
+						deny.push('MANAGE_CHANNELS')
+					}
+          if (role.messages) {
+						allowed.push('MANAGE_MESSAGES')
+					} else if (role.messages === false) {
+						deny.push('MANAGE_MESSAGES')
+					}
+          if (role.roles) {
+						allowed.push('MANAGE_ROLES')
+					} else if (role.roles === false) {
+						deny.push('MANAGE_ROLES')
+					}
+          if (role.webhooks) {
+						allowed.push('MANAGE_WEBHOOKS')
+					} else if (role.webhooks === false) {
+						deny.push('MANAGE_WEBHOOKS')
+					}
+          if (role.threads) {
+						allowed.push('MANAGE_THREADS')
+					} else if (role.threads === false) {
+						deny.push('MANAGE_THREADS')
+					}
+          if (role.events) {
+						allowed.push('MANAGE_EVENTS')
+					} else if (role.events === false) {
+						deny.push('MANAGE_EVENTS')
+					}
+          if (role.mute) {
+						allowed.push('MUTE_MEMBERS')
+					} else if (role.mute === false) {
+						deny.push('MUTE_MEMBERS')
+					}
+          if (role.deafen) {
+						allowed.push('DEAFEN_MEMBERS')
+					} else if (role.deafen === false) {
+						deny.push('DEAFEN_MEMBERS')
+					}
+          if (role.move) {
+						allowed.push('MOVE_MEMBERS')
+					} else if (role.move === false) {
+						deny.push('MOVE_MEMBERS')
 					}
 					roleOverwrites.push({ id: roleId, allow: allowed, deny })
 				}
@@ -179,9 +269,12 @@ exports.run = async (client, msg, [args]) => {
 		}
 
 		for (const channelDefinition of template.definition.channels) {
-			const channelOptions = {
-				type: 'GUILD_TEXT',
-			}
+      const channelOptions = {}
+      if (channelDefinition.channelType === "text") {
+        channelOptions.type = 'GUILD_TEXT'
+      } else if (channelDefinition.channelType === "voice") {
+        channelOptions.type = 'GUILD_VOICE'
+      }
 			if (categoryId) {
 				channelOptions.parent = categoryId
 			}
@@ -247,6 +340,11 @@ exports.run = async (client, msg, [args]) => {
 					} else if (role.attachFiles === false) {
 						deny.push('ATTACH_FILES')
 					}
+					if (role.sendTTS) {
+						allowed.push('SEND_TTS_MESSAGES')
+					} else if (role.sendTTS === false) {
+						deny.push('SEND_TTS_MESSAGES')
+					}
 					if (role.externalEmoji) {
 						allowed.push('USE_EXTERNAL_EMOJIS')
 					} else if (role.externalEmoji === false) {
@@ -272,10 +370,95 @@ exports.run = async (client, msg, [args]) => {
 					} else if (role.sendThreads === false) {
 						deny.push('SEND_MESSAGES_IN_THREADS')
 					}
-          if (role.slash) {
+          if (role.slashCommands) {
 						allowed.push('USE_APPLICATION_COMMANDS')
-					} else if (role.slash === false) {
+					} else if (role.slashCommands === false) {
 						deny.push('USE_APPLICATION_COMMANDS')
+					}
+          if (role.connect) {
+						allowed.push('CONNECT')
+					} else if (role.connect === false) {
+						deny.push('CONNECT')
+					}
+          if (role.speak) {
+						allowed.push('SPEAK')
+					} else if (role.speak === false) {
+						deny.push('SPEAK')
+					}
+          if (role.autoMic) {
+						allowed.push('USE_VAD')
+					} else if (role.autoMic === false) {
+						deny.push('USE_VAD')
+					}
+          if (role.stream) {
+						allowed.push('STREAM')
+					} else if (role.stream === false) {
+						deny.push('STREAM')
+					}
+/*           if (role.soundboard) {
+						allowed.push('USE_SOUNDBOARD')
+					} else if (role.soundboard === false) {
+						deny.push('USE_SOUNDBOARD')
+					} */ //future use, v9 API
+          if (role.vcActivities) {
+						allowed.push('START_EMBEDDED_ACTIVITIES')
+					} else if (role.vcActivities === false) {
+						deny.push('START_EMBEDDED_ACTIVITIES')
+					}
+          if (role.prioritySpeaker) {
+						allowed.push('PRIORITY_SPEAKER')
+					} else if (role.prioritySpeaker === false) {
+						deny.push('PRIORITY_SPEAKER')
+					}
+          if (role.createInvite) {
+						allowed.push('CREATE_INSTANT_INVITE')
+					} else if (role.createInvite === false) {
+						deny.push('CREATE_INSTANT_INVITE')
+					}
+          if (role.channels) {
+						allowed.push('MANAGE_CHANNELS')
+					} else if (role.channels === false) {
+						deny.push('MANAGE_CHANNELS')
+					}
+          if (role.messages) {
+						allowed.push('MANAGE_MESSAGES')
+					} else if (role.messages === false) {
+						deny.push('MANAGE_MESSAGES')
+					}
+          if (role.roles) {
+						allowed.push('MANAGE_ROLES')
+					} else if (role.roles === false) {
+						deny.push('MANAGE_ROLES')
+					}
+          if (role.webhooks) {
+						allowed.push('MANAGE_WEBHOOKS')
+					} else if (role.webhooks === false) {
+						deny.push('MANAGE_WEBHOOKS')
+					}
+          if (role.threads) {
+						allowed.push('MANAGE_THREADS')
+					} else if (role.threads === false) {
+						deny.push('MANAGE_THREADS')
+					}
+          if (role.events) {
+						allowed.push('MANAGE_EVENTS')
+					} else if (role.events === false) {
+						deny.push('MANAGE_EVENTS')
+					}
+          if (role.mute) {
+						allowed.push('MUTE_MEMBERS')
+					} else if (role.mute === false) {
+						deny.push('MUTE_MEMBERS')
+					}
+          if (role.deafen) {
+						allowed.push('DEAFEN_MEMBERS')
+					} else if (role.deafen === false) {
+						deny.push('DEAFEN_MEMBERS')
+					}
+          if (role.move) {
+						allowed.push('MOVE_MEMBERS')
+					} else if (role.move === false) {
+						deny.push('MOVE_MEMBERS')
 					}
 					roleOverwrites.push({ id: roleId, allow: allowed, deny })
 				}
@@ -292,15 +475,15 @@ exports.run = async (client, msg, [args]) => {
 				continue
 			}
 
-			const channelType = channelDefinition.controlType
-			await msg.reply(`>> Adding control type: ${channelType}`)
+			const controlType = channelDefinition.controlType
+			await msg.reply(`>> Adding control type: ${controlType}`)
 
 			// register channel in poracle
 			let id
 			let type
 			let name
 
-			if (channelType === 'bot') {
+			if (controlType === 'bot') {
 				id = channel.id
 				type = 'discord:channel'
 				name = format(channelDefinition.channelName, subArgs)

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -69,13 +69,112 @@ exports.run = async (client, msg, [args]) => {
 		}
 
 		// switch underscores back in so works for substitution later
+    const subArgs = []
 		for (let x = 0; x < args.length; x++) {
-			args[x] = args[x].replace(/ /g, '_')
+			subArgs[x] = args[x].replace(/ /g, '_')
 		}
 
 		let categoryId
 		if (template.definition.category) {
-			const category = await guild.channels.create(format(template.definition.category, args), { type: 'GUILD_CATEGORY' })
+			const categoryOptions = {
+				type: 'GUILD_CATEGORY',
+			}
+
+			const categoryName = format(template.definition.category.categoryName, args)
+
+			// add role permissions
+			let roleId
+			if (template.definition.category.roles) {
+				const roleOverwrites = []
+				for (const role of template.definition.category.roles) {
+					const allowed = []
+					const deny = []
+          const roleNames = guild.roles.cache.map(r => r.name.toLowerCase())
+          const roleIds = guild.roles.cache.map(r => r.id)
+          for (let x = 0; x < roleNames.length; x++) {
+            if ((format(role.name, args)) === roleNames[x]) {
+              roleId = await guild.roles.cache.get(roleIds[x])
+            }
+          }
+          if (!roleId) {
+            roleId = await guild.roles.create({
+              name: (format(role.name, args)),
+              permissions: []
+            })
+          }
+					if (role.view) {
+						allowed.push('VIEW_CHANNEL')
+					} else if (role.view === false) {
+						deny.push('VIEW_CHANNEL')
+					}
+					if (role.viewHistory) {
+						allowed.push('READ_MESSAGE_HISTORY')
+					} else if (role.viewHistory === false) {
+						deny.push('READ_MESSAGE_HISTORY')
+					}
+					if (role.send) {
+						allowed.push('SEND_MESSAGES')
+					} else if (role.send === false) {
+						deny.push('SEND_MESSAGES')
+					}
+					if (role.react) {
+						allowed.push('ADD_REACTIONS')
+					} else if (role.react === false) {
+						deny.push('ADD_REACTIONS')
+					}
+					if (role.pingEveryone) {
+						allowed.push('MENTION_EVERYONE')
+					} else if (role.pingEveryone === false) {
+						deny.push('MENTION_EVERYONE')
+					}
+					if (role.embedLinks) {
+						allowed.push('EMBED_LINKS')
+					} else if (role.embedLinks === false) {
+						deny.push('EMBED_LINKS')
+					}
+					if (role.attachFiles) {
+						allowed.push('ATTACH_FILES')
+					} else if (role.attachFiles === false) {
+						deny.push('ATTACH_FILES')
+					}
+					if (role.externalEmoji) {
+						allowed.push('USE_EXTERNAL_EMOJIS')
+					} else if (role.externalEmoji === false) {
+						deny.push('USE_EXTERNAL_EMOJIS')
+					}
+					if (role.externalStickers) {
+						allowed.push('USE_EXTERNAL_STICKERS')
+					} else if (role.externalStickers === false) {
+						deny.push('USE_EXTERNAL_STICKERS')
+					}
+          if (role.createPublicThreads) {
+						allowed.push('CREATE_PUBLIC_THREADS')
+					} else if (role.createPublicThreads === false) {
+						deny.push('CREATE_PUBLIC_THREADS')
+					}
+          if (role.createPrivateThreads) {
+						allowed.push('CREATE_PRIVATE_THREADS')
+					} else if (role.createPrivateThreads === false) {
+						deny.push('CREATE_PRIVATE_THREADS')
+					}
+          if (role.sendThreads) {
+						allowed.push('SEND_MESSAGES_IN_THREADS')
+					} else if (role.sendThreads === false) {
+						deny.push('SEND_MESSAGES_IN_THREADS')
+					}
+          if (role.slash) {
+						allowed.push('USE_APPLICATION_COMMANDS')
+					} else if (role.slash === false) {
+						deny.push('USE_APPLICATION_COMMANDS')
+					}
+					roleOverwrites.push({ id: roleId, allow: allowed, deny })
+				}
+				categoryOptions.permissionOverwrites = roleOverwrites
+			}
+
+			// create category in discord
+			const category = await guild.channels.create(categoryName, categoryOptions)
+			await msg.reply(`>> Creating ${categoryName}`)
 			categoryId = category.id
 		}
 
@@ -100,7 +199,19 @@ exports.run = async (client, msg, [args]) => {
 				for (const role of channelDefinition.roles) {
 					const allowed = []
 					const deny = []
-					roleId = await guild.roles.cache.get(format(role.id, args))
+          const roleNames = guild.roles.cache.map(r => r.name.toLowerCase())
+          const roleIds = guild.roles.cache.map(r => r.id)
+          for (let x = 0; x < roleNames.length; x++) {
+            if ((format(role.name, args)) === roleNames[x]) {
+              roleId = await guild.roles.cache.get(roleIds[x])
+            }
+          }
+          if (!roleId) {
+            roleId = await guild.roles.create({
+              name: (format(role.name, args)),
+              permissions: []
+            })
+          }
 					if (role.view) {
 						allowed.push('VIEW_CHANNEL')
 					} else if (role.view === false) {
@@ -120,6 +231,51 @@ exports.run = async (client, msg, [args]) => {
 						allowed.push('ADD_REACTIONS')
 					} else if (role.react === false) {
 						deny.push('ADD_REACTIONS')
+					}
+					if (role.pingEveryone) {
+						allowed.push('MENTION_EVERYONE')
+					} else if (role.pingEveryone === false) {
+						deny.push('MENTION_EVERYONE')
+					}
+					if (role.embedLinks) {
+						allowed.push('EMBED_LINKS')
+					} else if (role.embedLinks === false) {
+						deny.push('EMBED_LINKS')
+					}
+					if (role.attachFiles) {
+						allowed.push('ATTACH_FILES')
+					} else if (role.attachFiles === false) {
+						deny.push('ATTACH_FILES')
+					}
+					if (role.externalEmoji) {
+						allowed.push('USE_EXTERNAL_EMOJIS')
+					} else if (role.externalEmoji === false) {
+						deny.push('USE_EXTERNAL_EMOJIS')
+					}
+					if (role.externalStickers) {
+						allowed.push('USE_EXTERNAL_STICKERS')
+					} else if (role.externalStickers === false) {
+						deny.push('USE_EXTERNAL_STICKERS')
+					}
+          if (role.createPublicThreads) {
+						allowed.push('CREATE_PUBLIC_THREADS')
+					} else if (role.createPublicThreads === false) {
+						deny.push('CREATE_PUBLIC_THREADS')
+					}
+          if (role.createPrivateThreads) {
+						allowed.push('CREATE_PRIVATE_THREADS')
+					} else if (role.createPrivateThreads === false) {
+						deny.push('CREATE_PRIVATE_THREADS')
+					}
+          if (role.sendThreads) {
+						allowed.push('SEND_MESSAGES_IN_THREADS')
+					} else if (role.sendThreads === false) {
+						deny.push('SEND_MESSAGES_IN_THREADS')
+					}
+          if (role.slash) {
+						allowed.push('USE_APPLICATION_COMMANDS')
+					} else if (role.slash === false) {
+						deny.push('USE_APPLICATION_COMMANDS')
 					}
 					roleOverwrites.push({ id: roleId, allow: allowed, deny })
 				}
@@ -147,13 +303,13 @@ exports.run = async (client, msg, [args]) => {
 			if (channelType === 'bot') {
 				id = channel.id
 				type = 'discord:channel'
-				name = channel.name
+				name = format(channelDefinition.channelName, subArgs)
 			} else {
-				const webhookName = channel.name
+				const webhookName = format(channelDefinition.channelName, subArgs)
 				const res = await channel.createWebhook('Poracle')
 				id = res.url
 				type = 'webhook'
-				name = channelDefinition.webhookName ? format(channelDefinition.webhookName, args) : webhookName
+				name = channelDefinition.webhookName ? format(channelDefinition.webhookName, subArgs) : webhookName
 			}
 
 			// Create
@@ -167,7 +323,7 @@ exports.run = async (client, msg, [args]) => {
 
 			// Commands
 
-			const commands = channelDefinition.commands.map((x) => format(x, args))
+			const commands = channelDefinition.commands.map((x) => format(x, subArgs))
 
 			const pdm = new PoracleDiscordMessage(client, msg)
 			const pds = new PoracleDiscordState(client)

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -23,6 +23,14 @@ exports.run = async (client, msg, [args]) => {
 			return await msg.author.send(client.translator.translate('Please run commands in Direct Messages'))
 		}
 
+    for (const commandText of msg.content.split('\n')) {
+      args = commandText.slice(client.config.discord.prefix.length)
+        .trim()
+        .match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g)
+        .map((x) => x.replace(/"/g, ''))
+      args.shift()
+    }
+
 		let { guild } = msg
 
 		let guildIdOverride = args.find((arg) => arg.match(client.re.guildRe))

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -23,13 +23,13 @@ exports.run = async (client, msg, [args]) => {
 			return await msg.author.send(client.translator.translate('Please run commands in Direct Messages'))
 		}
 
-    for (const commandText of msg.content.split('\n')) {
-      args = commandText.slice(client.config.discord.prefix.length)
-        .trim()
-        .match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g)
-        .map((x) => x.replace(/"/g, ''))
-      args.shift()
-    }
+		for (const commandText of msg.content.split('\n')) {
+			args = commandText.slice(client.config.discord.prefix.length)
+				.trim()
+				.match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g)
+				.map((x) => x.replace(/"/g, ''))
+			args.shift()
+		}
 
 		let { guild } = msg
 
@@ -77,7 +77,7 @@ exports.run = async (client, msg, [args]) => {
 		}
 
 		// switch underscores back in so works for substitution later
-    const subArgs = []
+		const subArgs = []
 		for (let x = 0; x < args.length; x++) {
 			subArgs[x] = args[x].replace(/ /g, '_')
 		}
@@ -97,19 +97,19 @@ exports.run = async (client, msg, [args]) => {
 				for (const role of template.definition.category.roles) {
 					const allowed = []
 					const deny = []
-          const roleNames = guild.roles.cache.map(r => r.name)
-          const roleIds = guild.roles.cache.map(r => r.id)
-          for (let x = 0; x < roleNames.length; x++) {
-            if ((format(role.name, args)) === roleNames[x]) {
-              roleId = await guild.roles.cache.get(roleIds[x])
-            }
-          }
-          if (!roleId) {
-            roleId = await guild.roles.create({
-              name: (format(role.name, args)),
-              permissions: []
-            })
-          }
+					const roleNames = guild.roles.cache.map((r) => r.name)
+					const roleIds = guild.roles.cache.map((r) => r.id)
+					for (let x = 0; x < roleNames.length; x++) {
+						if ((format(role.name, args)) === roleNames[x]) {
+							roleId = await guild.roles.cache.get(roleIds[x])
+						}
+					}
+					if (!roleId) {
+						roleId = await guild.roles.create({
+							name: (format(role.name, args)),
+							permissions: [],
+						})
+					}
 					if (role.view) {
 						allowed.push('VIEW_CHANNEL')
 					} else if (role.view === false) {
@@ -160,107 +160,107 @@ exports.run = async (client, msg, [args]) => {
 					} else if (role.externalStickers === false) {
 						deny.push('USE_EXTERNAL_STICKERS')
 					}
-          if (role.createPublicThreads) {
+					if (role.createPublicThreads) {
 						allowed.push('CREATE_PUBLIC_THREADS')
 					} else if (role.createPublicThreads === false) {
 						deny.push('CREATE_PUBLIC_THREADS')
 					}
-          if (role.createPrivateThreads) {
+					if (role.createPrivateThreads) {
 						allowed.push('CREATE_PRIVATE_THREADS')
 					} else if (role.createPrivateThreads === false) {
 						deny.push('CREATE_PRIVATE_THREADS')
 					}
-          if (role.sendThreads) {
+					if (role.sendThreads) {
 						allowed.push('SEND_MESSAGES_IN_THREADS')
 					} else if (role.sendThreads === false) {
 						deny.push('SEND_MESSAGES_IN_THREADS')
 					}
-          if (role.slashCommands) {
+					if (role.slashCommands) {
 						allowed.push('USE_APPLICATION_COMMANDS')
 					} else if (role.slashCommands === false) {
 						deny.push('USE_APPLICATION_COMMANDS')
 					}
-          if (role.connect) {
+					if (role.connect) {
 						allowed.push('CONNECT')
 					} else if (role.connect === false) {
 						deny.push('CONNECT')
 					}
-          if (role.speak) {
+					if (role.speak) {
 						allowed.push('SPEAK')
 					} else if (role.speak === false) {
 						deny.push('SPEAK')
 					}
-          if (role.autoMic) {
+					if (role.autoMic) {
 						allowed.push('USE_VAD')
 					} else if (role.autoMic === false) {
 						deny.push('USE_VAD')
 					}
-          if (role.stream) {
+					if (role.stream) {
 						allowed.push('STREAM')
 					} else if (role.stream === false) {
 						deny.push('STREAM')
 					}
-/*           if (role.soundboard) {
+					/*           if (role.soundboard) {
 						allowed.push('USE_SOUNDBOARD')
 					} else if (role.soundboard === false) {
 						deny.push('USE_SOUNDBOARD')
-					} */ //future use, v9 API
-          if (role.vcActivities) {
+					} */ // future use, v9 API
+					if (role.vcActivities) {
 						allowed.push('START_EMBEDDED_ACTIVITIES')
 					} else if (role.vcActivities === false) {
 						deny.push('START_EMBEDDED_ACTIVITIES')
 					}
-          if (role.prioritySpeaker) {
+					if (role.prioritySpeaker) {
 						allowed.push('PRIORITY_SPEAKER')
 					} else if (role.prioritySpeaker === false) {
 						deny.push('PRIORITY_SPEAKER')
 					}
-          if (role.createInvite) {
+					if (role.createInvite) {
 						allowed.push('CREATE_INSTANT_INVITE')
 					} else if (role.createInvite === false) {
 						deny.push('CREATE_INSTANT_INVITE')
 					}
-          if (role.channels) {
+					if (role.channels) {
 						allowed.push('MANAGE_CHANNELS')
 					} else if (role.channels === false) {
 						deny.push('MANAGE_CHANNELS')
 					}
-          if (role.messages) {
+					if (role.messages) {
 						allowed.push('MANAGE_MESSAGES')
 					} else if (role.messages === false) {
 						deny.push('MANAGE_MESSAGES')
 					}
-          if (role.roles) {
+					if (role.roles) {
 						allowed.push('MANAGE_ROLES')
 					} else if (role.roles === false) {
 						deny.push('MANAGE_ROLES')
 					}
-          if (role.webhooks) {
+					if (role.webhooks) {
 						allowed.push('MANAGE_WEBHOOKS')
 					} else if (role.webhooks === false) {
 						deny.push('MANAGE_WEBHOOKS')
 					}
-          if (role.threads) {
+					if (role.threads) {
 						allowed.push('MANAGE_THREADS')
 					} else if (role.threads === false) {
 						deny.push('MANAGE_THREADS')
 					}
-          if (role.events) {
+					if (role.events) {
 						allowed.push('MANAGE_EVENTS')
 					} else if (role.events === false) {
 						deny.push('MANAGE_EVENTS')
 					}
-          if (role.mute) {
+					if (role.mute) {
 						allowed.push('MUTE_MEMBERS')
 					} else if (role.mute === false) {
 						deny.push('MUTE_MEMBERS')
 					}
-          if (role.deafen) {
+					if (role.deafen) {
 						allowed.push('DEAFEN_MEMBERS')
 					} else if (role.deafen === false) {
 						deny.push('DEAFEN_MEMBERS')
 					}
-          if (role.move) {
+					if (role.move) {
 						allowed.push('MOVE_MEMBERS')
 					} else if (role.move === false) {
 						deny.push('MOVE_MEMBERS')
@@ -277,12 +277,12 @@ exports.run = async (client, msg, [args]) => {
 		}
 
 		for (const channelDefinition of template.definition.channels) {
-      const channelOptions = {}
-      if (channelDefinition.channelType === "text") {
-        channelOptions.type = 'GUILD_TEXT'
-      } else if (channelDefinition.channelType === "voice") {
-        channelOptions.type = 'GUILD_VOICE'
-      }
+			const channelOptions = {}
+			if (channelDefinition.channelType === 'text') {
+				channelOptions.type = 'GUILD_TEXT'
+			} else if (channelDefinition.channelType === 'voice') {
+				channelOptions.type = 'GUILD_VOICE'
+			}
 			if (categoryId) {
 				channelOptions.parent = categoryId
 			}
@@ -300,19 +300,19 @@ exports.run = async (client, msg, [args]) => {
 				for (const role of channelDefinition.roles) {
 					const allowed = []
 					const deny = []
-          const roleNames = guild.roles.cache.map(r => r.name)
-          const roleIds = guild.roles.cache.map(r => r.id)
-          for (let x = 0; x < roleNames.length; x++) {
-            if ((format(role.name, args)) === roleNames[x]) {
-              roleId = await guild.roles.cache.get(roleIds[x])
-            }
-          }
-          if (!roleId) {
-            roleId = await guild.roles.create({
-              name: (format(role.name, args)),
-              permissions: []
-            })
-          }
+					const roleNames = guild.roles.cache.map((r) => r.name)
+					const roleIds = guild.roles.cache.map((r) => r.id)
+					for (let x = 0; x < roleNames.length; x++) {
+						if ((format(role.name, args)) === roleNames[x]) {
+							roleId = await guild.roles.cache.get(roleIds[x])
+						}
+					}
+					if (!roleId) {
+						roleId = await guild.roles.create({
+							name: (format(role.name, args)),
+							permissions: [],
+						})
+					}
 					if (role.view) {
 						allowed.push('VIEW_CHANNEL')
 					} else if (role.view === false) {
@@ -363,107 +363,107 @@ exports.run = async (client, msg, [args]) => {
 					} else if (role.externalStickers === false) {
 						deny.push('USE_EXTERNAL_STICKERS')
 					}
-          if (role.createPublicThreads) {
+					if (role.createPublicThreads) {
 						allowed.push('CREATE_PUBLIC_THREADS')
 					} else if (role.createPublicThreads === false) {
 						deny.push('CREATE_PUBLIC_THREADS')
 					}
-          if (role.createPrivateThreads) {
+					if (role.createPrivateThreads) {
 						allowed.push('CREATE_PRIVATE_THREADS')
 					} else if (role.createPrivateThreads === false) {
 						deny.push('CREATE_PRIVATE_THREADS')
 					}
-          if (role.sendThreads) {
+					if (role.sendThreads) {
 						allowed.push('SEND_MESSAGES_IN_THREADS')
 					} else if (role.sendThreads === false) {
 						deny.push('SEND_MESSAGES_IN_THREADS')
 					}
-          if (role.slashCommands) {
+					if (role.slashCommands) {
 						allowed.push('USE_APPLICATION_COMMANDS')
 					} else if (role.slashCommands === false) {
 						deny.push('USE_APPLICATION_COMMANDS')
 					}
-          if (role.connect) {
+					if (role.connect) {
 						allowed.push('CONNECT')
 					} else if (role.connect === false) {
 						deny.push('CONNECT')
 					}
-          if (role.speak) {
+					if (role.speak) {
 						allowed.push('SPEAK')
 					} else if (role.speak === false) {
 						deny.push('SPEAK')
 					}
-          if (role.autoMic) {
+					if (role.autoMic) {
 						allowed.push('USE_VAD')
 					} else if (role.autoMic === false) {
 						deny.push('USE_VAD')
 					}
-          if (role.stream) {
+					if (role.stream) {
 						allowed.push('STREAM')
 					} else if (role.stream === false) {
 						deny.push('STREAM')
 					}
-/*           if (role.soundboard) {
+					/*           if (role.soundboard) {
 						allowed.push('USE_SOUNDBOARD')
 					} else if (role.soundboard === false) {
 						deny.push('USE_SOUNDBOARD')
-					} */ //future use, v9 API
-          if (role.vcActivities) {
+					} */ // future use, v9 API
+					if (role.vcActivities) {
 						allowed.push('START_EMBEDDED_ACTIVITIES')
 					} else if (role.vcActivities === false) {
 						deny.push('START_EMBEDDED_ACTIVITIES')
 					}
-          if (role.prioritySpeaker) {
+					if (role.prioritySpeaker) {
 						allowed.push('PRIORITY_SPEAKER')
 					} else if (role.prioritySpeaker === false) {
 						deny.push('PRIORITY_SPEAKER')
 					}
-          if (role.createInvite) {
+					if (role.createInvite) {
 						allowed.push('CREATE_INSTANT_INVITE')
 					} else if (role.createInvite === false) {
 						deny.push('CREATE_INSTANT_INVITE')
 					}
-          if (role.channels) {
+					if (role.channels) {
 						allowed.push('MANAGE_CHANNELS')
 					} else if (role.channels === false) {
 						deny.push('MANAGE_CHANNELS')
 					}
-          if (role.messages) {
+					if (role.messages) {
 						allowed.push('MANAGE_MESSAGES')
 					} else if (role.messages === false) {
 						deny.push('MANAGE_MESSAGES')
 					}
-          if (role.roles) {
+					if (role.roles) {
 						allowed.push('MANAGE_ROLES')
 					} else if (role.roles === false) {
 						deny.push('MANAGE_ROLES')
 					}
-          if (role.webhooks) {
+					if (role.webhooks) {
 						allowed.push('MANAGE_WEBHOOKS')
 					} else if (role.webhooks === false) {
 						deny.push('MANAGE_WEBHOOKS')
 					}
-          if (role.threads) {
+					if (role.threads) {
 						allowed.push('MANAGE_THREADS')
 					} else if (role.threads === false) {
 						deny.push('MANAGE_THREADS')
 					}
-          if (role.events) {
+					if (role.events) {
 						allowed.push('MANAGE_EVENTS')
 					} else if (role.events === false) {
 						deny.push('MANAGE_EVENTS')
 					}
-          if (role.mute) {
+					if (role.mute) {
 						allowed.push('MUTE_MEMBERS')
 					} else if (role.mute === false) {
 						deny.push('MUTE_MEMBERS')
 					}
-          if (role.deafen) {
+					if (role.deafen) {
 						allowed.push('DEAFEN_MEMBERS')
 					} else if (role.deafen === false) {
 						deny.push('DEAFEN_MEMBERS')
 					}
-          if (role.move) {
+					if (role.move) {
 						allowed.push('MOVE_MEMBERS')
 					} else if (role.move === false) {
 						deny.push('MOVE_MEMBERS')
@@ -483,7 +483,7 @@ exports.run = async (client, msg, [args]) => {
 				continue
 			}
 
-			const controlType = channelDefinition.controlType
+			const { controlType } = channelDefinition
 			await msg.reply(`>> Adding control type: ${controlType}`)
 
 			// register channel in poracle

--- a/src/lib/discord/commando/commands/autocreate.js
+++ b/src/lib/discord/commando/commands/autocreate.js
@@ -63,7 +63,7 @@ exports.run = async (client, msg, [args]) => {
 
 		const templateName = args.shift()
 
-		const template = channelTemplate.find((x) => x.name.toLowerCase() === templateName)
+		const template = channelTemplate.find((x) => x.name === templateName)
 		if (!template || !template.definition) {
 			return await msg.reply('I can\'t find that channel template! (remember it has to be your first parameter)')
 		}
@@ -89,7 +89,7 @@ exports.run = async (client, msg, [args]) => {
 				for (const role of template.definition.category.roles) {
 					const allowed = []
 					const deny = []
-          const roleNames = guild.roles.cache.map(r => r.name.toLowerCase())
+          const roleNames = guild.roles.cache.map(r => r.name)
           const roleIds = guild.roles.cache.map(r => r.id)
           for (let x = 0; x < roleNames.length; x++) {
             if ((format(role.name, args)) === roleNames[x]) {
@@ -292,7 +292,7 @@ exports.run = async (client, msg, [args]) => {
 				for (const role of channelDefinition.roles) {
 					const allowed = []
 					const deny = []
-          const roleNames = guild.roles.cache.map(r => r.name.toLowerCase())
+          const roleNames = guild.roles.cache.map(r => r.name)
           const roleIds = guild.roles.cache.map(r => r.id)
           for (let x = 0; x < roleNames.length; x++) {
             if ((format(role.name, args)) === roleNames[x]) {

--- a/src/lib/discord/commando/events/messageCreate.js
+++ b/src/lib/discord/commando/events/messageCreate.js
@@ -53,11 +53,9 @@ module.exports = async (client, msg) => {
 
 				// Convert to lower case, translate back to english, and substitute _ for spaces
 
-        if (args[0] != 'autocreate') {
-          args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase()
-            .replace(/_/g, ' '), true)
-            .toLowerCase())
-        }
+        args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase()
+          .replace(/_/g, ' '), true)
+          .toLowerCase())
 				const command = args.shift()
 
 				// eslint-disable-next-line no-continue

--- a/src/lib/discord/commando/events/messageCreate.js
+++ b/src/lib/discord/commando/events/messageCreate.js
@@ -53,9 +53,11 @@ module.exports = async (client, msg) => {
 
 				// Convert to lower case, translate back to english, and substitute _ for spaces
 
-				args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase()
-					.replace(/_/g, ' '), true)
-					.toLowerCase())
+        if (args[0] != 'autocreate') {
+          args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase()
+            .replace(/_/g, ' '), true)
+            .toLowerCase())
+        }
 				const command = args.shift()
 
 				// eslint-disable-next-line no-continue

--- a/src/lib/discord/commando/events/messageCreate.js
+++ b/src/lib/discord/commando/events/messageCreate.js
@@ -53,9 +53,9 @@ module.exports = async (client, msg) => {
 
 				// Convert to lower case, translate back to english, and substitute _ for spaces
 
-        args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase()
-          .replace(/_/g, ' '), true)
-          .toLowerCase())
+				args = args.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.toLowerCase()
+					.replace(/_/g, ' '), true)
+					.toLowerCase())
 				const command = args.shift()
 
 				// eslint-disable-next-line no-continue

--- a/src/lib/discord/poracleDiscordUtil.js
+++ b/src/lib/discord/poracleDiscordUtil.js
@@ -81,11 +81,11 @@ class PoracleDiscordUtil {
 	async commandAllowed(command) {
 		const roleList = this.client.config.discord.commandSecurity && this.client.config.discord.commandSecurity[command]
 		if (!roleList) return true
-    
-    if (this.options && this.options.targetOverride) {
-      // if target has been overrden by an admin, all commands are permitted
-      return true
-    }
+
+		if (this.options && this.options.targetOverride) {
+			// if target has been overrden by an admin, all commands are permitted
+			return true
+		}
 
 		const postUserId = this.msg.msg.author.id
 		if (roleList.includes(postUserId)) {

--- a/src/lib/discord/poracleDiscordUtil.js
+++ b/src/lib/discord/poracleDiscordUtil.js
@@ -81,6 +81,11 @@ class PoracleDiscordUtil {
 	async commandAllowed(command) {
 		const roleList = this.client.config.discord.commandSecurity && this.client.config.discord.commandSecurity[command]
 		if (!roleList) return true
+    
+    if (this.options && this.options.targetOverride) {
+      // if target has been overrden by an admin, all commands are permitted
+      return true
+    }
 
 		const postUserId = this.msg.msg.author.id
 		if (roleList.includes(postUserId)) {

--- a/src/statsWorker.js
+++ b/src/statsWorker.js
@@ -53,7 +53,6 @@ async function receiveCommand(cmd) {
 		log.debug(`Worker ${workerId}: receiveCommand ${cmd.type}`)
 		if (cmd.type === 'heapdump') {
 			writeHeapSnapshot()
-			return
 		}
 	} catch (err) {
 		log.error(`Worker ${workerId}: receiveCommand failed to process command`, err)


### PR DESCRIPTION
## Description
Autocreate can now:
- create both public and private categories with an extended array of permissions
- respect spaces and capital letters in names for role and category creation
- look up roles by name and create if missing, freeing up the 'guild specific' restriction
- do this all at the channel level as well

## Motivation and Context
I wanted a more robust command and to see if it could be done and if I was capable lol

## How Has This Been Tested?
Beat the ever living shit out of my testing server for two days until every part worked as described.
There is something preventing the tracking commands from working, I suspect this was an issue before I touched it and needs expert help.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change - update to template needed if already made, default example provided (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.