### PR TITLE
Fix raid/egg Everything Command

### DIFF
--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -58,7 +58,7 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'valor' || element === 'red') team = 2
 			else if (element === 'mystic' || element === 'blue') team = 1
 			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') Object.keys(raidLevels).forEach((x) => levelSet.add(+x))
+			else if (element === 'everything') Object.keys(raidLevels).forEach((x) => levelSet.add(x))
 			else if (element === 'clean') clean = true
 		})
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -103,7 +103,7 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'valor' || element === 'red') team = 2
 			else if (element === 'mystic' || element === 'blue') team = 1
 			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') Object.keys(raidLevels).forEach((x) => levelSet.add(+x))
+			else if (element === 'everything') Object.keys(raidLevels).forEach((x) => levelSet.add(x))
 			else if (element === 'clean') clean = true
 		}
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance


### PR DESCRIPTION
The last code change in #839 added a `+` to the everything command, which made it stop at level 9. This fix allows the command to track the whole array of raid levels.