### PR TITLE
Queststring fix

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -80,8 +80,7 @@
     // additional Shortlinks to Pogo Maps in DTS - supported RDM, Reactmap, RocketMAD
       "rdmURL": "",                // https://myRDM.com/
       "reactMapURL": "",           // https://myReactMap.com/
-      "rocketMadURL": "",           // https://myRocketMAD.com/
-      "unknownQuestString": "Unknown Task" // What to tell users when task for quest is unknown
+      "rocketMadURL": ""           // https://myRocketMAD.com/
   },
   //
   // Configuration for the user reconciliation/role check function

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -133,6 +133,7 @@ class Quest extends Controller {
 				return []
 			}
 
+			data.questStringEng = await this.getQuest(data, "en")
 			data.questString = await this.getQuest(data, this.config.general.locale)
 			data.rewardData = await this.getReward(logReference, data)
 			this.log.debug(`${logReference} Quest: data.questString: ${data.questString}, data.rewardData: ${JSON.stringify(data.rewardData)}`)
@@ -383,20 +384,26 @@ class Quest extends Controller {
 
 	async getQuest(item, language) {
 		let str
-		if (item.title) {
-			item.quest_title = item.title
-		}
-		const questinfo = `quest_title_${item.title}`
-		const questTitle = this.GameData.translations[language].questTitles
-		if (questinfo) {
-			try {
-				str = questTitle[questinfo]
-			} catch {
-				str = this.config.general.unknownQuestString
-				this.log.warn(`Missing Task for ${questinfo}`)
+		if (item.quest_task && !this.config.general.ignoreMADQuestString) {
+			str = item.quest_task
+		} else {
+			if (item.title) {
+				item.quest_title = item.title
+			}
+			const questinfo = `quest_title_${item.title}`
+			const questTitle = this.GameData.translations[language].questTitles
+			if (item.title) {
+				try {
+					str = questTitle[questinfo]
+					if (str.toLowerCase().includes('{{amount_0}}') && item.target) {
+						str = str.replace('{{amount_0}}', item.target)
+					}
+				} catch {
+					str = this.GameData.translations[language].questTypes['quest_0']
+					this.log.warn(`Missing Task for ${questinfo}`)
+				}
 			}
 		}
-		str = str.replace('{{amount_0}}', item.target)
 		return str
 	}
 


### PR DESCRIPTION
fix to PR#838 `Generate questString using quest_title from RDM` looks like some backwards fix are needed
missing/away are: 
- questStringEng
- quest_task from MADQuestString

https://github.com/KartulUdus/PoracleJS/blob/a6bc50d31d79d3c0e27de43f4d45bdca3dde8075/src/controllers/quest.js#L399
think i throws an error, if there is no {{amount_0}} and/or item.target!?!

no need for addtional `config.general.unknownQuestString` can use `questTypes['quest_0']` in user language instead