### PR TITLE
QuestsFix v4 - fallback lang to en when lang isnt in masterfile for Questtask

### DIFF
--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -247,7 +247,12 @@ class Quest extends Controller {
 				let [platform] = cares.type.split(':')
 				if (platform === 'webhook') platform = 'discord'
 				if (language !== this.config.general.locale) {
-					data.questString = await this.getQuest(data, language)
+					if (!Object.keys(this.GameData.translations).includes(language)) {
+						this.log.warn(`Missing language ${language}, fallback to english`)
+						data.questString = await this.getQuest(data, "en")
+					} else {
+						data.questString = await this.getQuest(data, language)
+					}
 				}
 
 				for (const monster of data.rewardData.monsters) {

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -247,12 +247,7 @@ class Quest extends Controller {
 				let [platform] = cares.type.split(':')
 				if (platform === 'webhook') platform = 'discord'
 				if (language !== this.config.general.locale) {
-					if (!Object.keys(this.GameData.translations).includes(language)) {
-						this.log.warn(`Missing language ${language}, fallback to english`)
-						data.questString = await this.getQuest(data, "en")
-					} else {
-						data.questString = await this.getQuest(data, language)
-					}
+					data.questString = await this.getQuest(data, language)
 				}
 
 				for (const monster of data.rewardData.monsters) {
@@ -392,6 +387,10 @@ class Quest extends Controller {
 		if (item.quest_task && !this.config.general.ignoreMADQuestString) {
 			str = item.quest_task
 		} else {
+			if (!Object.keys(this.GameData.translations).includes(language)) {
+				this.log.warn(`Missing language ${language}, fallback to english`)
+				language = 'en'
+			}
 			const questinfo = `quest_title_${item.title.toLowerCase()}`
 			const questTitle = this.GameData.translations[language].questTitles
 			if (item.title) {

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -387,10 +387,7 @@ class Quest extends Controller {
 		if (item.quest_task && !this.config.general.ignoreMADQuestString) {
 			str = item.quest_task
 		} else {
-			if (!Object.keys(this.GameData.translations).includes(language)) {
-				this.log.warn(`Missing language ${language}, fallback to english`)
-				language = 'en'
-			}
+			language = !this.GameData.translations[language] ? 'en' : language
 			const questinfo = `quest_title_${item.title.toLowerCase()}`
 			const questTitle = this.GameData.translations[language].questTitles
 			if (item.title) {


### PR DESCRIPTION
if user use language in poracle for dts, which isnt in masterfile, the questtask gen. fails - so:
check masterfile for available language and if it dosnt match to user language -> fallback to english

tested by dkmur in his multilang poracle