### PR TITLE
fix: include `lure_encounter` seen type

### DIFF
--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -527,6 +527,7 @@ class Monster extends Controller {
 								data.seenType = 'lure'
 								break
 							}
+							case 'lure_encounter':
 							case 'encounter':
 							case 'wild': {
 								data.seenType = data.seen_type


### PR DESCRIPTION
Golbat sends `lure_encounter` as seen type in webhooks, this commit adds PoracleJS support