### PR TITLE
fix: geofence API caused by rtree

### DIFF
--- a/src/routes/apiGeofence.js
+++ b/src/routes/apiGeofence.js
@@ -20,7 +20,7 @@ module.exports = async (fastify, options, next) => {
 		}
 
 		try {
-			const url = await geofenceTileGenerator.generateGeofenceTile(fastify.geofence, fastify.query.tileserverPregen, req.params.area)
+			const url = await geofenceTileGenerator.generateGeofenceTile(fastify.geofence.geofence, fastify.query.tileserverPregen, req.params.area)
 			return {
 				status: 'ok',
 				url,
@@ -140,7 +140,7 @@ module.exports = async (fastify, options, next) => {
 		}
 
 		const areas = {}
-		for (const fence of fastify.geofence) {
+		for (const fence of fastify.geofence.geofence) {
 			areas[fence.name] = require('crypto').createHash('md5').update(JSON.stringify(fence.path)).digest('hex')
 		}
 
@@ -173,7 +173,7 @@ module.exports = async (fastify, options, next) => {
 
 		return {
 			status: 'ok',
-			geofence: fastify.geofence,
+			geofence: fastify.geofence.geofence,
 		}
 	})
 
@@ -202,7 +202,7 @@ module.exports = async (fastify, options, next) => {
 			type: 'FeatureCollection',
 			features: [],
 		}
-		const inGeoJSON = fastify.geofence
+		const inGeoJSON = fastify.geofence.geofence
 
 		for (let i = 0; i < inGeoJSON.length; i++) {
 			const inGeofence = inGeoJSON[i]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
PoracleWeb minimaps were not created due to a geofence API error introduced by https://github.com/KartulUdus/PoracleJS/commit/f923708f609aceb65d4be751491c607050158a37

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Production running fine

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.