### PR TITLE
Allows info command to return Previous Evolutions

### DIFF
--- a/src/lib/poracleMessage/commands/info.js
+++ b/src/lib/poracleMessage/commands/info.js
@@ -239,6 +239,9 @@ exports.run = async (client, msg, args, options) => {
 						}
 
 						const mon = monsters[0]
+						const logReference = mon.id
+                        const monEvos = {}
+                        require('../../../util/getEvoData').setEvolutions(monEvos, client.GameData, client.log, logReference, translator, emojiLookup, platform, mon)
 						const typeData = client.GameData.utilData.types
 						const types = mon.types.map((type) => type.name)
 						const strengths = {}
@@ -316,19 +319,35 @@ exports.run = async (client, msg, args, options) => {
 							message = message.concat(`\n**${translator.translate('Third Move Cost')}:**\n${mon.thirdMoveCandy} ${translator.translate('Candies')}\n${new Intl.NumberFormat(language).format(mon.thirdMoveStardust)} ${translator.translate('Stardust')}\n`)
 						}
 
-						if (mon.evolutions) {
-							message = message.concat(`\n**${translator.translate('Evolutions')}:**`)
-							for (const evolution of mon.evolutions) {
-								message = message.concat(`\n${translator.translate(`${client.GameData.monsters[`${evolution.evoId}_${evolution.id || 0}`]?.name || 'Unknown'}`)} (${evolution.candyCost} ${translator.translate('Candies')})`)
-								if (evolution.itemRequirement) message = message.concat(`\n- ${translator.translate('Needed Item')}: ${translator.translate(evolution.itemRequirement)}`)
-								if (evolution.mustBeBuddy) message = message.concat(`\n\u2705 ${translator.translate('Must Be Buddy')}`)
-								if (evolution.onlyNighttime) message = message.concat(`\n\u2705 ${translator.translate('Only Nighttime')}`)
-								if (evolution.onlyDaytime) message = message.concat(`\n\u2705 ${translator.translate('Only Daytime')}`)
-								if (evolution.tradeBonus) message = message.concat(`\n\u2705 ${translator.translate('Trade Bonus')}`)
-								message.concat('\n')
-								if (evolution.questRequirement) message = message.concat(`\n${translator.translate('Special Requirement')}: ${translator.translate(evolution.questRequirement.i18n).replace('{{amount}}', evolution.questRequirement.target)}`)
-								message = message.concat('\n')
+						if (monEvos && monEvos.previousEvolutions.length) {
+							message = message.concat(`\n**Previous ${translator.translate('Evolutions')}:**`)
+							for (let i = monEvos.previousEvolutions.length -1; i>= 0; i--) {
+									const evolution = monEvos.previousEvolutions[i]
+									message = message.concat(`\n${translator.translate(`${client.GameData.monsters[`${evolution.id}_${evolution.form || 0}`]?.name || 'Unknown'}`)} (${evolution.candyCost} ${translator.translate('Candies')})`)
+									if (evolution.itemRequirement) message = message.concat(`\n- ${translator.translate('Needed Item')}: ${translator.translate(evolution.itemRequirement)}`)
+									if (evolution.mustBeBuddy) message = message.concat(`\n\u2705 ${translator.translate('Must Be Buddy')}`)
+									if (evolution.onlyNighttime) message = message.concat(`\n\u2705 ${translator.translate('Only Nighttime')}`)
+									if (evolution.onlyDaytime) message = message.concat(`\n\u2705 ${translator.translate('Only Daytime')}`)
+									if (evolution.tradeBonus) message = message.concat(`\n\u2705 ${translator.translate('Trade Bonus')}`)
+									message.concat('\n')
+									if (evolution.questRequirement) message = message.concat(`\n${translator.translate('Special Requirement')}: ${translator.translate(evolution.questRequirement.i18n).replace('{{amount}}', evolution.questRequirement.target)}`)
 							}
+							message = message.concat('\n')
+						}
+
+						if (monEvos && monEvos.evolutions.length) {
+							message = message.concat(`\n**${translator.translate('Evolutions')}:**`)
+							for (const evolution of monEvos.evolutions) {
+									message = message.concat(`\n${translator.translate(`${client.GameData.monsters[`${evolution.id}_${evolution.form || 0}`]?.name || 'Unknown'}`)} (${evolution.candyCost} ${translator.translate('Candies')})`)
+									if (evolution.itemRequirement) message = message.concat(`\n- ${translator.translate('Needed Item')}: ${translator.translate(evolution.itemRequirement)}`)
+									if (evolution.mustBeBuddy) message = message.concat(`\n\u2705 ${translator.translate('Must Be Buddy')}`)
+									if (evolution.onlyNighttime) message = message.concat(`\n\u2705 ${translator.translate('Only Nighttime')}`)
+									if (evolution.onlyDaytime) message = message.concat(`\n\u2705 ${translator.translate('Only Daytime')}`)
+									if (evolution.tradeBonus) message = message.concat(`\n\u2705 ${translator.translate('Trade Bonus')}`)
+									message.concat('\n')
+									if (evolution.questRequirement) message = message.concat(`\n${translator.translate('Special Requirement')}: ${translator.translate(evolution.questRequirement.i18n).replace('{{amount}}', evolution.questRequirement.target)}`)
+							}
+							message = message.concat('\n')
 						}
 
 						message = message.concat('\n💯:\n')

--- a/src/lib/poracleMessage/commands/info.js
+++ b/src/lib/poracleMessage/commands/info.js
@@ -240,8 +240,8 @@ exports.run = async (client, msg, args, options) => {
 
 						const mon = monsters[0]
 						const logReference = mon.id
-                        const monEvos = {}
-                        require('../../../util/getEvoData').setEvolutions(monEvos, client.GameData, client.log, logReference, translator, emojiLookup, platform, mon)
+						const monEvos = {}
+						require('../../../util/getEvoData').setEvolutions(monEvos, client.GameData, client.log, logReference, translator, emojiLookup, platform, mon)
 						const typeData = client.GameData.utilData.types
 						const types = mon.types.map((type) => type.name)
 						const strengths = {}

--- a/src/util/getEvoData.js
+++ b/src/util/getEvoData.js
@@ -1,0 +1,135 @@
+/* Evolution calculations */
+
+function setEvolutions(data, GameData, log, logReference, translator, emojiLookup, platform, monster) {
+    data.hasEvolutions = monster.evolutions && monster.evolutions.length
+
+    let totalCount = 0
+    const evolutions = []
+    const previousEvolutions = []
+    // Check if mon has a previousEvolution
+    const previousEvo = Object.values(GameData.monsters).filter((mon) => {
+            return mon.evolutions && mon.evolutions.some((evo) => evo.evoId === monster.id && mon.form.id === 0)
+    })
+
+    // eslint-disable-next-line no-shadow
+    const calcEvolutions = (monster) => {
+            if (++totalCount >= 10) {
+                    log.error(`${logReference}: Too many possible evolutions ${monster.id}_${monster.form.id}`)
+                    return
+            }
+
+            if (monster.evolutions && monster.evolutions.length) {
+                    for (const evo of monster.evolutions) {
+                            const newMonster = GameData.monsters[`${evo.evoId}_${evo.id}`]
+
+                            if (newMonster) {
+                                    const { types } = newMonster
+                                    // eslint-disable-next-line no-shadow
+                                    const e = []
+                                    // eslint-disable-next-line no-shadow
+                                    const n = []
+
+                                    types.forEach((type) => {
+                                            e.push(translator.translate(emojiLookup.lookup(GameData.utilData.types[type.name].emoji, platform)))
+                                            n.push(type.name)
+                                    })
+
+                                    const typeName = n.map((type) => translator.translate(type))
+                                            .join(', ')
+                                    const emojiString = e.join('')
+
+                                    const nameEng = newMonster.name
+                                    const name = translator.translate(nameEng)
+                                    const formNameEng = newMonster.form.name
+                                    const formNormalisedEng = formNameEng === 'Normal' ? '' : formNameEng
+                                    const formNormalised = translator.translate(formNormalisedEng)
+
+                                    const fullNameEng = nameEng.concat(formNormalisedEng ? ' ' : '', formNormalisedEng)
+                                    const fullName = name.concat(formNormalised ? ' ' : '', formNormalised)
+
+                                    evolutions.push({
+                                            id: evo.evoId,
+                                            form: evo.id,
+                                            fullName,
+                                            fullNameEng,
+                                            formNormalised,
+                                            formNormalisedEng,
+                                            name,
+                                            nameEng,
+                                            formNameEng,
+                                            typeName,
+                                            typeEmoji: emojiString,
+                                            baseStats: newMonster.stats,
+                                            candyCost: evo.candyCost
+                                    })
+
+                                    calcEvolutions(newMonster)
+                            }
+                    }
+            }
+    }
+
+    const calcDevolutions = (monster) => {
+            if (++totalCount >= 5) {
+                    log.error(`${logReference}: Too many possible devolutions ${monster.id}_${monster.form.id}`)
+                    return
+            }
+            const newMonster = GameData.monsters[`${monster.id}_${monster.form.id || 0}`]
+
+            if (newMonster) {
+                    const { types } = newMonster
+                    // eslint-disable-next-line no-shadow
+                    const e = []
+                    // eslint-disable-next-line no-shadow
+                    const n = []
+
+                    types.forEach((type) => {
+                            e.push(translator.translate(emojiLookup.lookup(GameData.utilData.types[type.name].emoji, platform)))
+                            n.push(type.name)
+                    })
+
+                    const typeName = n.map((type) => translator.translate(type))
+                            .join(', ')
+                    const emojiString = e.join('')
+
+                    const nameEng = newMonster.name
+                    const name = translator.translate(nameEng)
+                    const formNameEng = newMonster.form.name
+                    const formNormalisedEng = formNameEng === 'Normal' ? '' : formNameEng
+                    const formNormalised = translator.translate(formNormalisedEng)
+
+                    const fullNameEng = nameEng.concat(formNormalisedEng ? ' ' : '', formNormalisedEng)
+                    const fullName = name.concat(formNormalised ? ' ' : '', formNormalised)
+
+                    previousEvolutions.push({
+                            id: monster.id,
+                            form: monster.form.id,
+                            fullName,
+                            fullNameEng,
+                            formNormalised,
+                            formNormalisedEng,
+                            name,
+                            nameEng,
+                            formNameEng,
+                            typeName,
+                            typeEmoji: emojiString,
+                            baseStats: newMonster.stats,
+                            candyCost: newMonster.evolutions[0].candyCost // Evolutions is a nested object
+                    })
+                    // Check if there is another devolution
+                    const nextMonster = Object.values(GameData.monsters).filter((mon) => {
+                            return mon.evolutions && mon.evolutions.some((evo) => evo.evoId === newMonster.id && mon.form.id === 0)
+                    })
+                    if (nextMonster && nextMonster.length) calcDevolutions(nextMonster[0])
+            }
+    }
+
+    if (data.hasEvolutions) calcEvolutions(monster)
+    if (previousEvo && previousEvo.length) calcDevolutions(previousEvo[0])
+    data.evolutions = evolutions
+
+    data.hasPreviousEvolutions = !!previousEvolutions.length
+    data.previousEvolutions = previousEvolutions
+}
+
+module.exports = { setEvolutions }

--- a/src/util/getEvoData.js
+++ b/src/util/getEvoData.js
@@ -68,7 +68,7 @@ function setEvolutions(data, GameData, log, logReference, translator, emojiLooku
                     }
             }
     }
-
+    // eslint-disable-next-line no-shadow
     const calcDevolutions = (monster) => {
             if (++totalCount >= 5) {
                     log.error(`${logReference}: Too many possible devolutions ${monster.id}_${monster.form.id}`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR will make it so that when a user runs the `!info` command on a mon, it will do a search for previous evolutions along side evolutions (i.e `!info Charmeleon` would return the data for both Charmander and Charizard). This also introduces a new util file called evoGetData.js. The `calcDevolutions` part of this can be moved over to the same file that `raids` uses if required.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was just something that was in #wishlist so I decided to work on adding it
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this with my own instance.
## Screenshots (if appropriate):
![image](https://github.com/KartulUdus/PoracleJS/assets/26911453/bebf0c95-ed80-4125-bebe-3f663b3f415e)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.