### PR TITLE
fastify version uplift and raid tracking API form upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "deep-object-diff": "^1.1.9",
     "discord.js": "^13.16.0",
     "fast-json-stable-stringify": "^2.1.0",
-    "fastify": "^4.23.0",
+    "fastify": "^4.25.2",
     "flat-cache": "^3.0.4",
     "form-data": "^4.0.0",
     "geo-tz": "^7.0.7",

--- a/src/routes/apiTrackingRaid.js
+++ b/src/routes/apiTrackingRaid.js
@@ -102,7 +102,7 @@ module.exports = async (fastify, options, next) => {
 				team: row.team >= 0 && row.team <= 4 ? row.team : 4, // carefully chosen to get nulls/undefined to 4 but allow 0
 				clean: +defaultTo(+row.clean, 0),
 				level: +level,
-				form: 0,
+				form: +defaultTo(row.form, 0),
 				move: +defaultTo(row.move, 9000),
 				evolution: +defaultTo(row.evolution, 9000),
 				gym_id: row.gym_id ? row.gym_id : null,


### PR DESCRIPTION
## Description
Updates fastify to v4.25.2 and updates raid tracking API to allow forms courtesy of @kbtbc 

## Motivation and Context

API didn't allow forms to be set and Jabes requested the fastify uplift at the same time

## How Has This Been Tested?

I ran it after both of these changes. Fastify didn't appear to break anything API wise and tracking Rockruff form via ReactMap worked as expected.

## Screenshots (if appropriate):

![image](https://github.com/KartulUdus/PoracleJS/assets/10819615/aa821dbe-7e4f-4588-93d2-21454e64672a)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.