### PR TITLE
add *Eng for the pokemons in the `weatherchange` dts

### DIFF
--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -413,8 +413,13 @@ class Weather extends Controller {
 				data.weatherEmoji = data.weatherEmojiEng ? translator.translate(data.weatherEmojiEng) : ''
 				if (this.config.weather.showAlteredPokemon && data.activePokemons) {
 					data.activePokemons.map((pok) => {
+						pok.nameEng = pok.name
 						pok.name = translator.translate(pok.name)
+						pok.formNameEng = pok.formName
+						pok.formNormalisedEng = pok.formNameEng === 'Normal' ? '' : pok.formNameEng
+						pok.formNormalised = translator.translate(pok.formNormalisedEng)
 						pok.formName = translator.translate(pok.formName)
+						pok.fullNameEng = pok.nameEng.concat(pok.formNormalisedEng ? ' ' : '', pok.formNormalisedEng)
 					})
 				}
 


### PR DESCRIPTION
## Description
Added the following that can be used in the `activePokemons` of the `weatherchange` dts:
- nameEng
- fullNameEng
- formNameEng
- formNormalised
- formNormalisedEng

Ex:
```
{{#each activePokemons}}**{{this.fullNameEng}}** - {{round this.iv}}% - {{this.cp}}CP\n{{/each}}
```

Running locally in production for a while. Same logic as found in `monster.js`