### PR TITLE
Change PoGo event data source

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-#!/bin/sh
 npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
-#!/bin/sh
 npm run lint

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "latest": "npm run generate latest && npm run koji && node .",
     "lint": "./node_modules/.bin/eslint ./src --fix",
     "migrateV3": "node src/init/migrateV3.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "start": "npm run generate && npm run koji && node .",
     "test": "node test/test"
   },

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -322,7 +322,7 @@ class Invasion extends Controller {
 							// Lineup 100% of encounter
 							let gruntLineupformNormalised = ''
 							const gruntLineupList = { confirmed: true, monsters: [] }
-							if (data.lineup && data.lineup != 'null') {
+							if (data.lineup && data.lineup !== 'null') {
 								data.lineup.forEach((lr) => {
 									const lineup = +lr.pokemon_id
 									const lineupForm = +lr.form

--- a/src/lib/pogoEventParser.js
+++ b/src/lib/pogoEventParser.js
@@ -9,6 +9,8 @@ const moment = require('moment-timezone')
 class PogoEventParser {
 	constructor(log) {
 		this.log = log
+		this.spawnEvents = []
+		this.questEvents = []
 	}
 
 	/**
@@ -25,7 +27,7 @@ class PogoEventParser {
 			// Timeout Logic
 		}, timeoutMs)
 
-		const url = 'https://raw.githubusercontent.com/ccev/pogoinfo/v2/active/events.json'
+		const url = 'https://raw.githubusercontent.com/bigfoott/ScrapedDuck/data/events.json'
 		const result = await axios({
 			method: 'get',
 			url,
@@ -42,7 +44,25 @@ class PogoEventParser {
 	 * @param events
 	 */
 	loadEvents(events) {
-		this.events = events
+		try{
+			// create filtered pokemon spawn event list
+			// for now, only filter by eventType until spawn information is available
+			var filteredEvents = []
+			for (const event of events.filter((x) => x.eventType === 'community-day' || x.eventType === 'pokemon-spotlight-hour')) {
+				filteredEvents.push(event)
+			}
+			this.spawnEvents = filteredEvents
+
+			// create filtered quest event list
+			// for now, only filter by eventType until field research task information is available
+			filteredEvents = []
+			for (const event of events.filter((x) => x.eventType === 'community-day' )) {
+				filteredEvents.push(event)
+			}
+			this.questEvents = filteredEvents
+		} catch (err) {
+			this.log.error('PogoEvents: Error creating filtered spawn and quest event lists', err)
+		}
 	}
 
 	/**
@@ -54,12 +74,12 @@ class PogoEventParser {
 	 * @returns {{reason: string, name, time}}
 	 */
 	eventChangesSpawn(startTime, disappearTime, lat, lon) {
-		if (!this.events) return
+		if (!this.spawnEvents) return
 
 		try {
 			const tz = geoTz.find(lat, lon)[0].toString()
 
-			for (const event of this.events.filter((x) => (x.spawns && x.spawns.length) || x.type === 'community-day' || x.type === 'spotlight-hour')) {
+			for (const event of this.spawnEvents) {
 				const eventStart = moment.tz(event.start, tz).unix()
 				const eventEnd = moment.tz(event.end, tz).unix()
 				if (startTime < eventStart && eventStart < disappearTime) {
@@ -91,12 +111,12 @@ class PogoEventParser {
 	 * @returns {{reason: string, name, time}}
 	 */
 	eventChangesQuest(startTime, disappearTime, lat, lon) {
-		if (!this.events) return
+		if (!this.questEvents) return
 
 		try {
 			const tz = geoTz.find(lat, lon)[0].toString()
 
-			for (const event of this.events.filter((x) => x.has_quests)) {
+			for (const event of this.questEvents) {
 				const eventStart = moment.tz(event.start, tz).unix()
 				const eventEnd = moment.tz(event.end, tz).unix()
 				if (startTime < eventStart && eventStart < disappearTime) {

--- a/src/lib/pogoEventParser.js
+++ b/src/lib/pogoEventParser.js
@@ -44,10 +44,10 @@ class PogoEventParser {
 	 * @param events
 	 */
 	loadEvents(events) {
-		try{
+		try {
 			// create filtered pokemon spawn event list
 			// for now, only filter by eventType until spawn information is available
-			var filteredEvents = []
+			let filteredEvents = []
 			for (const event of events.filter((x) => x.eventType === 'community-day' || x.eventType === 'pokemon-spotlight-hour')) {
 				filteredEvents.push(event)
 			}
@@ -56,7 +56,7 @@ class PogoEventParser {
 			// create filtered quest event list
 			// for now, only filter by eventType until field research task information is available
 			filteredEvents = []
-			for (const event of events.filter((x) => x.eventType === 'community-day' )) {
+			for (const event of events.filter((x) => x.eventType === 'community-day')) {
 				filteredEvents.push(event)
 			}
 			this.questEvents = filteredEvents

--- a/src/lib/pogoEventParser.js
+++ b/src/lib/pogoEventParser.js
@@ -86,14 +86,14 @@ class PogoEventParser {
 					return {
 						reason: 'start',
 						name: event.name,
-						time: event.start.split(' ')[1],
+						time: moment(event.start).format('HH:mm'),
 					}
 				}
 				if (startTime < eventEnd && eventEnd < disappearTime) {
 					return {
 						reason: 'end',
 						name: event.name,
-						time: event.end.split(' ')[1],
+						time: moment(event.end).format('HH:mm'),
 					}
 				}
 			}
@@ -123,14 +123,14 @@ class PogoEventParser {
 					return {
 						reason: 'start',
 						name: event.name,
-						time: event.start.split(' ')[1],
+						time: moment(event.start).format('HH:mm'),
 					}
 				}
 				if (startTime < eventEnd && eventEnd < disappearTime) {
 					return {
 						reason: 'end',
 						name: event.name,
-						time: event.end.split(' ')[1],
+						time: moment(event.end).format('HH:mm'),
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Changed to "official" Leekduck datasouce based [ScrapedDuck](https://github.com/bigfoott/ScrapedDuck).
Limits: current datasource don't contain event information regarding field research tasks and pokemon pool (spawns) for general events (eventType = 'event'). This PR contain intermediate solution to check only eventType.

Additional: 
1. filter events directly in loadEvents() instead on every eventChanges###() request
2. lint fix for PR #906
3. Migrate Husky pre-commit and pre-push scripts to v9 (see [Changelog v9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1) -> "How to Migrate") by removing obsolte script husky.sh
4. Add new argument for 'poracle-test' command `disapeardt` to overwrite disapear time by datetime e.g. `!poracle-test pokemon boring disapeardt2024-08-07T18:00:00`. So testing against next upcoming event is easier.
 
## Motivation and Context
Old event data source not maintained anymore and data are outdated.

## How Has This Been Tested?
Local debugging. Filtered event lists contain expected events.  Also modified eventlist to check if event start is detected.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.