### PR TITLE
refactor: swap to uicons.js lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "strip-json-comments": "^3.1.1",
     "suncalc": "^1.9.0",
     "telegraf": "^4.12.0",
+    "uicons.js": "^1.1.4",
     "winston": "^3.9.0",
     "winston-daily-rotate-file": "^5.0.0"
   },

--- a/src/lib/uicons.js
+++ b/src/lib/uicons.js
@@ -1,123 +1,18 @@
 const axios = require('axios')
 const { Mutex } = require('async-mutex')
+const { UICONS } = require('uicons.js')
 
 const mutex = new Mutex()
-const uiconsIndex = {}
-const lastRetrieved = {}
 
-function resolvePokemonIcon(availPokemon, imageType, pokemonId, form = 0, evolution = 0, gender = 0, costume = 0, alignment = 0, shiny = false) {
-	const evolutionSuffixes = evolution ? [`_e${evolution}`, ''] : ['']
-	const formSuffixes = form ? [`_f${form}`, ''] : ['']
-	const costumeSuffixes = costume ? [`_c${costume}`, ''] : ['']
-	const genderSuffixes = gender ? [`_g${gender}`, ''] : ['']
-	const alignmentSuffixes = alignment ? [`_a${alignment}`, ''] : ['']
-	const shinySuffixes = shiny ? ['_s', ''] : ['']
-	for (const evolutionSuffix of evolutionSuffixes) {
-		for (const formSuffix of formSuffixes) {
-			for (const costumeSuffix of costumeSuffixes) {
-				for (const genderSuffix of genderSuffixes) {
-					for (const alignmentSuffix of alignmentSuffixes) {
-						for (const shinySuffix of shinySuffixes) {
-							const result = `${pokemonId}${evolutionSuffix}${formSuffix}${costumeSuffix}${genderSuffix}${alignmentSuffix}${shinySuffix}.${imageType}`
-							if (availPokemon.has(result)) return result
-						}
-					}
-				}
-			}
-		}
-	}
-	return `0.${imageType}` // substitute
-}
-
-function resolveGymIcon(availGym, imageType, teamId, trainerCount = 0, inBattle = false, ex = false) {
-	const trainerSuffixes = trainerCount ? [`_t${trainerCount}`, ''] : ['']
-	const inBattleSuffixes = inBattle ? ['_b', ''] : ['']
-	const exSuffixes = ex ? ['_ex', ''] : ['']
-	for (const trainerSuffix of trainerSuffixes) {
-		for (const inBattleSuffix of inBattleSuffixes) {
-			for (const exSuffix of exSuffixes) {
-				const result = `${teamId}${trainerSuffix}${inBattleSuffix}${exSuffix}.${imageType}`
-				if (availGym.has(result)) return result
-			}
-		}
-	}
-	return `0.${imageType}` // substitute
-}
-
-function resolvePokestopIcon(availPokestop, imageType, lureId, invasionActive = false, incidentDisplayType = 0, questActive = false) {
-	const invasionSuffixes = invasionActive ? ['_i', ''] : ['']
-	const incidentDisplayTypeSuffixes = incidentDisplayType ? [`${incidentDisplayType}`, ''] : ['']
-	const questSuffixes = questActive ? ['_q', ''] : ['']
-	for (const invasionSuffix of invasionSuffixes) {
-		for (const incidentDisplayTypeSuffix of incidentDisplayTypeSuffixes) {
-			for (const questSuffix of questSuffixes) {
-				const result = `${lureId}${invasionSuffix}${incidentDisplayTypeSuffix}${questSuffix}.${imageType}`
-				if (availPokestop.has(result)) return result
-			}
-		}
-	}
-	return `0.${imageType}` // substitute
-}
-
-function resolveEggIcon(availEgg, imageType, level, hatched = false, ex = false) {
-	const hatchedSuffixes = hatched ? ['_h', ''] : ['']
-	const exSuffixes = ex ? ['_ex', ''] : ['']
-	for (const hatchedSuffix of hatchedSuffixes) {
-		for (const exSuffix of exSuffixes) {
-			const result = `${level}${hatchedSuffix}${exSuffix}.${imageType}`
-			if (availEgg.has(result)) return result
-		}
-	}
-	return `0.${imageType}` // substitute
-}
-
-function resolveWeatherIcon(availWeather, imageType, weatherId) {
-	const result = `${weatherId}.${imageType}`
-	if (availWeather.has(result)) return result
-
-	return `0.${imageType}` // substitute
-}
-
-function resolveInvasionIcon(availInvasion, imageType, gruntType) {
-	const result = `${gruntType}.${imageType}`
-	if (availInvasion.has(result)) return result
-
-	return `0.${imageType}` // substitute
-}
-
-function resolveTypeIcon(availTypes, imageType, typeId) {
-	const result = `${typeId}.${imageType}`
-	if (availTypes.has(result)) return result
-
-	return `0.${imageType}` // substitute
-}
-
-function resolveTeamIcon(availTeams, imageType, teamId) {
-	const result = `${teamId}.${imageType}`
-	if (availTeams.has(result)) return result
-
-	return `0.${imageType}` // substitute
-}
-
-function resolveItemIcon(itemAvail, imageType, id, amount = 0) {
-	if (amount) {
-		const resultAmount = `${id}_a${amount}.${imageType}`
-		if (itemAvail.has(resultAmount)) return resultAmount
-	}
-	const result = `${id}.${imageType}`
-	if (itemAvail.has(result)) return result
-
-	return `0.${imageType}` // substitute
-}
+const uiconsIndex = /** @type {Record<string, UICONS>} */ ({})
+const lastRetrieved = /** @type {Record<string, number>} */ ({})
 
 const maxAge = 60 * 60 * 1000	// 1 hour
 
 async function getAvailableIcons(log, baseUrl) {
-	let currentSet
-	let lastRetrievedDate
+	let currentSet = uiconsIndex[baseUrl]
+	let lastRetrievedDate = lastRetrieved[baseUrl]
 	try {
-		currentSet = uiconsIndex[baseUrl]
-		lastRetrievedDate = lastRetrieved[baseUrl]
 		if (currentSet === undefined || lastRetrievedDate === undefined || Date.now() - lastRetrievedDate > maxAge) {
 			await mutex.runExclusive(async () => {
 				currentSet = uiconsIndex[baseUrl]
@@ -147,27 +42,9 @@ async function getAvailableIcons(log, baseUrl) {
 							break
 						}
 						case 200: {
-							const results = response.data
-							currentSet = {
-								raid: {
-									egg: new Set(results.raid ? results.raid.egg : []),
-								},
-								gym: new Set(results.gym),
-								team: new Set(results.team),
-								weather: new Set(results.weather),
-								pokestop: new Set(results.pokestop),
-								reward: {
-									item: new Set(results.reward ? results.reward.item : []),
-									stardust: new Set(results.reward ? results.reward.stardust : []),
-									candy: new Set(results.reward ? results.reward.candy : []),
-									xl_candy: new Set(results.reward ? results.reward.xl_candy : []),
-									mega_resource: new Set(results.reward ? results.reward.mega_resource : []),
-								},
-								invasion: new Set(results.invasion),
-								pokemon: new Set(results.pokemon),
-								type: new Set(results.type),
-							}
-							uiconsIndex[baseUrl] = currentSet
+							const uicons = new UICONS(baseUrl)
+							uicons.init(response.data)
+							uiconsIndex[baseUrl] = uicons
 							break
 						}
 						default: {
@@ -197,85 +74,84 @@ class Uicons {
 
 	async isUiconsRepository() {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-
 		return !!currentSet
 	}
 
 	async pokemonIcon(pokemonId, form = 0, evolution = 0, gender = 0, costume = 0, alignment = 0, shiny = false) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/pokemon/${resolvePokemonIcon(currentSet.pokemon, this.imageType, pokemonId, form, evolution, gender, costume, alignment, shiny)}`
+		if (currentSet) return currentSet.pokemon(pokemonId, form, evolution, gender, costume, alignment, shiny)
 		if (this.fallback) return `${this.url}/pokemon_icon_${pokemonId.toString().padStart(3, '0')}_${form ? form.toString() : '00'}${evolution > 0 ? `_${evolution.toString()}` : ''}.${this.imageType}`
 		return null
 	}
 
 	async eggIcon(level, hatched = false, ex = false) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/raid/egg/${resolveEggIcon(currentSet.raid.egg, this.imageType, level, hatched, ex)}`
+		if (currentSet) return currentSet.raidEgg(level, hatched, ex)
 		if (this.fallback) return `${this.url}/egg${level}.${this.imageType}`
 		return null
 	}
 
 	async invasionIcon(gruntType) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/invasion/${resolveInvasionIcon(currentSet.invasion, this.imageType, gruntType)}` : null
+		return currentSet ? currentSet.invasion(gruntType) : null
 	}
 
 	async typeIcon(typeId) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/type/${resolveTypeIcon(currentSet.type, this.imageType, typeId)}` : null
+		return currentSet ? currentSet.type(typeId) : null
 	}
 
 	async teamIcon(teamId) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/team/${resolveTeamIcon(currentSet.type, this.imageType, teamId)}` : null
+		return currentSet ? currentSet.team(teamId) : null
 	}
 
 	async rewardItemIcon(itemId) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/reward/item/${resolveItemIcon(currentSet.reward.item, this.imageType, itemId)}`
+		if (currentSet) return currentSet.reward('item', itemId)
 		if (this.fallback) return `${this.url}/rewards/reward_${itemId}_1.${this.imageType}`
 		return null
 	}
 
 	async rewardStardustIcon(amount) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/reward/stardust/${resolveItemIcon(currentSet.reward.stardust, this.imageType, amount)}`
+		if (currentSet) return currentSet.reward('stardust', amount)
 		if (this.fallback) return `${this.url}/rewards/reward_stardust.${this.imageType}`
 		return null
 	}
 
 	async rewardMegaEnergyIcon(pokemonId, amount) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/reward/mega_resource/${resolveItemIcon(currentSet.reward.mega_resource, this.imageType, pokemonId, amount)}`
+		if (currentSet) return currentSet.reward('mega_resource', pokemonId, amount)
 		if (this.fallback) return `${this.url}/rewards/reward_mega_energy_${pokemonId}.${this.imageType}`
 		return null
 	}
 
 	async rewardCandyIcon(pokemonId, amount) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		if (currentSet) return `${this.url}/reward/candy/${resolveItemIcon(currentSet.reward.candy, this.imageType, pokemonId, amount)}`
+		if (currentSet) return currentSet.reward('candy', pokemonId, amount)
 		if (this.fallback) return `${this.url}/rewards/reward_candy_${pokemonId}.${this.imageType}`
 		return null
 	}
 
 	async rewardXlCandyIcon(pokemonId, amount) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/reward/xl_candy/${resolveItemIcon(currentSet.reward.xl_candy, this.imageType, pokemonId, amount)}` : null
+		return currentSet ? currentSet.reward('xl_candy', pokemonId, amount) : null
 	}
 
 	async gymIcon(teamId, trainerCount = 0, inBattle = false, ex = false) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/gym/${resolveGymIcon(currentSet.gym, this.imageType, teamId, trainerCount, inBattle, ex)}` : null
+		return currentSet ? currentSet.gym(teamId, trainerCount, inBattle, ex) : null
 	}
 
 	async weatherIcon(weatherId) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/weather/${resolveWeatherIcon(currentSet.weather, this.imageType, weatherId)}` : null
+		return currentSet ? currentSet.weather(weatherId) : null
 	}
 
 	async pokestopIcon(lureId = 0, invasionActive = false, incidentDisplayType = 0, questActive = false) {
 		const currentSet = await getAvailableIcons(this.log, this.url)
-		return currentSet ? `${this.url}/pokestop/${resolvePokestopIcon(currentSet.pokestop, this.imageType, lureId, invasionActive, incidentDisplayType, questActive)}` : null
+		return currentSet ? currentSet.pokestop(lureId, 0, incidentDisplayType, invasionActive, questActive) : null
 	}
 }
 


### PR DESCRIPTION
## Description
Simplify the poracle uicons class by moving large portions of the logic to the external [uicons.js](https://github.com/TurtIeSocks/uicons.js) lib, written by yours truly and implemented in ReactMap and other pogo tools.

## Motivation and Context
This keeps our approach to uicons in sync.

## How Has This Been Tested?
Currently untested.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.