### PR TITLE
Using new ScrapedDuck generic event data

### DIFF
--- a/src/lib/pogoEventParser.js
+++ b/src/lib/pogoEventParser.js
@@ -27,7 +27,7 @@ class PogoEventParser {
 			// Timeout Logic
 		}, timeoutMs)
 
-		const url = 'https://raw.githubusercontent.com/bigfoott/ScrapedDuck/data/events.json'
+		const url = 'https://raw.githubusercontent.com/hamster007Github/ScrapedDuck/data/events.json'
 		const result = await axios({
 			method: 'get',
 			url,
@@ -48,7 +48,7 @@ class PogoEventParser {
 			// create filtered pokemon spawn event list
 			// for now, only filter by eventType until spawn information is available
 			let filteredEvents = []
-			for (const event of events.filter((x) => x.eventType === 'community-day' || x.eventType === 'pokemon-spotlight-hour')) {
+			for (const event of events.filter((x) => x.eventType === 'community-day' || x.eventType === 'pokemon-spotlight-hour' || x.extraData.generic.hasSpawns)) {
 				filteredEvents.push(event)
 			}
 			this.spawnEvents = filteredEvents
@@ -56,7 +56,7 @@ class PogoEventParser {
 			// create filtered quest event list
 			// for now, only filter by eventType until field research task information is available
 			filteredEvents = []
-			for (const event of events.filter((x) => x.eventType === 'community-day')) {
+			for (const event of events.filter((x) => x.eventType === 'community-day' || x.extraData.generic.hasFieldResearchTasks)) {
 				filteredEvents.push(event)
 			}
 			this.questEvents = filteredEvents

--- a/src/lib/pogoEventParser.js
+++ b/src/lib/pogoEventParser.js
@@ -27,7 +27,7 @@ class PogoEventParser {
 			// Timeout Logic
 		}, timeoutMs)
 
-		const url = 'https://raw.githubusercontent.com/hamster007Github/ScrapedDuck/data/events.json'
+		const url = 'https://raw.githubusercontent.com/bigfoott/ScrapedDuck/data/events.json'
 		const result = await axios({
 			method: 'get',
 			url,


### PR DESCRIPTION
Using new additional generic event data to also notify about events != spotlight-hour and community day.

## Description
- change event data source to ScrapedDuck hamster007Github fork inclusing generic event data for each type of event
- check new `extraData` -> `generic` block in event data

## Motivation and Context
Using ScrapedDuck hamster007Github fork, because no feedback for PR since > 2 weeks. 

## How Has This Been Tested?
Local debugging. Filtered event lists contain expected events.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.