### PR TITLE
suppressMessage parameter for tracking endpoints to suppress confirmation messages

### DIFF
--- a/src/routes/apiTrackingEgg.js
+++ b/src/routes/apiTrackingEgg.js
@@ -152,6 +152,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'egg',
 				{
@@ -180,10 +182,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',

--- a/src/routes/apiTrackingGym.js
+++ b/src/routes/apiTrackingGym.js
@@ -150,6 +150,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'gym',
 				{
@@ -178,10 +180,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',

--- a/src/routes/apiTrackingInvasion.js
+++ b/src/routes/apiTrackingInvasion.js
@@ -143,6 +143,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'invasion',
 				{
@@ -171,10 +173,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',

--- a/src/routes/apiTrackingLure.js
+++ b/src/routes/apiTrackingLure.js
@@ -143,6 +143,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'lures',
 				{
@@ -171,10 +173,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',

--- a/src/routes/apiTrackingMonster.js
+++ b/src/routes/apiTrackingMonster.js
@@ -208,6 +208,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			// await fastify.query.deleteWhereInQuery('monsters', {
 			// 	id,
 			// 	profile_no: currentProfileNo,
@@ -239,10 +241,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			if (fastify.triggerReloadAlerts) fastify.triggerReloadAlerts()
 

--- a/src/routes/apiTrackingNest.js
+++ b/src/routes/apiTrackingNest.js
@@ -139,6 +139,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'nests',
 				{
@@ -167,10 +169,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',

--- a/src/routes/apiTrackingQuest.js
+++ b/src/routes/apiTrackingQuest.js
@@ -146,6 +146,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'quest',
 				{
@@ -174,10 +176,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',

--- a/src/routes/apiTrackingRaid.js
+++ b/src/routes/apiTrackingRaid.js
@@ -158,6 +158,8 @@ module.exports = async (fastify, options) => {
 				}
 			}
 
+			if (req.query.suppressMessage) message = ''
+
 			await fastify.query.deleteWhereInQuery(
 				'raid',
 				{
@@ -186,10 +188,12 @@ module.exports = async (fastify, options) => {
 				language,
 			}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+			if (message) {
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',


### PR DESCRIPTION
Use case: I have a bot on the same discord user that handles the interface, so I don't want poracle to send its own confirmations.