### PR TITLE
Adds verified only tracking

### DIFF
--- a/locale/fr.json
+++ b/locale/fr.json
@@ -81,6 +81,7 @@
 	"404 no valid tracks found":"Erreur de commande",
 	"everything":"tous",
 	"individually":"séparés",
+	"verified":"vérifié",
 	"maxlevel":"maxniveau",
 	"great":"super",
 	"greatcp":"superpc",

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -116,6 +116,7 @@ class Monster extends Controller {
 		min_iv<=${data.iv} and
 		max_iv>=${data.iv} and
 		min_time<=${data.tthSeconds} and
+		(verified_only = ${data.confirmedTime} or verified_only = 0) and
 		min_cp<=${data.cp} and
 		max_cp>=${data.cp} and
 		(gender = ${data.gender} or gender = 0) and
@@ -416,6 +417,7 @@ class Monster extends Controller {
 				whoCares = data.poracleTest ? [{
 					...data.poracleTest,
 					clean: false,
+					verified_only: false,
 					ping: '',
 					pvp_ranking_worst: 100,
 				}] : await this.monsterWhoCaresInMemory(data)
@@ -423,6 +425,7 @@ class Monster extends Controller {
 				whoCares = data.poracleTest ? [{
 					...data.poracleTest,
 					clean: false,
+					verified_only: false,
 					ping: '',
 					pvp_ranking_worst: 100,
 				}] : await this.monsterWhoCares(data)
@@ -431,6 +434,7 @@ class Monster extends Controller {
 					const whoCares2 = data.poracleTest ? [{
 						...data.poracleTest,
 						clean: false,
+						verified_only: false,
 						ping: '',
 						pvp_ranking_worst: 100,
 					}] : await this.monsterWhoCaresInMemory(data)
@@ -627,6 +631,7 @@ class Monster extends Controller {
 									name: cares.name,
 									type: cares.type,
 									clean: cares.clean,
+									verified_only: cares.verified_only,
 									ping: cares.ping,
 									template: cares.template,
 									language: cares.language,
@@ -898,6 +903,7 @@ class Monster extends Controller {
 							name: cares.name,
 							tth: data.tth,
 							clean: cares.clean,
+							verified_only: cares.verified_only,
 							emoji: data.emoji,
 							logReference,
 							language,

--- a/src/controllers/monsterAlarmMatch.js
+++ b/src/controllers/monsterAlarmMatch.js
@@ -160,6 +160,7 @@ class MonsterAlarmMatch {
 				if (+data.iv < monster.min_iv) continue
 				if (+data.iv > monster.max_iv) continue
 				if (+data.tthSeconds < monster.min_time) continue
+				if (monster.verified_only && monster.verified_only !== +data.confirmedTime) continue
 				if (+data.cp < monster.min_cp) continue
 				if (+data.cp > monster.max_cp) continue
 				if (monster.gender && monster.gender !== +data.gender) continue

--- a/src/lib/db/migrations/v19_verified_only.js
+++ b/src/lib/db/migrations/v19_verified_only.js
@@ -1,0 +1,12 @@
+const { log } = require('../../logger')
+
+exports.up = async function migrationUp(knex) {
+	await knex.schema.alterTable('monsters', (table) => {
+		table.boolean('verified_only').notNullable().defaultTo(false)
+	})
+	log.info('Monster verified_only migration applied')
+}
+
+exports.down = async function migrationDown(knex) {
+	log.info(knex)
+}

--- a/src/lib/poracleMessage/commands/track.js
+++ b/src/lib/poracleMessage/commands/track.js
@@ -134,6 +134,7 @@ exports.run = async (client, msg, args, options) => {
 			genderless: '^genderless$',
 			clean: '^clean$',
 			ping: '^<@.*',			// will not be used but stops it being listed as invalid parameter
+			verified_only: '^verified$',
 		}
 
 		if (!disableEverythingTracking || msg.isFromAdmin) parameterDefinition.everything = '^everything$'
@@ -421,6 +422,7 @@ exports.run = async (client, msg, args, options) => {
 			size: +size,
 			max_size: +maxSize,
 			min_time: +(parameterValues.t ?? 0),
+			verified_only: +(parameterValues.verified_only ?? 0),
 		}))
 		if (!insert.length) {
 			return await msg.reply(translator.translate('404 No monsters found'))
@@ -443,7 +445,7 @@ exports.run = async (client, msg, args, options) => {
 						insert.splice(i, 1)
 						break
 					case 2:		// One difference (something + uid)
-						if (Object.keys(differences).some((x) => ['min_iv', 'distance', 'template', 'clean'].includes(x))) {
+						if (Object.keys(differences).some((x) => ['min_iv', 'distance', 'template', 'clean', 'verified_only'].includes(x))) {
 							updates.push({
 								...toInsert,
 								uid: existing.uid,

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -12,6 +12,10 @@ function standardText(config, translator, row) {
 		text = text.concat(` ${translator.translate('clean')}`)
 	}
 
+	if (row.verified_only) {
+		text = text.concat(` ${translator.translate('verified')}`)
+	}
+
 	return text
 }
 


### PR DESCRIPTION
This PR is adding the option to set tracking for verified timers only using the parameter `verified`

Seems to be working fine here after running a few hours and testing various trackings / removals, but some edge cases can be there as I haven't coded in Poracle since a while...

Warning: includes a db migration of monsters table