### PR TITLE
RSVP support

### DIFF
--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -189,13 +189,20 @@ class Raid extends Controller {
 				return []
 			}
 
+			const unixMsNow = new Date().getTime()
+
 			if (data.rsvps) {
+				const newRsvps = []
 				for (const rsvp of data.rsvps) {
-					rsvp.timeSlot = Math.ceil(rsvp.timeslot / 1000)
-					rsvp.time = moment(rsvp.timeslot).tz(timezone).format(this.config.locale.time)
-					rsvp.goingCount = rsvp.going_count || 0
-					rsvp.maybeCount = rsvp.maybe_count || 0
+					if (rsvp.timeslot > unixMsNow) {
+						rsvp.timeSlot = Math.ceil(rsvp.timeslot / 1000)
+						rsvp.time = moment(rsvp.timeslot).tz(timezone).format(this.config.locale.time)
+						rsvp.goingCount = rsvp.going_count || 0
+						rsvp.maybeCount = rsvp.maybe_count || 0
+						newRsvps.push(rsvp)
+					}
 				}
+				data.rsvps = newRsvps
 			}
 
 			if (data.pokemon_id) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -9,7 +9,7 @@ class Raid extends Controller {
 		const { areastring, strictareastring } = this.buildAreaString(data.matched)
 
 		let query = `
-		select humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, raid.template, raid.distance, raid.clean, raid.ping from raid
+		select humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, raid.template, raid.distance, raid.clean, raid.ping, raid.rsvp_changes from raid
 		join humans on (humans.id = raid.id and humans.current_profile_no = raid.profile_no)
 		where humans.enabled = 1 and humans.admin_disable = false and (humans.blocked_alerts IS NULL OR humans.blocked_alerts NOT LIKE '%raid%') and
 		(pokemon_id=${data.pokemon_id} or (pokemon_id=9000 and (raid.level=${data.level} or raid.level=90))) and
@@ -72,7 +72,7 @@ class Raid extends Controller {
 		const { areastring, strictareastring } = this.buildAreaString(data.matched)
 
 		let query = `
-		select humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, egg.template, egg.distance, egg.clean, egg.ping from egg
+		select humans.id, humans.name, humans.type, humans.language, humans.latitude, humans.longitude, egg.template, egg.distance, egg.clean, egg.ping, egg.rsvp_changes from egg
 		join humans on (humans.id = egg.id and humans.current_profile_no = egg.profile_no)
 		where humans.enabled = 1 and humans.admin_disable = false and (humans.blocked_alerts IS NULL OR humans.blocked_alerts NOT LIKE '%egg%') and
 		(egg.level = ${data.level} or egg.level = 90) and
@@ -165,7 +165,8 @@ class Raid extends Controller {
 			data.gymColor = this.GameData.utilData.teams[data.team_id].color
 			data.ex = !!(data.ex_raid_eligible ?? data.is_ex_raid_eligible)
 			data.gymUrl = data.gym_url || data.url || ''
-			const disappearTime = moment(data.end * 1000).tz(geoTz.find(data.latitude, data.longitude)[0].toString())
+			const timezone = geoTz.find(data.latitude, data.longitude)[0].toString()
+			const disappearTime = moment(data.end * 1000).tz(timezone)
 			data.disappearTime = disappearTime.format(this.config.locale.time)
 			data.applemap = data.appleMapUrl // deprecated
 			data.mapurl = data.googleMapUrl // deprecated
@@ -186,6 +187,15 @@ class Raid extends Controller {
 				&& (data.end - data.start) > 47 * 60) {
 				this.log.verbose(`${this.logReference}: Raid/Egg on ${data.gymName} will be longer than 47 minutes - ignored`)
 				return []
+			}
+
+			if (data.rsvps) {
+				for (const rsvp of data.rsvps) {
+					rsvp.timeSlot = Math.ceil(rsvp.timeslot / 1000)
+					rsvp.time = moment(rsvp.timeslot).tz(timezone).format(this.config.locale.time)
+					rsvp.goingCount = rsvp.going_count || 0
+					rsvp.maybeCount = rsvp.maybe_count || 0
+				}
 			}
 
 			if (data.pokemon_id) {
@@ -271,6 +281,18 @@ class Raid extends Controller {
 						await require('./common/weather').calculateForecastImpact(data, this.GameData, weatherCellId, this.weatherData, data.end, this.config)
 
 						for (const cares of whoCares) {
+							if (cares.rsvp_changes === 0 && !data.firstNotification) {
+								this.log.debug(`${logReference}: Not creating raid alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template} - no rsvp changes`, cares)
+								// eslint-disable-next-line no-continue
+								continue
+							}
+
+							if (cares.rsvp_changes === 2 && !data.rsvps || data.rsvps?.length === 0) {
+								this.log.debug(`${logReference}: Not creating raid alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template} - only rsvp changes`, cares)
+								// eslint-disable-next-line no-continue
+								continue
+							}
+
 							this.log.debug(`${logReference}: Creating raid alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template}`, cares)
 
 							const rateLimitTtr = this.getRateLimitTimeToRelease(cares.id)
@@ -520,6 +542,17 @@ class Raid extends Controller {
 					data.staticmap = data.staticMap // deprecated
 
 					for (const cares of whoCares) {
+						if (cares.rsvp_changes === 0 && !data.firstNotification) {
+							this.log.debug(`${logReference}: Not creating egg alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template} - no rsvp changes`, cares)
+							// eslint-disable-next-line no-continue
+							continue
+						}
+
+						if (cares.rsvp_changes === 2 && !data.rsvps || data.rsvps?.length === 0) {
+							this.log.debug(`${logReference}: Not creating egg alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template} - only rsvp changes`, cares)
+							// eslint-disable-next-line no-continue
+							continue
+						}
 						this.log.debug(`${logReference}: Creating egg alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template}`, cares)
 						const rateLimitTtr = this.getRateLimitTimeToRelease(cares.id)
 						if (rateLimitTtr) {

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -287,7 +287,7 @@ class Raid extends Controller {
 								continue
 							}
 
-							if (cares.rsvp_changes === 2 && !data.rsvps || data.rsvps?.length === 0) {
+							if (cares.rsvp_changes === 2 && (!data.rsvps || data.rsvps?.length === 0)) {
 								this.log.debug(`${logReference}: Not creating raid alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template} - only rsvp changes`, cares)
 								// eslint-disable-next-line no-continue
 								continue
@@ -548,7 +548,7 @@ class Raid extends Controller {
 							continue
 						}
 
-						if (cares.rsvp_changes === 2 && !data.rsvps || data.rsvps?.length === 0) {
+						if (cares.rsvp_changes === 2 && (!data.rsvps || data.rsvps?.length === 0)) {
 							this.log.debug(`${logReference}: Not creating egg alert for ${cares.id} ${cares.name} ${cares.type} ${cares.language} ${cares.template} - only rsvp changes`, cares)
 							// eslint-disable-next-line no-continue
 							continue

--- a/src/lib/db/migrations/v19_rsvps.js
+++ b/src/lib/db/migrations/v19_rsvps.js
@@ -1,0 +1,12 @@
+const { log } = require('../../logger')
+
+exports.up = async function migrationUp(knex) {
+	await knex.schema.alterTable('raid', (table) => {
+		table.tinyint('rsvp_changes', 8).notNullable().defaultTo(0)
+	})
+	log.info('Rsvp raid migration applied')
+}
+
+exports.down = async function migrationDown(knex) {
+	log.info(knex)
+}

--- a/src/lib/db/migrations/v20_egg_rsvps.js
+++ b/src/lib/db/migrations/v20_egg_rsvps.js
@@ -1,12 +1,12 @@
 const { log } = require('../../logger')
 
 exports.up = async function migrationUp(knex) {
-    await knex.schema.alterTable('egg', (table) => {
-        table.tinyint('rsvp_changes', 8).notNullable().defaultTo(0)
-    })
-    log.info('Rsvp egg migration applied')
+	await knex.schema.alterTable('egg', (table) => {
+		table.tinyint('rsvp_changes', 8).notNullable().defaultTo(0)
+	})
+	log.info('Rsvp egg migration applied')
 }
 
 exports.down = async function migrationDown(knex) {
-    log.info(knex)
+	log.info(knex)
 }

--- a/src/lib/db/migrations/v20_egg_rsvps.js
+++ b/src/lib/db/migrations/v20_egg_rsvps.js
@@ -1,0 +1,12 @@
+const { log } = require('../../logger')
+
+exports.up = async function migrationUp(knex) {
+    await knex.schema.alterTable('egg', (table) => {
+        table.tinyint('rsvp_changes', 8).notNullable().defaultTo(0)
+    })
+    log.info('Rsvp egg migration applied')
+}
+
+exports.down = async function migrationDown(knex) {
+    log.info(knex)
+}

--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -45,6 +45,7 @@ exports.run = async (client, msg, args, options) => {
 		let team = 4
 		let template = client.config.general.defaultTemplateName
 		let clean = false
+		let rsvpChanges = 0
 		const levelSet = new Set()
 		const pings = msg.getPings()
 
@@ -59,6 +60,9 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'harmony' || element === 'gray') team = 0
 			else if (element === 'everything') Object.keys(client.GameData.utilData.raidLevels).forEach((x) => levelSet.add(+x))
 			else if (element === 'clean') clean = true
+			else if (element === 'no rsvp') rsvpChanges = 0
+			else if (element === 'rsvp') rsvpChanges = 1
+			else if (element === 'rsvp only') rsvpChanges = 2
 		})
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
@@ -93,6 +97,7 @@ exports.run = async (client, msg, args, options) => {
 				clean: +clean,
 				level: +lvl,
 				gym_id: null,
+				rsvp_changes: +rsvpChanges,
 			}))
 
 			const tracked = await client.query.selectAllQuery('egg', { id: target.id, profile_no: currentProfileNo })

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -51,6 +51,7 @@ exports.run = async (client, msg, args, options) => {
 		let clean = false
 		const evolution = 9000
 		let move = 9000
+		let rsvpChanges = 0
 		const levelSet = new Set()
 		const pings = msg.getPings()
 		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase())
@@ -104,6 +105,9 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'harmony' || element === 'gray') team = 0
 			else if (element === 'everything') Object.keys(client.GameData.utilData.raidLevels).forEach((x) => levelSet.add(+x))
 			else if (element === 'clean') clean = true
+			else if (element === 'no rsvp') rsvpChanges = 0
+			else if (element === 'rsvp') rsvpChanges = 1
+			else if (element === 'rsvp only') rsvpChanges = 2
 		}
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
@@ -141,6 +145,7 @@ exports.run = async (client, msg, args, options) => {
 				evolution: +evolution,
 				move: +move,
 				gym_id: null,
+				rsvp_changes: +rsvpChanges,
 			}))
 
 			levels.forEach((level) => {
@@ -159,6 +164,7 @@ exports.run = async (client, msg, args, options) => {
 					evolution: +evolution,
 					move: +move,
 					gym_id: null,
+					rsvp_changes: +rsvpChanges,
 				})
 			})
 

--- a/src/lib/poracleMessage/commands/tracked.js
+++ b/src/lib/poracleMessage/commands/tracked.js
@@ -66,13 +66,23 @@ async function raidRowText(config, translator, GameData, raid, scannerQuery) {
 	let gymNameText = null
 	if (raid.gym_id) gymNameText = scannerQuery ? await scannerQuery.getGymName(raid.gym_id) || raid.gym_id : raid.gym_id
 
+	let rsvpText = ''
+	switch (raid.rsvp_changes) {
+		case 0:	rsvpText = translator.translate('without rsvp updates')
+			break
+		case 1: rsvpText = translator.translate('including rsvp updates')
+			break
+		case 2: rsvpText = translator.translate('rsvp only')
+			break
+		default: break
+	}
 	const moveName = raid.move !== 9000 && GameData.moves[raid.move] ? `${translator.translate(GameData.moves[raid.move].name)}/${translator.translate(GameData.moves[raid.move].type)}` : ''
 
 	if (+raid.pokemon_id === 9000) {
-		return `**${raid.level === 90 ? translator.translate('All level') : `${translator.translate('level').charAt(0).toUpperCase() + translator.translate('level').slice(1)} ${raid.level}`} ${translator.translate('raids')}** ${raid.distance ? ` | ${translator.translate('distance')}: ${raid.distance}m` : ''}${moveName ? ` | ${translator.translate('with move')} ${moveName}` : ''}${raid.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${raid.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''} ${standardText(config, translator, raid)}${raid.gym_id ? ` ${translator.translate('at gym ')} ${gymNameText}` : ''}`
+		return `**${raid.level === 90 ? translator.translate('All level') : `${translator.translate('level').charAt(0).toUpperCase() + translator.translate('level').slice(1)} ${raid.level}`} ${translator.translate('raids')}** ${raid.distance ? ` | ${translator.translate('distance')}: ${raid.distance}m` : ''}${moveName ? ` | ${translator.translate('with move')} ${moveName}` : ''}${raid.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${raid.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''} ${standardText(config, translator, raid)}${raid.gym_id ? ` ${translator.translate('at gym ')} ${gymNameText}` : ''} ${rsvpText}`
 	}
 
-	return `**${monsterName}**${formName ? ` ${translator.translate('form')}: ${formName}` : ''}${raid.distance ? ` | ${translator.translate('distance')}: ${raid.distance}m` : ''}${moveName ? ` | ${translator.translate('with move')} ${moveName}` : ''}${raid.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${raid.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''} ${standardText(config, translator, raid)}${raid.gym_id ? ` ${translator.translate('at gym ')} ${gymNameText}` : ''}`
+	return `**${monsterName}**${formName ? ` ${translator.translate('form')}: ${formName}` : ''}${raid.distance ? ` | ${translator.translate('distance')}: ${raid.distance}m` : ''}${moveName ? ` | ${translator.translate('with move')} ${moveName}` : ''}${raid.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${raid.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''} ${standardText(config, translator, raid)}${raid.gym_id ? ` ${translator.translate('at gym ')} ${gymNameText}` : ''} ${rsvpText}`
 }
 
 async function gymRowText(config, translator, GameData, gym, scannerQuery) {
@@ -107,7 +117,18 @@ async function eggRowText(config, translator, GameData, egg, scannerQuery) {
 	let gymNameText = null
 	if (egg.gym_id) gymNameText = scannerQuery ? await scannerQuery.getGymName(egg.gym_id) || egg.gym_id : egg.gym_id
 
-	return `**${egg.level === 90 ? translator.translate('All level') : `${translator.translate('level').charAt(0).toUpperCase() + translator.translate('level').slice(1)} ${egg.level}`} ${translator.translate('eggs')}** ${egg.distance ? ` | ${translator.translate('distance')}: ${egg.distance}m` : ''} ${egg.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${egg.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''} ${standardText(config, translator, egg)}${egg.gym_id ? ` ${translator.translate('at gym ')} ${gymNameText}` : ''}`
+	let rsvpText = ''
+	switch (egg.rsvp_changes) {
+		case 0:	rsvpText = translator.translate('without rsvp updates')
+			break
+		case 1: rsvpText = translator.translate('including rsvp updates')
+			break
+		case 2: rsvpText = translator.translate('rsvp only')
+			break
+		default: break
+	}
+
+	return `**${egg.level === 90 ? translator.translate('All level') : `${translator.translate('level').charAt(0).toUpperCase() + translator.translate('level').slice(1)} ${egg.level}`} ${translator.translate('eggs')}** ${egg.distance ? ` | ${translator.translate('distance')}: ${egg.distance}m` : ''} ${egg.team === 4 ? '' : ` | ${translator.translate('controlled by')} ${raidTeam}`}${egg.exclusive ? ` | ${translator.translate('must be an EX Gym')}` : ''} ${standardText(config, translator, egg)}${egg.gym_id ? ` ${translator.translate('at gym ')} ${gymNameText}` : ''} ${rsvpText}`
 }
 
 function questRowText(config, translator, GameData, quest) {


### PR DESCRIPTION
Wouldn't it be nice to track raids with RSVP notifications?
Never fear, Poracle is here!

<img width="533" alt="image" src="https://github.com/user-attachments/assets/4ccacb49-4c26-4a52-949f-6b6df5d04706" />

There's some nice fields to support adding to your DTS, for example:
```
{{#if rsvps}}RSVPS:
{{#each rsvps}}Time:  {{time}} <t:{{timeSlot}}:R> Going: {{goingCount}} Maybe: {{maybeCount}}
{{/each}}{{/if}}
```

Raids tracks will normally only fire when the egg/raid goes live but you can opt into some additional changes

`!raid level5 rsvp`
* Get all rsvp updates

`!raid level5 rsvp_only`
* Only get notified of raids with rsvp

Eggs, similarly
